### PR TITLE
Fix JSON-RPC (Inaccurate description of miner_getWork)

### DIFF
--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -690,7 +690,7 @@ Response Example
 ```
 
 ## miner_getWork
-Returns the hash of the current block, score and block number.
+Returns the hash of the current block and score.
 
 Params: No parameters
 


### PR DESCRIPTION
No block number is used. (https://github.com/CodeChain-io/codechain/blob/master/spec/JSON-RPC.md#miner_getwork)