### PR TITLE
Make UntrustedRlp::at not to read over prefixed length

### DIFF
--- a/core/src/blockchain/extras.rs
+++ b/core/src/blockchain/extras.rs
@@ -218,7 +218,7 @@ impl Encodable for ParcelInvoice {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
             ParcelInvoice::Single(invoice) => {
-                s.append(invoice);
+                s.append_single_value(invoice);
             }
             ParcelInvoice::Multiple(invoices) => {
                 s.append_list(invoices);

--- a/core/src/consensus/epoch.rs
+++ b/core/src/consensus/epoch.rs
@@ -83,7 +83,7 @@ pub struct PendingTransition {
 
 impl Encodable for PendingTransition {
     fn rlp_append(&self, s: &mut RlpStream) {
-        s.append(&self.proof);
+        s.append_single_value(&self.proof);
     }
 }
 

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -95,7 +95,7 @@ impl Decodable for Step {
 
 impl Encodable for Step {
     fn rlp_append(&self, s: &mut RlpStream) {
-        s.append_internal(&self.number());
+        s.append_single_value(&self.number());
     }
 }
 

--- a/core/src/invoice.rs
+++ b/core/src/invoice.rs
@@ -26,8 +26,8 @@ pub enum Invoice {
 impl Encodable for Invoice {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
-            Invoice::Success => s.append(&1u8),
-            Invoice::Failed => s.append(&0u8),
+            Invoice::Success => s.append_single_value(&1u8),
+            Invoice::Failed => s.append_single_value(&0u8),
         };
     }
 }

--- a/discovery/src/kademlia/message.rs
+++ b/discovery/src/kademlia/message.rs
@@ -27,7 +27,7 @@ impl Encodable for Message {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
             Message::FindNode(len) => {
-                s.append(len);
+                s.append_single_value(len);
             }
             Message::Nodes(addresses) => {
                 s.append_list(addresses);

--- a/discovery/src/unstructured/message.rs
+++ b/discovery/src/unstructured/message.rs
@@ -27,7 +27,7 @@ impl Encodable for Message {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
             Message::Request(len) => {
-                s.append(len);
+                s.append_single_value(len);
             }
             Message::Response(addresses) => {
                 s.append_list(addresses);

--- a/key/src/network.rs
+++ b/key/src/network.rs
@@ -41,6 +41,6 @@ impl Decodable for Network {
 
 impl Encodable for Network {
     fn rlp_append(&self, s: &mut RlpStream) {
-        s.append(&(*self as u8));
+        s.append_single_value(&(*self as u8));
     }
 }

--- a/util/rlp/benches/rlp.rs
+++ b/util/rlp/benches/rlp.rs
@@ -27,7 +27,7 @@ fn bench_stream_u64_value(b: &mut Bencher) {
     b.iter(|| {
         // u64
         let mut stream = RlpStream::new();
-        stream.append(&0x1023456789abcdefu64);
+        stream.append_single_value(&0x1023456789abcdefu64);
         let _ = stream.out();
     });
 }
@@ -48,7 +48,7 @@ fn bench_stream_u256_value(b: &mut Bencher) {
         // u256
         let mut stream = RlpStream::new();
         let uint: U256 = "8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0".into();
-        stream.append(&uint);
+        stream.append_single_value(&uint);
         let _ = stream.out();
     });
 }

--- a/util/rlp/src/lib.rs
+++ b/util/rlp/src/lib.rs
@@ -110,7 +110,7 @@ pub fn encode<E>(object: &E) -> ElasticArray1024<u8>
 where
     E: Encodable, {
     let mut stream = RlpStream::new();
-    stream.append(object);
+    stream.append_single_value(object);
     stream.drain()
 }
 

--- a/util/rlp/src/stream.rs
+++ b/util/rlp/src/stream.rs
@@ -96,7 +96,7 @@ impl RlpStream {
 
     /// Appends value to the end of stream, but do not count it as an appended item.
     /// It's useful for wrapper types
-    pub fn append_internal<'a, E>(&'a mut self, value: &E) -> &'a mut Self
+    pub fn append_single_value<'a, E>(&'a mut self, value: &E) -> &'a mut Self
     where
         E: Encodable, {
         value.rlp_append(self);

--- a/util/rlp/src/untrusted_rlp.rs
+++ b/util/rlp/src/untrusted_rlp.rs
@@ -201,6 +201,9 @@ where
             return Err(DecoderError::RlpExpectedToBeList)
         }
 
+        let payload_info = self.payload_info()?;
+        let offset_max = payload_info.header_len + payload_info.value_len - 1;
+
         // move to cached position if its index is less or equal to
         // current search index, otherwise move to beginning of list
         let c = self.offset_cache.get();
@@ -212,8 +215,16 @@ where
         // skip up to x items
         bytes = UntrustedRlp::consume_items(bytes, to_skip)?;
 
+        let new_offset = self.bytes.len() - bytes.len();
+
+        // self.data.len() can be greater than byte length from payload's length
+        // But you should not read the data which is lied after payload's length
+        if new_offset > offset_max {
+            return Err(DecoderError::RlpIsTooShort)
+        }
+
         // update the cache
-        self.offset_cache.set(OffsetCache::new(index, self.bytes.len() - bytes.len()));
+        self.offset_cache.set(OffsetCache::new(index, new_offset));
 
         // construct new rlp
         let found = BasicDecoder::payload_info(bytes)?;
@@ -408,6 +419,7 @@ impl<'a> BasicDecoder<'a> {
 #[cfg(test)]
 mod tests {
     use {DecoderError, UntrustedRlp};
+    use traits::Encodable;
 
     #[test]
     fn test_rlp_display() {
@@ -423,5 +435,29 @@ mod tests {
         let rlp = UntrustedRlp::new(&bs);
         let res: Result<u8, DecoderError> = rlp.as_val();
         assert_eq!(Err(DecoderError::RlpInvalidLength), res);
+    }
+
+    #[test]
+    fn at_overflow() {
+        let bs = vec![vec![1], vec![2,3,4], vec![3]].rlp_bytes();
+        let rlp = UntrustedRlp::new(&*bs);
+        let first_element: Result<Vec<u8>, _> = rlp.at(2).and_then(|elem| elem.as_val());
+        assert_eq!(Ok(vec![3]), first_element);
+
+        let fourth_element: Result<Vec<u8>, _> = rlp.at(3).and_then(|elem| elem.as_val());
+        assert_eq!(Err(DecoderError::RlpIsTooShort), fourth_element);
+    }
+
+
+    #[test]
+    fn invalid_length_rlp_at_overflow() {
+        // [1,2,3,4] with invalid byte length 3
+        let bs = [0xc3, 0x01, 0x02, 0x03, 0x04];
+        let rlp = UntrustedRlp::new(&bs);
+        let first_element: Result<u8, _> = rlp.at(2).and_then(|elem| elem.as_val());
+        assert_eq!(Ok(3), first_element);
+
+        let fourth_element: Result<u8, _> = rlp.at(3).and_then(|elem| elem.as_val());
+        assert_eq!(Err(DecoderError::RlpIsTooShort), fourth_element);
     }
 }


### PR DESCRIPTION
RlpStream's append modify internal state about list length.
So if you want to just one entity, you should use append_internal