### PR TITLE
Bug - unchanged logging level

### DIFF
--- a/util/logger/src/logger.rs
+++ b/util/logger/src/logger.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::env;
 use std::thread;
 use time;
 
@@ -41,8 +42,12 @@ pub struct Logger {
 
 impl Logger {
     pub fn new(config: &Config) -> Self {
-        let mut builder = FilterBuilder::from_env("RUST_LOG");
+        let mut builder = FilterBuilder::new();
         builder.filter(None, LevelFilter::Info);
+
+        if let Ok(rust_log) = env::var("RUST_LOG") {
+            builder.parse(&rust_log);
+        }
 
         Self {
             instance_id: config.instance_id,


### PR DESCRIPTION
The program doesn't apply the logging level from the RUST_LOG environment variable, so it gives the below output: 

```
RUST_LOG=info ./target/release/codechain

#267117000 2018-06-15 15:04:23  main INFO codechain  Starting client
#267117000 2018-06-15 15:04:23  main INFO codechain  RPC Listening on 8080
#267117000 2018-06-15 15:04:23  main INFO codechain  Handshake Listening on 3485
#267117000 2018-06-15 15:04:23  main INFO discovery  Node runs with unstructured discovery
#267117000 2018-06-15 15:04:23  main INFO test_script  Initialization complete
#267117000 2018-06-15 15:04:23  IO Worker #2 INFO sync  Sync extension initialized
```

```
RUST_LOG=debug ./target/release/codechain

#481804000 2018-06-15 15:30:49  main INFO codechain  Starting client
#481804000 2018-06-15 15:30:49  main INFO codechain  RPC Listening on 8080
#481804000 2018-06-15 15:30:49  main INFO codechain  Handshake Listening on 3485
#481804000 2018-06-15 15:30:49  main INFO discovery  Node runs with unstructured discovery
#481804000 2018-06-15 15:30:49  main INFO test_script  Initialization complete
#481804000 2018-06-15 15:30:51  IO Worker #2 INFO sync  Sync extension initialized
```

