### PR TITLE
Ignore the received packet while disconnecting the connection

### DIFF
--- a/network/src/p2p/connection.rs
+++ b/network/src/p2p/connection.rs
@@ -560,6 +560,10 @@ impl Connection {
                 connection.reregister(reg, event_loop)?;
                 Ok(ConnectionType::Established)
             }
+            State::Disconnecting(_) => {
+                ctrace!(NET, "Packet received while disconnecting");
+                Ok(ConnectionType::Disconnecting)
+            }
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
May fix #496

I suspect that the panic occurred when a packet is received while disconnecting the connection.