### PR TITLE
Apply conditional build flag(in C compiler)

### DIFF
--- a/util/secp256k1/build.rs
+++ b/util/secp256k1/build.rs
@@ -92,7 +92,7 @@ fn main() {
 		.define("ENABLE_MODULE_RECOVERY", Some("1"));
 
     base_config.flag("-Wno-unused-function");
-    base_config.flag("-Wno-nonnull-compare");
+    base_config.flag_if_supported("-Wno-nonnull-compare");
 
     // secp256k1
     base_config


### PR DESCRIPTION
Fix: #142 
Since **```-Wno-nnull-compare```** build option is only available for gcc(https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#Warning-Options),
clang(used by Mac) could not resolve the flag. (https://clang.llvm.org/docs/DiagnosticsReference.html)

Thanks to @Kais-DkM, this PR removed typo.
