### PR TITLE
Implement Client with macro

### DIFF
--- a/network/src/client.rs
+++ b/network/src/client.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Weak};
 
 use parking_lot::RwLock;
 
-use super::{Api, Extension, NodeId, Result as ExtensionResult};
+use super::{Api, Error as ExtensionError, Extension, NodeId};
 
 struct ClientApi {
     client: Weak<Client>,
@@ -62,6 +62,50 @@ pub struct Client {
     extensions: RwLock<HashMap<String, Weak<Extension>>>,
 }
 
+macro_rules! define_broadcast_method {
+    ($method_name: ident) => {
+        pub fn $method_name (&self) {
+            let extensions = self.extensions.read();
+            for (ref name, ref extension) in extensions.iter() {
+                if let Some(ref extension) = extension.upgrade() {
+                    extension.$method_name();
+                } else {
+                    info!("Extension {} already dropped before {}", name, stringify!($method_name));
+                }
+            }
+        }
+    };
+    ($method_name: ident; $($var: ident, $t: ty);*) => {
+        pub fn $method_name (&self, $($var: $t), *) {
+            let extensions = self.extensions.read();
+            for (ref name, ref extension) in extensions.iter() {
+                if let Some(ref extension) = extension.upgrade() {
+                    extension.$method_name($($var),*);
+                } else {
+                    info!("Extension {} already dropped before {}", name, stringify!($method_name));
+                }
+            }
+        }
+    };
+}
+
+macro_rules! define_method {
+    ($method_name: ident; $($var: ident, $t: ty);*) => {
+        pub fn $method_name (&self, name: &String, $($var: $t), *) {
+            let extensions = self.extensions.read();
+            if let Some(ref extension) = extensions.get(name) {
+                if let Some(ref extension) = extension.upgrade() {
+                    extension.$method_name($($var),*);
+                } else {
+                    info!("Extension {} already dropped before {}", name, stringify!($method_name));
+                }
+            } else {
+                info!("{} doesn't exist.", name);
+            }
+        }
+    };
+}
+
 impl Client {
     pub fn register_extension(client: Arc<Client>, extension: Arc<Extension>) -> Arc<Api> {
         let name = extension.name();
@@ -85,38 +129,212 @@ impl Client {
         })
     }
 
-    fn on_message(&self, name: &String, id: &NodeId, data: &Vec<u8>) {
-        let extensions = self.extensions.read();
-        if let Some(extension) = extensions.get(name) {
-            if let Some(extension) = extension.upgrade() {
-                extension.on_message(&id, data);
-            } else {
-                info!("The extension already dropped");
-            }
-        } else {
-            info!("The handler for {} doesn't exist.", name);
+    define_broadcast_method!(on_node_added; id, &NodeId);
+    define_broadcast_method!(on_node_removed; id, &NodeId);
+
+    define_method!(on_connected; id, &NodeId);
+    define_method!(on_connection_allowed; id, &NodeId);
+    define_method!(on_connection_denied; id, &NodeId; error, ExtensionError);
+
+    define_method!(on_message; id, &NodeId; data, &Vec<u8>);
+
+    define_broadcast_method!(on_close);
+
+    define_method!(on_timer_set_allowed; timer_id, usize);
+    define_method!(on_timer_set_denied; timer_id, usize; error, ExtensionError);
+    define_method!(on_timeout; timer_id, usize);
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        self.on_close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+    use std::sync::Arc;
+    use std::vec::Vec;
+
+    use cio::IoService;
+    use parking_lot::Mutex;
+
+    use super::{Api, Client, Extension, ExtensionError, NodeId};
+
+    struct TestApi {
+    }
+
+    impl Api for TestApi {
+        fn send(&self, id: &usize, message: &Vec<u8>) {
+            unimplemented!()
+        }
+
+        fn connect(&self, id: &usize) {
+            unimplemented!()
+        }
+
+        fn set_timer(&self, timer_id: usize, ms: u64) {
+            unimplemented!()
+        }
+
+        fn set_timer_once(&self, timer_id: usize, ms: u64) {
+            unimplemented!()
+        }
+
+        fn clear_timer(&self, timer_id: usize, ms: u64) {
+            unimplemented!()
         }
     }
 
-    fn on_node_added(&self, id: &NodeId) {
-        let extensions = self.extensions.read();
-        for (_, extension) in extensions.iter() {
-            if let Some(extension) = extension.upgrade() {
-                extension.on_node_added(&id);
-            } else {
-                info!("ClientApi already dropped");
+    #[derive(Debug, Eq, PartialEq)]
+    enum Callback {
+        Initialize,
+        NodeAdded,
+        NodeRemoved,
+        Connected,
+        ConnectionAllowed,
+        ConnectionDenied,
+        Message,
+        Close,
+        TimerSetAllowed,
+        TimerSetDenied,
+        Timeout,
+    }
+
+    struct TestExtension {
+        name: String,
+        callbacks: Mutex<Vec<Callback>>,
+    }
+
+    impl TestExtension {
+        fn new(name: String) -> Self {
+            Self {
+                name,
+                callbacks: Mutex::new(vec![]),
             }
         }
     }
 
-    fn on_node_removed(&self, id: &NodeId) {
-        let extensions = self.extensions.read();
-        for (_, extension) in extensions.iter() {
-            if let Some(extension) = extension.upgrade() {
-                extension.on_node_removed(&id);
-            } else {
-                info!("The extension already dropped");
-            }
+    impl Extension for TestExtension {
+        fn name(&self) -> String {
+            self.name.clone()
+        }
+
+        fn need_encryption(&self) -> bool {
+            false
+        }
+
+        fn on_initialize(&self, _api: Arc<Api>) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Initialize);
+        }
+
+        fn on_node_added(&self, _id: &NodeId) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::NodeAdded);
+        }
+
+        fn on_node_removed(&self, _id: &NodeId) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::NodeRemoved);
+        }
+
+        fn on_connected(&self, _id: &NodeId) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Connected);
+        }
+
+        fn on_connection_allowed(&self, _id: &NodeId) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Connected);
+        }
+
+        fn on_connection_denied(&self, _id: &NodeId, _error: ExtensionError) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::ConnectionDenied);
+        }
+
+        fn on_message(&self, _id: &NodeId, _message: &Vec<u8>) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Message);
+        }
+
+        fn on_close(&self) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Close);
+        }
+
+        fn on_timer_set_allowed(&self, _timer_id: usize) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::TimerSetAllowed);
+        }
+
+        fn on_timer_set_denied(&self, _timer_id: usize, _error: ExtensionError) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::TimerSetDenied);
+        }
+
+        fn on_timeout(&self, _timer_id: usize) {
+            let mut callbacks = self.callbacks.lock();
+            callbacks.push(Callback::Timeout);
+        }
+    }
+
+    #[test]
+    fn broadcast_node_added() {
+        let client = Client::new();
+
+        let e1 = Arc::new(TestExtension::new("e1".to_string()));
+        let _ = Client::register_extension(Arc::clone(&client), Arc::clone(&e1) as Arc<Extension>);
+        let e2 = Arc::new(TestExtension::new("e2".to_string()));
+        let _ = Client::register_extension(Arc::clone(&client), Arc::clone(&e2) as Arc<Extension>);
+
+        client.on_node_added(&1);
+
+        {
+            let callbacks = e1.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::NodeAdded]);
+        }
+
+        {
+            let callbacks = e2.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::NodeAdded]);
+        }
+    }
+
+    #[test]
+    fn message_only_to_target() {
+        let client = Client::new();
+
+        let e1 = Arc::new(TestExtension::new("e1".to_string()));
+        let _ = Client::register_extension(Arc::clone(&client), Arc::clone(&e1) as Arc<Extension>);
+        let e2 = Arc::new(TestExtension::new("e2".to_string()));
+        let _ = Client::register_extension(Arc::clone(&client), Arc::clone(&e2) as Arc<Extension>);
+
+        client.on_message(&"e1".to_string(), &1, &vec![]);
+        {
+            let callbacks = e1.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::Message]);
+            let callbacks = e2.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize]);
+        }
+
+        client.on_message(&"e2".to_string(), &1, &vec![]);
+        {
+            let callbacks = e1.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::Message]);
+            let callbacks = e2.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::Message]);
+        }
+
+        client.on_message(&"e2".to_string(), &5, &vec![]);
+        client.on_message(&"e2".to_string(), &1, &vec![]);
+        {
+            let callbacks = e1.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::Message]);
+            let callbacks = e2.callbacks.lock();
+            assert_eq!(callbacks.deref(), &vec![Callback::Initialize, Callback::Message, Callback::Message, Callback::Message]);
         }
     }
 }

--- a/network/src/extension.rs
+++ b/network/src/extension.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 
 use cio::{StreamToken};
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, )]
-pub struct NodeId(StreamToken);
+pub type NodeId = StreamToken;
 
+#[derive(Clone, Copy, Debug)]
 pub enum Error {
     ExtensionDropped,
     DuplicatedTimerSeq,


### PR DESCRIPTION
Client has two kinds of callback methods.

One is broadcast. For instance, on_node_added must be called for each
extension.
The other is a callback which is called for specific extension. Timer
callbacks and on_message callback are these kinds of callbacks.