### PR TITLE
Bug: Crash - missing account's subcommand

### DIFF
--- a/codechain/account_command.rs
+++ b/codechain/account_command.rs
@@ -22,6 +22,11 @@ use clap::ArgMatches;
 use clogger::{self, LoggerConfig};
 
 pub fn run_account_command(matches: ArgMatches) -> Result<(), String> {
+    if matches.subcommand.is_none() {
+        println!("{}", matches.usage());
+        return Ok(())
+    }
+
     clogger::init(&LoggerConfig::new(0)).expect("Logger must be successfully initialized");
 
     let subcommand = matches.subcommand.unwrap();


### PR DESCRIPTION
> I'm running:
./target/release/codechain account

Running codechain from command line gives the below output:

```stack backtrace:
   0:        0x10215f3de - backtrace::backtrace::trace::haea36227af60f9b9
   1:        0x10215dc2c - backtrace::capture::Backtrace::new::h6cce72b756ca69a6
   2:        0x10215d203 - panic_hook::panic_hook::h3d5b3b94c1cc4174
   3:        0x102a9c984 - std::panicking::rust_panic_with_hook::h5960f68f624e3f04
   4:        0x102a9c470 - std::panicking::begin_panic_fmt::h636c8ed25334894b
   5:        0x102a9c432 - rust_begin_unwind
   6:        0x102ad5115 - core::panicking::panic_fmt::h0a4522f173e9c631
   7:        0x102ad5016 - core::panicking::panic::h9e7f80f984348687
   8:        0x1020f8b56 - codechain::account_command::run_account_command::h5c73f3d0c293d6f5
   9:        0x10214e5a2 - codechain::main::h01725c144c9bf198
  10:        0x10212e951 - std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h0bb368e70c0cefc8
  11:        0x102a9c397 - std::panicking::try::do_call::h691e10ccfd4b84fd (.llvm.15766040419507725257)
  12:        0x102aa809e - __rust_maybe_catch_panic
  13:        0x102a8ed21 - std::rt::lang_start_internal::h6fcee8df76db3c23
  14:        0x102150eab - main

Thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', libcore/option.rs:335```