### PR TITLE
Change the way to create the address of top level item

### DIFF
--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -17,9 +17,8 @@
 macro_rules! define_address_constructor {
     (TOP, $name:ident, $prefix:expr) => {
         fn from_transaction_hash(transaction_hash: ::primitives::H256, index: u64) -> Self {
-            let h248: ::primitives::H248 =
+            let mut hash: ::primitives::H256 =
                 ::ccrypto::Blake::blake_with_key(&transaction_hash, &::primitives::H128::from(index));
-            let mut hash: H256 = h248.into();
             hash[0..1].clone_from_slice(&[$prefix]);
             $name(hash)
         }


### PR DESCRIPTION
Currently, CodeChain calculates 31 bytes blake2b hash and adds a prefix to get the address of the top level item.

This patch changes the way how CodeChain calculates the address in the same way as CodeChain calculates the address of shard level items. More specifically, this patch makes CodeChain use the 32 bytes hash whose first byte is replaced by the prefix as the address.
