### PR TITLE
Rename chain_type field to chain

### DIFF
--- a/codechain/config/mod.rs
+++ b/codechain/config/mod.rs
@@ -94,7 +94,7 @@ pub struct Operating {
     pub instance_id: Option<usize>,
     pub db_path: String,
     pub snapshot_path: String,
-    pub chain_type: ChainType,
+    pub chain: ChainType,
     pub enable_block_sync: bool,
     pub enable_parcel_relay: bool,
     pub secret_key: Secret,
@@ -122,7 +122,7 @@ impl Operating {
             self.snapshot_path = snapshot_path.to_string();
         }
         if let Some(chain) = matches.value_of("chain") {
-            self.chain_type = chain.parse()?;
+            self.chain = chain.parse()?;
         }
         if matches.is_present("no-sync") {
             self.enable_block_sync = false;

--- a/codechain/config/presets/config.dev.toml
+++ b/codechain/config/presets/config.dev.toml
@@ -2,7 +2,7 @@
 quiet = false
 db_path = "db"
 snapshot_path = "snapshot"
-chain_type = "tendermint"
+chain = "tendermint"
 enable_block_sync = true
 enable_parcel_relay = true
 secret_key = "0x0000000000000000000000000000000000000000000000000000000000000001"

--- a/codechain/main.rs
+++ b/codechain/main.rs
@@ -147,7 +147,7 @@ fn run_node(matches: ArgMatches) -> Result<(), String> {
     let config_path = matches.value_of("config-path").unwrap_or(DEFAULT_CONFIG_PATH);
     let mut config = config::load(&config_path)?;
     config.operating.overwrite_with(&matches)?;
-    let spec = config.operating.chain_type.spec()?;
+    let spec = config.operating.chain.spec()?;
 
     let instance_id = config.operating.instance_id.unwrap_or(SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,7 +19,7 @@ The following represents the default configuration values of ``config.dev.toml``
     [codechain]
     quiet = false
     db_path = "db"
-    chain_type = "tendermint"
+    chain = "tendermint"
     enable_block_sync = true
     enable_parcel_relay = true
     secret_key = "0x0000000000000000000000000000000000000000000000000000000000000001"


### PR DESCRIPTION
Make the naming consistent with command line option.