### PR TITLE
Make Chain decide whether to use shard validation

### DIFF
--- a/codechain/rpc_apis.rs
+++ b/codechain/rpc_apis.rs
@@ -25,7 +25,7 @@ pub struct ApiDependencies {
     pub miner: Arc<Miner>,
     pub network_control: Arc<NetworkControl>,
     pub account_provider: Arc<AccountProvider>,
-    pub shard_validator: Arc<ShardValidator>,
+    pub shard_validator: Option<Arc<ShardValidator>>,
 }
 
 impl ApiDependencies {
@@ -38,7 +38,9 @@ impl ApiDependencies {
         handler.extend_with(
             AccountClient::new(&self.account_provider, self.client.engine().params().network_id).to_delegate(),
         );
-        handler.extend_with(ShardValidatorClient::new(Arc::clone(&self.shard_validator)).to_delegate());
+        self.shard_validator.as_ref().map(|shard_validator| {
+            handler.extend_with(ShardValidatorClient::new(Arc::clone(&shard_validator)).to_delegate());
+        });
     }
 }
 

--- a/core/res/blake_pow.json
+++ b/core/res/blake_pow.json
@@ -14,7 +14,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": true
   },
   "genesis": {
     "seal": {

--- a/core/res/cuckoo.json
+++ b/core/res/cuckoo.json
@@ -17,7 +17,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": true
   },
   "genesis": {
     "seal": {

--- a/core/res/null.json
+++ b/core/res/null.json
@@ -11,7 +11,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": false
   },
   "genesis": {
     "seal": {

--- a/core/res/solo.json
+++ b/core/res/solo.json
@@ -12,7 +12,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": false
   },
   "genesis": {
     "seal": {

--- a/core/res/solo_authority.json
+++ b/core/res/solo_authority.json
@@ -16,7 +16,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": false
   },
   "genesis": {
     "seal": {

--- a/core/res/tendermint.json
+++ b/core/res/tendermint.json
@@ -22,7 +22,8 @@
     "networkID": "0x11",
     "minParcelCost": "10",
     "maxBodySize": 4194304,
-    "snapshotPeriod": 16384
+    "snapshotPeriod": 16384,
+    "useShardValidator": false
   },
   "genesis": {
     "seal": {

--- a/core/src/spec/spec.rs
+++ b/core/src/spec/spec.rs
@@ -54,6 +54,8 @@ pub struct CommonParams {
     pub max_body_size: usize,
     /// Snapshot creation period in unit of block numbers.
     pub snapshot_period: u64,
+    /// Flag whether to use shard validator.
+    pub use_shard_validator: bool,
 }
 
 impl From<cjson::spec::Params> for CommonParams {
@@ -65,6 +67,7 @@ impl From<cjson::spec::Params> for CommonParams {
             min_parcel_cost: p.min_parcel_cost.into(),
             max_body_size: p.max_body_size.into(),
             snapshot_period: p.snapshot_period.into(),
+            use_shard_validator: p.use_shard_validator.into(),
         }
     }
 }

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -33,6 +33,7 @@ pub struct Params {
     pub max_body_size: Uint,
     /// Snapshot creation period in unit of block numbers.
     pub snapshot_period: Uint,
+    pub use_shard_validator: bool,
 }
 
 #[cfg(test)]
@@ -51,7 +52,8 @@ mod tests {
             "networkID" : "0x1",
             "minParcelCost" : "10",
             "maxBodySize" : 4194304,
-            "snapshotPeriod": 16384
+            "snapshotPeriod": 16384,
+            "useShardValidator": true
         }"#;
 
         let deserialized: Params = serde_json::from_str(s).unwrap();
@@ -61,5 +63,6 @@ mod tests {
         assert_eq!(deserialized.min_parcel_cost, Uint(U256::from(10)));
         assert_eq!(deserialized.max_body_size, Uint(4194304.into()));
         assert_eq!(deserialized.snapshot_period, Uint(16384.into()));
+        assert_eq!(deserialized.use_shard_validator, true);
     }
 }

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -79,7 +79,8 @@ mod tests {
                 "networkID" : "0x2",
                 "minParcelCost" : "10",
                 "maxBodySize": 4194304,
-                "snapshotPeriod": 16384
+                "snapshotPeriod": 16384,
+                "useShardValidator": true
             },
             "genesis": {
                 "seal": {


### PR DESCRIPTION
This patch adds a useShardValidator field to CommonParams. This field determines whether to use shard validation or not. If this field is false, the chain disables RPC and network extension about shard validation.