### PR TITLE
Add Sanity check for unlock script

### DIFF
--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -18,7 +18,7 @@ use ccrypto::{blake256, keccak256, ripemd160, sha256};
 use ckeys::{verify_ecdsa, ECDSASignature};
 use ctypes::{H256, H520, Public};
 
-use instruction::Instruction;
+use instruction::{is_valid_unlock_script, Instruction};
 
 const DEFAULT_MAX_MEMORY: usize = 1024;
 
@@ -147,6 +147,11 @@ pub fn execute(
     config: Config,
 ) -> Result<ScriptResult, RuntimeError> {
     // FIXME: don't merge scripts
+
+    if !is_valid_unlock_script(unlock) {
+        return Ok(ScriptResult::Fail)
+    }
+
     let param_scripts: Vec<_> = params.iter().map(|p| Instruction::PushB(p.clone())).rev().collect();
     let script = [unlock, &param_scripts, lock].concat();
 

--- a/vm/src/instruction.rs
+++ b/vm/src/instruction.rs
@@ -36,3 +36,11 @@ pub enum Instruction {
     Ripemd160,
     Keccak256,
 }
+
+pub fn is_valid_unlock_script(instrs: &[Instruction]) -> bool {
+    instrs.iter().all(|instr| match instr {
+        Instruction::Push(_) => true,
+        Instruction::PushB(_) => true,
+        _ => false,
+    })
+}

--- a/vm/src/tests/executor.rs
+++ b/vm/src/tests/executor.rs
@@ -38,13 +38,13 @@ fn simple_failure() {
 
 #[test]
 fn simple_burn() {
-    assert_eq!(execute(&[Instruction::Burn], &[], &[], H256::default(), Config::default()), Ok(ScriptResult::Burnt));
+    assert_eq!(execute(&[], &[], &[Instruction::Burn], H256::default(), Config::default()), Ok(ScriptResult::Burnt));
 }
 
 #[test]
 fn underflow() {
     assert_eq!(
-        execute(&[Instruction::Pop], &[], &[], H256::default(), Config::default()),
+        execute(&[], &[], &[Instruction::Pop], H256::default(), Config::default()),
         Err(RuntimeError::StackUnderflow)
     );
 }
@@ -58,6 +58,11 @@ fn out_of_memory() {
         execute(&[Instruction::Push(0), Instruction::Push(1), Instruction::Push(2)], &[], &[], H256::default(), config),
         Err(RuntimeError::OutOfMemory)
     );
+}
+
+#[test]
+fn invalid_unlock_script() {
+    assert_eq!(execute(&[Instruction::Nop], &[], &[], H256::default(), Config::default()), Ok(ScriptResult::Fail));
 }
 
 #[test]


### PR DESCRIPTION
Fix #280 

- check valid instructions for unlock
- fix test cases (simple_burn and underflow)