### PR TITLE
Update setup.rst

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -43,7 +43,7 @@ CodeChain requires Rust version 1.26 to build. Using `rustup <https://rustup.rs/
     * Ubuntu
 
     .. note::
-        ``gcc`` and ``g++`` are required for installing packages.
+        ``gcc``, ``g++`` and ``make`` are required for installing packages.
 
     ::
 


### PR DESCRIPTION
Add requirement to pre-installed package ``make`` to avoid below build error.
``` 
   Compiling codechain-discovery v0.1.0 (file:///home/paik/Workspace/codechain/discovery)
error: failed to run custom build command for `backtrace-sys v0.1.16`
process didn't exit successfully: `/home/paik/Workspace/codechain/target/debug/build/backtrace-sys-cc2dd5f162f36cd0/build-script-build` (exit code: 101)
--- stdout
OPT_LEVEL = Some("0")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CC_x86_64-unknown-linux-gnu = None
CC_x86_64_unknown_linux_gnu = None
HOST_CC = None
CC = None
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CFLAGS_x86_64-unknown-linux-gnu = None
CFLAGS_x86_64_unknown_linux_gnu = None
HOST_CFLAGS = None
CFLAGS = None
DEBUG = Some("true")
running: "sh" "/home/paik/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.16/src/libbacktrace/configure" "--with-pic" "--disable-multilib" "--disable-shared" "--disable-host-shared" "--host=x86_64-unknown-linux-gnu" "--build=x86_64-unknown-linux-gnu"
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking target system type... x86_64-unknown-linux-gnu
checking for x86_64-unknown-linux-gnu-gcc... cc
checking for C compiler default output file name... a.out
checking whether the C compiler works... yes
checking whether we are cross compiling... no
checking for suffix of executables...
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether cc accepts -g... yes
checking for cc option to accept ISO C89... none needed
checking how to run the C preprocessor... cc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... no
checking whether to enable maintainer-specific portions of Makefiles... no
checking for x86_64-unknown-linux-gnu-gcc... (cached) cc
checking whether we are using the GNU C compiler... (cached) yes
checking whether cc accepts -g... (cached) yes
checking for cc option to accept ISO C89... (cached) none needed
checking for x86_64-unknown-linux-gnu-ranlib... ranlib
checking for gawk... (cached) gawk
checking how to print strings... printf
checking for a sed that does not truncate output... /bin/sed
checking for fgrep... /bin/grep -F
checking for ld used by cc... /usr/bin/x86_64-linux-gnu-ld
checking if the linker (/usr/bin/x86_64-linux-gnu-ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... yes
checking for /usr/bin/x86_64-linux-gnu-ld option to reload object files... -r
checking for x86_64-unknown-linux-gnu-objdump... no
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for x86_64-unknown-linux-gnu-ar... ar
checking for x86_64-unknown-linux-gnu-strip... no
checking for strip... strip
checking for x86_64-unknown-linux-gnu-ranlib... (cached) ranlib
checking command to parse /usr/bin/nm -B output from cc object... ok
checking for dlfcn.h... yes
checking for objdir... .libs
checking if cc supports -fno-rtti -fno-exceptions... no
checking for cc option to produce PIC... -fPIC -DPIC
checking if cc PIC flag -fPIC -DPIC works... yes
checking if cc static flag -static works... yes
checking if cc supports -c -o file.o... yes
checking if cc supports -c -o file.o... (cached) yes
checking whether the cc linker (/usr/bin/x86_64-linux-gnu-ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking unwind.h usability... yes
checking unwind.h presence... yes
checking for unwind.h... yes
checking for _Unwind_Backtrace... yes
checking for -funwind-tables option... yes
checking for -frandom-seed=string option... yes
checking whether cc supports -W... yes
checking whether cc supports -Wall... yes
checking whether cc supports -Wwrite-strings... yes
checking whether cc supports -Wstrict-prototypes... yes
checking whether cc supports -Wmissing-prototypes... yes
checking whether cc supports -Wold-style-definition... yes
checking whether cc supports -Wmissing-format-attribute... yes
checking whether cc supports -Wcast-qual... yes
checking for _Unwind_GetIPInfo... yes
checking __sync extensions... yes
checking __atomic extensions... yes
checking output filetype... elf64
looking for a compliant stdint.h in stdint.h, checking for uintmax_t... yes
checking for uintptr_t... yes
checking for int_least32_t... yes
checking for int_fast32_t... yes
checking for uint64_t... yes
checking what to include in gstdint.h... stdint.h (already complete)
checking sys/mman.h usability... yes
checking sys/mman.h presence... yes
checking for sys/mman.h... yes
checking for mmap... yes
checking link.h usability... yes
checking link.h presence... yes
checking for link.h... yes
checking for dl_iterate_phdr... yes
checking for fcntl... yes
checking whether strnlen is declared... yes
checking for getexecname... no
checking whether tests can run... yes
configure: creating ./config.status
config.status: creating Makefile
config.status: creating backtrace-supported.h
config.status: creating config.h
config.status: executing libtool commands
config.status: executing gstdint.h commands
config.status: executing default commands
running: "make" "INCDIR=/home/paik/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.16/src/libbacktrace"

--- stderr
thread 'main' panicked at '

failed to execute command: No such file or directory (os error 2)
Is `make` not installed?

', /home/paik/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.16/build.rs:168:13
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```