### PR TITLE
Implement SetRegularKey

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -155,7 +155,7 @@ impl<'x> OpenBlock<'x> {
             return Err(StateError::Parcel(ParcelError::ParcelAlreadyImported).into())
         }
 
-        let outcomes = self.block.state.apply(&parcel, parcel.sender())?;
+        let outcomes = self.block.state.apply(&parcel, parcel.sender(), &parcel.public_key())?;
 
         self.block.parcels_set.insert(h.unwrap_or_else(|| parcel.hash()));
         self.block.parcels.push(parcel.into());

--- a/state/src/backend.rs
+++ b/state/src/backend.rs
@@ -44,8 +44,8 @@ use hashdb::HashDB;
 use primitives::{Bytes, H256};
 
 use super::{
-    Account, ActionHandler, Asset, AssetAddress, AssetScheme, AssetSchemeAddress, Metadata, MetadataAddress, Shard,
-    ShardAddress,
+    Account, ActionHandler, Asset, AssetAddress, AssetScheme, AssetSchemeAddress, Metadata, MetadataAddress,
+    RegularAccount, RegularAccountAddress, Shard, ShardAddress,
 };
 
 
@@ -61,6 +61,12 @@ pub trait Backend: Send {
 pub trait TopBackend: Send {
     /// Add an account entry to the cache.
     fn add_to_account_cache(&mut self, addr: Address, data: Option<Account>, modified: bool);
+    fn add_to_regular_account_cache(
+        &mut self,
+        address: RegularAccountAddress,
+        data: Option<RegularAccount>,
+        modified: bool,
+    );
     fn add_to_metadata_cache(&mut self, address: MetadataAddress, item: Option<Metadata>, modified: bool);
     fn add_to_shard_cache(&mut self, address: ShardAddress, item: Option<Shard>, modified: bool);
     fn add_to_action_data_cache(&mut self, address: H256, item: Option<Bytes>, modified: bool);
@@ -68,6 +74,7 @@ pub trait TopBackend: Send {
     /// Get basic copy of the cached account. Not required to include storage.
     /// Returns 'None' if cache is disabled or if the account is not cached.
     fn get_cached_account(&self, addr: &Address) -> Option<Option<Account>>;
+    fn get_cached_regular_account(&self, addr: &RegularAccountAddress) -> Option<Option<RegularAccount>>;
     fn get_cached_metadata(&self, addr: &MetadataAddress) -> Option<Option<Metadata>>;
     fn get_cached_shard(&self, addr: &ShardAddress) -> Option<Option<Shard>>;
     fn get_cached_action_data(&self, key: &H256) -> Option<Option<Bytes>>;
@@ -79,6 +86,10 @@ pub trait TopBackend: Send {
     fn get_cached_account_with<F, U>(&self, a: &Address, f: F) -> Option<U>
     where
         F: FnOnce(Option<&mut Account>) -> U;
+
+    fn get_cached_regular_account_with<F, U>(&self, a: &RegularAccountAddress, f: F) -> Option<U>
+    where
+        F: FnOnce(Option<&mut RegularAccount>) -> U;
 
     fn custom_handlers(&self) -> &[Arc<ActionHandler>];
 }

--- a/state/src/item/mod.rs
+++ b/state/src/item/mod.rs
@@ -22,5 +22,6 @@ pub mod asset;
 pub mod asset_scheme;
 pub mod cache;
 pub mod metadata;
+pub mod regular_account;
 pub mod shard;
 pub mod shard_metadata;

--- a/state/src/item/regular_account.rs
+++ b/state/src/item/regular_account.rs
@@ -1,0 +1,90 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use ckey::{public_to_address, Address, Public};
+use primitives::H256;
+use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
+
+use super::cache::CacheableItem;
+
+#[derive(Clone, Debug)]
+pub struct RegularAccount {
+    master_account: Public,
+}
+
+impl RegularAccount {
+    pub fn new(master_account: Public) -> Self {
+        Self {
+            master_account,
+        }
+    }
+
+    pub fn master_account(&self) -> &Public {
+        &self.master_account
+    }
+
+    pub fn set_master_account(&mut self, master_public: &Public) {
+        self.master_account = *master_public;
+    }
+}
+
+impl CacheableItem for RegularAccount {
+    type Address = RegularAccountAddress;
+
+    fn is_null(&self) -> bool {
+        self.master_account.is_zero()
+    }
+}
+
+const PREFIX: u8 = 'R' as u8;
+
+impl Encodable for RegularAccount {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2).append(&PREFIX).append(&self.master_account);
+    }
+}
+
+impl Decodable for RegularAccount {
+    fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
+        if rlp.item_count()? != 2 {
+            return Err(DecoderError::RlpInvalidLength)
+        }
+        let prefix = rlp.val_at::<u8>(0)?;
+        if PREFIX != prefix {
+            cdebug!(STATE, "{} is not an expected prefix for regular account", prefix);
+            return Err(DecoderError::Custom("Unexpected prefix"))
+        }
+        Ok(Self {
+            master_account: rlp.val_at(1)?,
+        })
+    }
+}
+
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RegularAccountAddress(H256);
+
+impl_address!(TOP, RegularAccountAddress, PREFIX);
+
+impl RegularAccountAddress {
+    pub fn new(public: &Public) -> Self {
+        let address = public_to_address(public);
+        Self::from_transaction_hash(::ccrypto::blake256(&address), 0)
+    }
+
+    pub fn from_address(address: &Address) -> Self {
+        Self::from_transaction_hash(::ccrypto::blake256(address), 0)
+    }
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -62,6 +62,7 @@ pub use item::asset::{Asset, AssetAddress};
 pub use item::asset_scheme::{AssetScheme, AssetSchemeAddress};
 pub use item::cache::{Cache, CacheableItem};
 pub use item::metadata::{Metadata, MetadataAddress};
+pub use item::regular_account::{RegularAccount, RegularAccountAddress};
 pub use item::shard::{Shard, ShardAddress};
 pub use item::shard_metadata::{ShardMetadata, ShardMetadataAddress};
 pub use traits::{ShardState, ShardStateInfo, StateWithCache, TopState, TopStateInfo};

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -65,11 +65,15 @@ where
     B: TopBackend, {
     /// Remove an existing account.
     fn kill_account(&mut self, account: &Address);
+    fn kill_regular_account(&mut self, account: &Public);
 
     fn account_exists(&self, a: &Address) -> TrieResult<bool>;
 
     fn account_exists_and_not_null(&self, a: &Address) -> TrieResult<bool>;
     fn account_exists_and_has_nonce(&self, a: &Address) -> TrieResult<bool>;
+
+    fn master_account_exists_and_not_null(&self, a: &Address) -> TrieResult<bool>;
+    fn regular_account_exists_and_not_null(&self, a: &Address) -> TrieResult<bool>;
 
     /// Add `incr` to the balance of account `a`.
     fn add_balance(&mut self, a: &Address, incr: &U256) -> TrieResult<()>;
@@ -81,8 +85,8 @@ where
     /// Increment the nonce of account `a` by 1.
     fn inc_nonce(&mut self, a: &Address) -> TrieResult<()>;
 
-    /// Set the regular key of account `a`
-    fn set_regular_key(&mut self, a: &Address, key: &Public) -> StateResult<()>;
+    /// Set the regular key of account `master_public`
+    fn set_regular_key(&mut self, master_public: &Public, key: &Public) -> StateResult<()>;
 
     fn create_shard(&mut self, shard_creation_cost: &U256, fee_payer: &Address) -> StateResult<()>;
 

--- a/types/src/parcel/error.rs
+++ b/types/src/parcel/error.rs
@@ -70,6 +70,9 @@ pub enum Error {
     InvalidSignature(String),
     InconsistentShardOutcomes,
     ParcelsTooBig,
+    RegularKeyAlreadyInUse,
+    RegularKeyAlreadyInUseAsMaster,
+    InvalidTransferDestination,
 }
 
 impl Display for Error {
@@ -101,6 +104,9 @@ impl Display for Error {
             Error::InvalidSignature(err) => format!("Parcel has invalid signature: {}.", err),
             Error::InconsistentShardOutcomes => "Shard outcomes are inconsistent".to_string(),
             Error::ParcelsTooBig => "Parcel size exceeded the body size limit".to_string(),
+            Error::RegularKeyAlreadyInUse => "The regular key is already registered to another account".to_string(),
+            Error::RegularKeyAlreadyInUseAsMaster => "The regular key is already used as a master account".to_string(),
+            Error::InvalidTransferDestination => "Transfer receiver is not valid account".to_string(),
         };
 
         f.write_fmt(format_args!("Parcel error ({})", msg))


### PR DESCRIPTION

@sgkim126 
Could you help me with the macro `from_transaction_hash`?
I used the macro, but compiler warned like below.
How can I solve the warning?

```
warning: method is never used: `from_transaction_hash`
  --> state/src/item/address.rs:19:9
   |
19 |         fn from_transaction_hash(transaction_hash: ::primitives::H256, index: u64) -> Self {
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
  ::: state/src/item/regular_account.rs:79:1
   |
79 | impl_address!(TOP, RegularAccountAddress, PREFIX);
   | -------------------------------------------------- in this macro invocation
   |
   = note: #[warn(dead_code)] on by default
```