### PR TITLE
Make RLP implementation of PodAccount uses state::Account

### DIFF
--- a/core/src/pod_account.rs
+++ b/core/src/pod_account.rs
@@ -34,15 +34,16 @@ pub struct PodAccount {
     pub regular_key: Option<Public>,
 }
 
+impl<'a> Into<Account> for &'a PodAccount {
+    fn into(self) -> Account {
+        Account::new_with_key(self.balance, self.nonce, self.regular_key)
+    }
+}
+
 impl Encodable for PodAccount {
     fn rlp_append(&self, stream: &mut RlpStream) {
-        // Don't forget to sync the field list with Account.
-        const PREFIX: u8 = 'C' as u8;
-        stream.begin_list(4);
-        stream.append(&PREFIX);
-        stream.append(&self.balance);
-        stream.append(&self.nonce);
-        stream.append(&self.regular_key);
+        let account: Account = self.into();
+        account.rlp_append(stream);
     }
 }
 

--- a/core/src/state/account.rs
+++ b/core/src/state/account.rs
@@ -44,6 +44,14 @@ impl Account {
         }
     }
 
+    pub fn new_with_key(balance: U256, nonce: U256, regular_key: Option<Public>) -> Self {
+        Self {
+            balance,
+            nonce,
+            regular_key,
+        }
+    }
+
     /// return the balance associated with this account.
     pub fn balance(&self) -> &U256 {
         &self.balance


### PR DESCRIPTION
Currently, there is a comment that PodAccount and Account must sync the
member, but there is no way to check it.

This patch makes RLP implementation of PodAccount uses state::Account.
For now, the compiler fails when only one of the PodAccount or
state::Account is updated.