### PR TITLE
Bind rpc server

### DIFF
--- a/codechain/commands/start.rs
+++ b/codechain/commands/start.rs
@@ -1,3 +1,4 @@
+use codechain_rpc::Server as RpcServer;
 use rpc::HttpConfiguration as RpcHttpConfig;
 
 use super::super::rpc;
@@ -12,8 +13,7 @@ pub fn forever() -> Result<(), String> {
     Ok(())
 }
 
-pub fn rpc_start(cfg: RpcHttpConfig) -> Result<(), String> {
+pub fn rpc_start(cfg: RpcHttpConfig) -> RpcServer {
     info!("RPC Listening on {}", cfg.port);
-    let _rpc_server = rpc::new_http(cfg);
-    Ok(())
+    rpc::new_http(cfg).unwrap().unwrap()
 }

--- a/codechain/main.rs
+++ b/codechain/main.rs
@@ -48,8 +48,7 @@ fn run() -> Result<(), String> {
     let log_config = LogConfig::default();
     let _logger = setup_log(&log_config).expect("Logger is initialized only once; qed");
 
-    if let Some(rpc_config) = try!(config::parse_rpc_config(&matches)) {
-        commands::rpc_start(rpc_config)?;
-    }
+    let _rpc_server = config::parse_rpc_config(&matches)?.map(commands::rpc_start);
+
     commands::forever()
 }


### PR DESCRIPTION
Currently, RPC server stops because it's not bound to
anywhere.