### PR TITLE
Make ShardId 16 bits

### DIFF
--- a/core/src/spec/spec.rs
+++ b/core/src/spec/spec.rs
@@ -200,12 +200,12 @@ impl Spec {
             shard_roots.push((*shard_id, shard_root));
         }
 
-        debug_assert_eq!(::std::mem::size_of::<u32>(), ::std::mem::size_of::<ShardId>());
+        debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
         debug_assert!(
-            shard_roots.len() <= ::std::u32::MAX as usize,
+            shard_roots.len() <= ::std::u16::MAX as usize,
             "{} <= {}",
             shard_roots.len(),
-            ::std::u32::MAX as usize
+            ::std::u16::MAX as usize
         );
         let global_metadata = Metadata::new(shard_roots.len() as ShardId);
 

--- a/json/src/spec/state.rs
+++ b/json/src/spec/state.rs
@@ -20,4 +20,4 @@ use super::super::hash::Address;
 use super::{Account, Shard};
 
 pub type Accounts = BTreeMap<Address, Account>;
-pub type Shards = BTreeMap<u32, Shard>;
+pub type Shards = BTreeMap<u16, Shard>;

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -1128,7 +1128,7 @@ mod tests_parcel {
                 transactions,
                 changes: vec![ChangeShard {
                     shard_id,
-                    pre_root: H256::from("0x3521429ad738442ad7aee37324331e5395bbd0aac7465fba8df12985f6fc2e60"),
+                    pre_root: H256::from("0xdd99c22174c7c1f12523c51d2555803c06c2932085d66ad870a4f6b35ddc47e0"),
                     post_root: H256::zero(),
                 }],
             },
@@ -1191,7 +1191,7 @@ mod tests_parcel {
                 transactions,
                 changes: vec![ChangeShard {
                     shard_id,
-                    pre_root: H256::from("0x3521429ad738442ad7aee37324331e5395bbd0aac7465fba8df12985f6fc2e60"),
+                    pre_root: H256::from("0xdd99c22174c7c1f12523c51d2555803c06c2932085d66ad870a4f6b35ddc47e0"),
                     post_root: H256::zero(),
                 }],
             },
@@ -1304,7 +1304,7 @@ mod tests_parcel {
                 transactions,
                 changes: vec![ChangeShard {
                     shard_id,
-                    pre_root: H256::from("0x3521429ad738442ad7aee37324331e5395bbd0aac7465fba8df12985f6fc2e60"),
+                    pre_root: H256::from("0xdd99c22174c7c1f12523c51d2555803c06c2932085d66ad870a4f6b35ddc47e0"),
                     post_root: H256::zero(),
                 }],
             },
@@ -1384,7 +1384,7 @@ mod tests_parcel {
                 transactions: vec![mint],
                 changes: vec![ChangeShard {
                     shard_id,
-                    pre_root: H256::from("0x3521429ad738442ad7aee37324331e5395bbd0aac7465fba8df12985f6fc2e60"),
+                    pre_root: H256::from("0xdd99c22174c7c1f12523c51d2555803c06c2932085d66ad870a4f6b35ddc47e0"),
                     post_root: H256::zero(),
                 }],
             },
@@ -1457,7 +1457,7 @@ mod tests_parcel {
                 transactions: vec![transfer],
                 changes: vec![ChangeShard {
                     shard_id,
-                    pre_root: H256::from("0x4eab3f0517c29ae11201a0c7f2570d8d7f7feb7f463a871b7255c83be6c1449d"),
+                    pre_root: H256::from("0x0ff1490ead36267f025c0ac335b0749eb502c8f74393ec781c68b4d2dcf3d9fd"),
                     post_root: H256::zero(),
                 }],
             },

--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -32,13 +32,15 @@ macro_rules! define_address_constructor {
         ) -> Self {
             let mut hash: ::primitives::H256 =
                 ::ccrypto::Blake::blake_with_key(&transaction_hash, &::primitives::H128::from(index));
-            hash[0..4].clone_from_slice(&[$prefix, 0, 0, 0]);
+            hash[0..2].clone_from_slice(&[$prefix, 0]);
 
             let mut shard_id_bytes = Vec::<u8>::new();
-            debug_assert_eq!(::std::mem::size_of::<u32>(), ::std::mem::size_of::<::ctypes::ShardId>());
-            ::byteorder::WriteBytesExt::write_u32::<::byteorder::BigEndian>(&mut shard_id_bytes, shard_id).unwrap();
-            assert_eq!(4, shard_id_bytes.len());
-            hash[4..8].clone_from_slice(&shard_id_bytes);
+            debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<::ctypes::ShardId>());
+            ::byteorder::WriteBytesExt::write_u16::<::byteorder::BigEndian>(&mut shard_id_bytes, shard_id).unwrap();
+            assert_eq!(2, shard_id_bytes.len());
+            hash[2..4].clone_from_slice(&shard_id_bytes);
+
+            hash[4..6].clone_from_slice(&[0, 0]); // world id
 
             $name(hash)
         }
@@ -50,9 +52,9 @@ macro_rules! define_shard_id {
     };
     (SHARD) => {
         pub fn shard_id(&self) -> ::ctypes::ShardId {
-            debug_assert_eq!(::std::mem::size_of::<u32>(), ::std::mem::size_of::<ShardId>());
+            debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
             use byteorder::ReadBytesExt;
-            ::std::io::Cursor::new(&self.0[4..8]).read_u32::<::byteorder::BigEndian>().unwrap()
+            ::std::io::Cursor::new(&self.0[2..4]).read_u16::<::byteorder::BigEndian>().unwrap()
         }
     };
 }

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -128,14 +128,16 @@ mod tests {
             }
             address
         };
-        let shard_id = 0xBeefCafe;
+        let shard_id = 0xBeef;
         let address1 = AssetAddress::new(parcel_id, 0, shard_id);
         let address2 = AssetAddress::new(parcel_id, 1, shard_id);
         assert_ne!(address1, address2);
-        assert_eq!(address1[0..4], [PREFIX, 0, 0, 0]);
-        assert_eq!(address1[4..8], [0xBE, 0xEF, 0xCA, 0xFE]); // shard id
-        assert_eq!(address2[0..4], [PREFIX, 0, 0, 0]);
-        assert_eq!(address2[4..8], [0xBE, 0xEF, 0xCA, 0xFE]); // shard id
+        assert_eq!(address1[0..2], [PREFIX, 0]);
+        assert_eq!(address1[2..4], [0xBE, 0xEF]); // shard id
+        assert_eq!(address1[4..6], [0, 0]); // world id
+        assert_eq!(address2[0..2], [PREFIX, 0]);
+        assert_eq!(address2[2..4], [0xBE, 0xEF]); // shard id
+        assert_eq!(address2[4..6], [0, 0]); // world id
     }
 
     #[test]
@@ -147,7 +149,7 @@ mod tests {
                 if hash[0] == PREFIX {
                     continue
                 }
-                for i in 1..8 {
+                for i in 1..6 {
                     if hash[i] == 0 {
                         continue
                     }
@@ -164,7 +166,7 @@ mod tests {
     fn parse_return_some() {
         let hash = {
             let mut hash = H256::random();
-            hash[0..8].clone_from_slice(&[PREFIX, 0, 0, 0, 0, 0, 0, 0]);
+            hash[0..6].clone_from_slice(&[PREFIX, 0, 0, 0, 0, 0]);
             hash
         };
         let address = AssetAddress::from_hash(hash.clone());
@@ -187,10 +189,9 @@ mod tests {
             hash[1] = 0;
             hash
         };
-        let shard_id = ((hash[4] as ShardId) << 24)
-            + ((hash[5] as ShardId) << 16)
-            + ((hash[6] as ShardId) << 8)
-            + (hash[7] as ShardId);
+        assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
+        let shard_id = ((hash[2] as ShardId) << 8)
+            + (hash[3] as ShardId);
         let asset_address = AssetAddress::from_hash(hash).unwrap();
         assert_eq!(shard_id, asset_address.shard_id());
     }

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -111,7 +111,7 @@ mod tests {
                 if address[0] == 'S' as u8 {
                     continue
                 }
-                for i in 1..8 {
+                for i in 1..6 {
                     if address[i] == 0 {
                         continue 'address
                     }
@@ -124,8 +124,9 @@ mod tests {
         let asset_address = AssetSchemeAddress::new(origin, shard_id);
         let hash: H256 = asset_address.into();
         assert_ne!(origin, hash);
-        assert_eq!(hash[0..4], [PREFIX, 0, 0, 0]);
-        assert_eq!(hash[4..8], [0, 0, 0x0B, 0xEE]); // shard id
+        assert_eq!(hash[0..2], [PREFIX, 0]);
+        assert_eq!(hash[2..4], [0x0B, 0xEE]); // shard id
+        assert_eq!(hash[4..6], [0, 0]); // world id
     }
 
     #[test]
@@ -144,10 +145,9 @@ mod tests {
             hash[1] = 0;
             hash
         };
-        let shard_id = ((hash[4] as ShardId) << 24)
-            + ((hash[5] as ShardId) << 16)
-            + ((hash[6] as ShardId) << 8)
-            + (hash[7] as ShardId);
+        assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
+        let shard_id = ((hash[2] as ShardId) << 8)
+            + (hash[3] as ShardId);
         let asset_scheme_address = AssetSchemeAddress::from_hash(hash).unwrap();
         assert_eq!(shard_id, asset_scheme_address.shard_id());
     }

--- a/state/src/item/shard_metadata.rs
+++ b/state/src/item/shard_metadata.rs
@@ -103,10 +103,12 @@ mod tests {
         let address1 = ShardMetadataAddress::new(0);
         let address2 = ShardMetadataAddress::new(1);
         assert_ne!(address1, address2);
-        assert_eq!(address1[0..4], [PREFIX, 0, 0, 0]);
-        assert_eq!(address1[4..8], [0, 0, 0, 0]); // shard id
-        assert_eq!(address2[0..4], [PREFIX, 0, 0, 0]);
-        assert_eq!(address2[4..8], [0, 0, 0, 1]); // shard id
+        assert_eq!(address1[0..2], [PREFIX, 0]);
+        assert_eq!(address1[2..4], [0, 0]); // shard id
+        assert_eq!(address1[4..6], [0, 0]); // world id
+        assert_eq!(address2[0..2], [PREFIX, 0]);
+        assert_eq!(address2[2..4], [0, 1]); // shard id
+        assert_eq!(address2[4..6], [0, 0]); // world id
     }
 
     #[test]
@@ -118,7 +120,7 @@ mod tests {
                 if hash[0] == PREFIX {
                     continue
                 }
-                for i in 1..8 {
+                for i in 1..6 {
                     if hash[i] == 0 {
                         continue 'hash
                     }
@@ -135,7 +137,7 @@ mod tests {
     fn parse_return_some() {
         let hash = {
             let mut hash = H256::random();
-            hash[0..8].clone_from_slice(&[PREFIX, 0, 0, 0, 0, 0, 0, 0]);
+            hash[0..6].clone_from_slice(&[PREFIX, 0, 0, 0, 0, 0]);
             hash
         };
         let address = ShardMetadataAddress::from_hash(hash.clone());
@@ -157,10 +159,8 @@ mod tests {
             hash[1] = 0;
             hash
         };
-        let shard_id = ((hash[4] as ShardId) << 24)
-            + ((hash[5] as ShardId) << 16)
-            + ((hash[6] as ShardId) << 8)
-            + (hash[7] as ShardId);
+        let shard_id = ((hash[2] as ShardId) << 8)
+            + (hash[3] as ShardId);
         let address = ShardMetadataAddress::from_hash(hash).unwrap();
         assert_eq!(shard_id, address.shard_id());
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -34,4 +34,4 @@ pub mod parcel;
 pub mod transaction;
 
 pub type BlockNumber = u64;
-pub type ShardId = u32;
+pub type ShardId = u16;

--- a/types/src/transaction/transaction.rs
+++ b/types/src/transaction/transaction.rs
@@ -252,8 +252,8 @@ impl Encodable for Transaction {
 
 impl AssetOutPoint {
     pub fn related_shard(&self) -> ShardId {
-        debug_assert_eq!(::std::mem::size_of::<u32>(), ::std::mem::size_of::<ShardId>());
-        Cursor::new(&self.asset_type[4..8]).read_u32::<BigEndian>().unwrap()
+        debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
+        Cursor::new(&self.asset_type[2..4]).read_u16::<BigEndian>().unwrap()
     }
 }
 
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn related_shard_of_asset_out_point() {
         let mut asset_type = H256::new();
-        asset_type[4..8].clone_from_slice(&[0xBE, 0xEF, 0x12, 0x34]);
+        asset_type[2..4].clone_from_slice(&[0xBE, 0xEF]);
 
         let p = AssetOutPoint {
             transaction_hash: H256::random(),
@@ -279,13 +279,13 @@ mod tests {
             amount: 34,
         };
 
-        assert_eq!(0xBEEF1234, p.related_shard());
+        assert_eq!(0xBEEF, p.related_shard());
     }
 
     #[test]
     fn related_shard_of_asset_transfer_input() {
         let mut asset_type = H256::new();
-        asset_type[4..8].clone_from_slice(&[0xBE, 0xEF, 0x12, 0x34]);
+        asset_type[2..4].clone_from_slice(&[0xBE, 0xEF]);
 
         let prev_out = AssetOutPoint {
             transaction_hash: H256::random(),
@@ -300,6 +300,6 @@ mod tests {
             unlock_script: vec![],
         };
 
-        assert_eq!(0xBEEF1234, input.related_shard());
+        assert_eq!(0xBEEF, input.related_shard());
     }
 }

--- a/util/primitives/src/hash.rs
+++ b/util/primitives/src/hash.rs
@@ -17,11 +17,20 @@
 pub use ethereum_types::{H1024, H128, H160, H256, H264, H32, H512, H520, H64};
 
 construct_hash!(H248, 31);
+construct_hash!(H208, 26);
 
 impl From<H248> for H256 {
     fn from(value: H248) -> H256 {
         let mut ret = H256::zero();
         ret.0[1..32].copy_from_slice(&value);
+        ret
+    }
+}
+
+impl From<H208> for H256 {
+    fn from(value: H208) -> H256 {
+        let mut ret = H256::zero();
+        ret.0[6..32].copy_from_slice(&value);
         ret
     }
 }
@@ -37,5 +46,19 @@ mod tests {
 
         assert_eq!(0u8, h256[0]);
         assert_eq!(h248[0..31], h256[1..32]);
+    }
+
+    #[test]
+    fn h208_can_be_converted_to_h256() {
+        let h208 = H208::random();
+        let h256 = H256::from(h208);
+
+        assert_eq!(0u8, h256[0]);
+        assert_eq!(0u8, h256[1]);
+        assert_eq!(0u8, h256[2]);
+        assert_eq!(0u8, h256[3]);
+        assert_eq!(0u8, h256[4]);
+        assert_eq!(0u8, h256[5]);
+        assert_eq!(h208[0..26], h256[6..32]);
     }
 }


### PR DESCRIPTION
This PR makes ShardId 16 bits and changes the mechanism to create asset/asset scheme address.
Currently, CodeChain generates 256 bits hash and replaces some bits with prefix and shard id and world id.
This patch changes CodeChain generates 208 bits hash instead of 256 bits hash since 48 bits will be removed.