### PR TITLE
Fixed #386 that adding optional block number param to getAsset() RPC method

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -265,8 +265,8 @@ impl AssetClient for Client {
         }
     }
 
-    fn get_asset(&self, transaction_hash: H256, index: usize) -> TrieResult<Option<Asset>> {
-        if let Some(state) = Client::state_at(&self, BlockId::Latest) {
+    fn get_asset(&self, transaction_hash: H256, index: usize, id: BlockId) -> TrieResult<Option<Asset>> {
+        if let Some(state) = Client::state_at(&self, id) {
             let shard_id = 0; // FIXME
             let address = AssetAddress::new(transaction_hash, index, shard_id);
             Ok(state.asset(shard_id, &address)?)

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -239,5 +239,5 @@ pub trait DatabaseClient {
 pub trait AssetClient {
     fn get_asset_scheme(&self, transaction_hash: H256) -> TrieResult<Option<AssetScheme>>;
 
-    fn get_asset(&self, transaction_hash: H256, index: usize) -> TrieResult<Option<Asset>>;
+    fn get_asset(&self, transaction_hash: H256, index: usize, id: BlockId) -> TrieResult<Option<Asset>>;
 }

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -87,8 +87,9 @@ where
         self.client.get_asset_scheme(transaction_hash).map_err(errors::parcel)
     }
 
-    fn get_asset(&self, transaction_hash: H256, index: usize) -> Result<Option<Asset>> {
-        self.client.get_asset(transaction_hash, index).map_err(errors::parcel)
+    fn get_asset(&self, transaction_hash: H256, index: usize, block_number: Option<u64>) -> Result<Option<Asset>> {
+        let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
+        self.client.get_asset(transaction_hash, index, block_id).map_err(errors::parcel)
     }
 
     fn get_nonce(&self, address: H160, block_number: Option<u64>) -> Result<Option<U256>> {

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -46,7 +46,7 @@ build_rpc_trait! {
 
         /// Gets asset with given asset type.
         # [rpc(name = "chain_getAsset")]
-        fn get_asset(&self, H256, usize) -> Result<Option<Asset>>;
+        fn get_asset(&self, H256, usize, Option<u64>) -> Result<Option<Asset>>;
 
         /// Gets nonce with given account.
         # [rpc(name = "chain_getNonce")]

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -461,6 +461,7 @@ Gets an asset with the given asset type.
 Params:
  1. transaction hash - `H256`
  2. index - `number`
+ 3. block number: `number` | `null`
 
 Return Type: `null` | `AssetObject`
 


### PR DESCRIPTION
Add a third parameter, block number, to the getAsset () RPC method.