### PR TITLE
Remove remainder from AssetScheme

### DIFF
--- a/core/src/state/asset.rs
+++ b/core/src/state/asset.rs
@@ -115,7 +115,6 @@ impl_address!(AssetAddress, PREFIX);
 impl AssetAddress {
     pub fn new(transaction_hash: H256, index: usize) -> Self {
         debug_assert_eq!(::std::mem::size_of::<u64>(), ::std::mem::size_of::<usize>());
-        debug_assert_ne!(index as u64, ::std::u64::MAX);
         let index = index as u64;
 
         Self::from_transaction(transaction_hash, index)

--- a/core/src/state_db.rs
+++ b/core/src/state_db.rs
@@ -615,16 +615,9 @@ mod tests {
         let h0 = H256::random();
         let mut batch = DBTransaction::new();
 
-        let lock_script_hash = H256::random();
-        let remainder = 1234;
+        let amount = 1234;
         let registrar = Some(Address::random());
-        let asset_scheme = AssetScheme::new(
-            "A metadata for test asset_scheme".to_string(),
-            lock_script_hash,
-            vec![],
-            remainder,
-            registrar,
-        );
+        let asset_scheme = AssetScheme::new("A metadata for test asset_scheme".to_string(), amount, registrar);
         let asset_scheme_address = AssetSchemeAddress::new(h0);
 
         let mut s = state_db.boxed_clone_canon(&root_parent);
@@ -655,8 +648,7 @@ mod tests {
         let asset_scheme = asset_scheme.unwrap();
 
         assert!(asset_scheme.is_permissioned());
-        assert_eq!(&remainder, asset_scheme.remainder());
-        assert_eq!(&lock_script_hash, asset_scheme.lock_script_hash());
+        assert_eq!(&amount, asset_scheme.amount());
         assert_eq!(&registrar, asset_scheme.registrar());
     }
 

--- a/rpc_cli/command-examples4.json
+++ b/rpc_cli/command-examples4.json
@@ -56,5 +56,19 @@
     "data": {
       "transaction_hash": "591a12799716600c9bb4680ebb8ea802c7ad4b7a0ba6151e7df643068967bc53"
     }
+  },
+  {
+    "name": "chain_getAsset",
+    "data": {
+      "transaction_hash": "b84926ca470ca5c41a350255d19d51f6a0f7f847776db6ae38193dc943bd5189",
+      "index": 0
+    }
+  },
+  {
+    "name": "chain_getAsset",
+    "data": {
+      "transaction_hash": "591a12799716600c9bb4680ebb8ea802c7ad4b7a0ba6151e7df643068967bc53",
+      "index": 0
+    }
   }
 ]

--- a/rpc_cli/command-examples5.json
+++ b/rpc_cli/command-examples5.json
@@ -15,7 +15,7 @@
               "inputs": [{
                   "prev_out": {
                       "transaction_hash": "591a12799716600c9bb4680ebb8ea802c7ad4b7a0ba6151e7df643068967bc53",
-                      "index": 18446744073709551615,
+                      "index": 0,
                       "asset_type": "5300000000000000254e62980bdac8dae8f192cb82e03d0f37a603bab74cb011",
                       "amount": 7
                   },
@@ -46,7 +46,7 @@
   {
     "name": "chain_getTransactionInvoice",
     "data": {
-      "hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df"
+      "hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525"
     }
   }
 ]

--- a/rpc_cli/command-examples6.json
+++ b/rpc_cli/command-examples6.json
@@ -14,28 +14,42 @@
   {
     "name": "chain_getAsset",
     "data": {
-      "transaction_hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df",
+      "transaction_hash": "b84926ca470ca5c41a350255d19d51f6a0f7f847776db6ae38193dc943bd5189",
       "index": 0
     }
   },
   {
     "name": "chain_getAsset",
     "data": {
-      "transaction_hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df",
+      "transaction_hash": "591a12799716600c9bb4680ebb8ea802c7ad4b7a0ba6151e7df643068967bc53",
+      "index": 0
+    }
+  },
+  {
+    "name": "chain_getAsset",
+    "data": {
+      "transaction_hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525",
+      "index": 0
+    }
+  },
+  {
+    "name": "chain_getAsset",
+    "data": {
+      "transaction_hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525",
       "index": 1
     }
   },
   {
     "name": "chain_getAsset",
     "data": {
-      "transaction_hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df",
+      "transaction_hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525",
       "index": 2
     }
   },
   {
     "name": "chain_getAsset",
     "data": {
-      "transaction_hash": "cc0c7c1185cd759cf16b0b0287ab05aacd832cc0dcd87deb920ddaf2be6d04ce",
+      "transaction_hash": "cc99efb35ab19c1842b9a14025d5b980418b69aa1c40d2b19a069fe6bb823f58",
       "index": 0
     }
   }

--- a/rpc_cli/command-examples7.json
+++ b/rpc_cli/command-examples7.json
@@ -10,7 +10,7 @@
           "data": {
               "inputs": [{
                   "prev_out": {
-                      "transaction_hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df",
+                      "transaction_hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525",
                       "index": 0,
                       "asset_type": "5300000000000000254e62980bdac8dae8f192cb82e03d0f37a603bab74cb011",
                       "amount": 4
@@ -19,7 +19,7 @@
                   "unlock_script": ""
               }, {
                   "prev_out": {
-                      "transaction_hash": "573933bbd737f89e1278fffd38afaacd36167391be51fbe440e62a9dcf0847df",
+                      "transaction_hash": "44ce819b6a731db103f8ab739558e59974e2edad022cdc7f9e9ea3382609f525",
                       "index": 2,
                       "asset_type": "5300000000000000254e62980bdac8dae8f192cb82e03d0f37a603bab74cb011",
                       "amount": 1
@@ -41,7 +41,7 @@
   {
     "name": "chain_getTransactionInvoice",
     "data": {
-      "hash": "cc0c7c1185cd759cf16b0b0287ab05aacd832cc0dcd87deb920ddaf2be6d04ce"
+      "hash": "cc99efb35ab19c1842b9a14025d5b980418b69aa1c40d2b19a069fe6bb823f58"
     }
   }
 ]


### PR DESCRIPTION
This patch makes
- AssetMint transaction generate an Asset
- AssetScheme immutable
- only Asset can be the input of AssetTransfer transaction