### PR TITLE
Remove UNSIGNED_SENDER in SignedParcel

### DIFF
--- a/core/src/codechain_machine.rs
+++ b/core/src/codechain_machine.rs
@@ -61,7 +61,7 @@ impl CodeChainMachine {
                 got: p.fee,
             }).into())
         }
-        p.verify_basic(self.params(), false).map_err(StateError::from)?;
+        p.verify_basic(self.params()).map_err(StateError::from)?;
 
         Ok(())
     }

--- a/key/src/ecdsa.rs
+++ b/key/src/ecdsa.rs
@@ -36,7 +36,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
-use primitives::{H256, H520, U256};
+use primitives::{H256, H520};
 use rustc_hex::{FromHex, ToHex};
 use secp256k1::{key, Error as SecpError, Message as SecpMessage, RecoverableSignature, RecoveryId};
 
@@ -87,12 +87,6 @@ impl ECDSASignature {
             && H256::from_slice(self.r()) >= 1.into()
             && H256::from_slice(self.s()) < "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141".into()
             && H256::from_slice(self.s()) >= 1.into()
-    }
-
-    pub fn is_unsigned(&self) -> bool {
-        let r: U256 = self.r().into();
-        let s: U256 = self.s().into();
-        r.is_zero() && s.is_zero()
     }
 }
 

--- a/key/src/schnorr.rs
+++ b/key/src/schnorr.rs
@@ -37,11 +37,6 @@ impl SchnorrSignature {
     pub fn is_low_s(&self) -> bool {
         true
     }
-
-    pub fn is_unsigned(&self) -> bool {
-        let signature_data: H512 = self.0.into();
-        signature_data.is_zero()
-    }
 }
 
 // manual implementation large arrays don't have trait impls by default.


### PR DESCRIPTION
The UNSIGNED_SENDER is introduced in EIP 86.
The purpose of UNSIGNED_SENDER is paying a transaction fee
from a contract. In codechain, we do not support smart contract.
So remove UNSIGNED_SENDER.