### PR TITLE
Remove redundant clear

### DIFF
--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -115,7 +115,6 @@ impl NetworkExtension for Extension {
     }
 
     fn on_initialize(&self, api: Arc<Api>) {
-        self.peers.write().clear();
         api.set_timer(SYNC_TIMER_TOKEN, Duration::milliseconds(SYNC_TIMER_INTERVAL));
         *self.api.lock() = Some(api);
     }

--- a/sync/src/transaction/extension.rs
+++ b/sync/src/transaction/extension.rs
@@ -62,7 +62,6 @@ impl NetworkExtension for Extension {
     }
 
     fn on_initialize(&self, api: Arc<Api>) {
-        self.peers.write().clear();
         api.set_timer(BROADCAST_TIMER_TOKEN, Duration::milliseconds(BROADCAST_TIMER_INTERVAL));
         api.set_timer(RESET_TIMER_TOKEN, Duration::milliseconds(RESET_TIMER_INTERVAL));
         *self.api.lock() = Some(api);


### PR DESCRIPTION
There is no need to clear a newly created HashMap.