### PR TITLE
Cleanup code

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -455,7 +455,7 @@ mod tests {
     fn open_block() {
         let spec = Spec::new_test();
         let genesis_header = spec.genesis_header();
-        let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
+        let db = spec.ensure_genesis_state(get_temp_state_db(), &Default::default()).unwrap();
         let b = OpenBlock::new(&*spec.engine, Default::default(), db, &genesis_header, Address::zero(), vec![], false)
             .unwrap();
         let parent_parcels_root = genesis_header.parcels_root().clone();

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -100,7 +100,7 @@ impl Client {
         let mut state_db = StateDB::new(journal_db, config.state_cache_size);
         if state_db.journal_db().is_empty() {
             // Sets the correct state root.
-            state_db = spec.ensure_db_good(state_db, &trie_factory)?;
+            state_db = spec.ensure_genesis_state(state_db, &trie_factory)?;
             let mut batch = DBTransaction::new();
             state_db.journal_under(&mut batch, 0, &spec.genesis_header().hash())?;
             db.write(batch).map_err(ClientError::Database)?;

--- a/core/src/consensus/solo.rs
+++ b/core/src/consensus/solo.rs
@@ -106,7 +106,7 @@ mod tests {
     fn solo_can_seal() {
         let spec = Spec::new_test_solo();
         let engine = &*spec.engine;
-        let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
+        let db = spec.ensure_genesis_state(get_temp_state_db(), &Default::default()).unwrap();
         let genesis_header = spec.genesis_header();
         let b =
             OpenBlock::new(engine, Default::default(), db, &genesis_header, Default::default(), vec![], false).unwrap();

--- a/core/src/consensus/solo_authority.rs
+++ b/core/src/consensus/solo_authority.rs
@@ -240,7 +240,7 @@ mod tests {
     fn can_generate_seal() {
         let spec = Spec::new_test_solo_authority();
         let engine = &*spec.engine;
-        let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
+        let db = spec.ensure_genesis_state(get_temp_state_db(), &Default::default()).unwrap();
         let genesis_header = spec.genesis_header();
         let b =
             OpenBlock::new(engine, Default::default(), db, &genesis_header, Default::default(), vec![], false).unwrap();

--- a/core/src/pod_account.rs
+++ b/core/src/pod_account.rs
@@ -17,8 +17,8 @@
 use std::fmt;
 
 use cjson;
-use ctypes::{Bytes, Public, U256};
-use rlp::RlpStream;
+use ctypes::{Public, U256};
+use rlp::{Encodable, RlpStream};
 
 use super::state::Account;
 
@@ -45,17 +45,17 @@ impl PodAccount {
             regular_key: acc.regular_key(),
         }
     }
+}
 
-    /// Returns the RLP for this account.
-    pub fn rlp(&self) -> Bytes {
+impl Encodable for PodAccount {
+    fn rlp_append(&self, stream: &mut RlpStream) {
         // Don't forget to sync the field list with Account.
-        let mut stream = RlpStream::new_list(4);
         const PREFIX: u8 = 'C' as u8;
+        stream.begin_list(4);
         stream.append(&PREFIX);
         stream.append(&self.balance);
         stream.append(&self.nonce);
         stream.append(&self.regular_key);
-        stream.out()
     }
 }
 


### PR DESCRIPTION
1. Remove unnecessary iter() call.
  No need to call iter() since PodState::get() returns reference.

2.  Make ensure_db_good return DB instead of Result<DB>.
  There is nothing we can do when initializing DB failed.

3. Rename ensure_db_good to ensure_genesis_state

4. Rename generic parameter T to DB