### PR TITLE
Use weak reference in RPC structs

### DIFF
--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use ccore::{
     AssetClient, BlockId, EngineInfo, ExecuteClient, MinerService, MiningBlockChainClient, RegularKey, Shard,
@@ -39,8 +39,8 @@ pub struct ChainClient<C, M>
 where
     C: AssetClient + MiningBlockChainClient + Shard + RegularKey + ExecuteClient + EngineInfo,
     M: MinerService, {
-    client: Arc<C>,
-    miner: Arc<M>,
+    client: Weak<C>,
+    miner: Weak<M>,
 }
 
 impl<C, M> ChainClient<C, M>
@@ -50,9 +50,17 @@ where
 {
     pub fn new(client: &Arc<C>, miner: &Arc<M>) -> Self {
         ChainClient {
-            client: client.clone(),
-            miner: miner.clone(),
+            client: Arc::downgrade(client),
+            miner: Arc::downgrade(miner),
         }
+    }
+
+    fn client(&self) -> Result<Arc<C>> {
+        self.client.upgrade().ok_or_else(|| errors::internal("Cannot get client", ""))
+    }
+
+    fn miner(&self) -> Result<Arc<M>> {
+        self.miner.upgrade().ok_or_else(|| errors::internal("Cannot get miner", ""))
     }
 }
 
@@ -68,7 +76,7 @@ where
             .and_then(|parcel: UnverifiedParcel| {
                 match &parcel.as_unsigned().action {
                     Action::Custom(bytes) => {
-                        if !self.client.custom_handlers().iter().any(|c| c.is_target(bytes)) {
+                        if !self.client()?.custom_handlers().iter().any(|c| c.is_target(bytes)) {
                             return Err(errors::rlp(DecoderError::Custom("Invalid custom action!")))
                         }
                     }
@@ -79,28 +87,28 @@ where
             .and_then(|parcel| SignedParcel::new(parcel).map_err(errors::parcel_core))
             .and_then(|signed| {
                 let hash = signed.hash();
-                self.miner.import_own_parcel(&*self.client, signed).map_err(errors::parcel_core).map(|_| hash)
+                self.miner()?.import_own_parcel(&*self.client()?, signed).map_err(errors::parcel_core).map(|_| hash)
             })
             .map(Into::into)
     }
 
     fn get_parcel(&self, parcel_hash: H256) -> Result<Option<Parcel>> {
-        match self.client.parcel(parcel_hash.into()) {
+        match self.client()?.parcel(parcel_hash.into()) {
             Some(parcel) => Ok(Some(parcel.into())),
             None => Ok(None),
         }
     }
 
     fn get_parcel_invoice(&self, parcel_hash: H256) -> Result<Option<ParcelInvoice>> {
-        Ok(self.client.parcel_invoice(parcel_hash.into()))
+        Ok(self.client()?.parcel_invoice(parcel_hash.into()))
     }
 
     fn get_transaction(&self, transaction_hash: H256) -> Result<Option<Transaction>> {
-        Ok(self.client.transaction(transaction_hash.into()))
+        Ok(self.client()?.transaction(transaction_hash.into()))
     }
 
     fn get_transaction_invoice(&self, transaction_hash: H256) -> Result<Option<Invoice>> {
-        Ok(self.client.transaction_invoice(transaction_hash.into()))
+        Ok(self.client()?.transaction_invoice(transaction_hash.into()))
     }
 
     fn get_asset_scheme_by_hash(&self, transaction_hash: H256, shard_id: ShardId) -> Result<Option<AssetScheme>> {
@@ -110,14 +118,14 @@ where
 
     fn get_asset_scheme_by_type(&self, asset_type: H256) -> Result<Option<AssetScheme>> {
         match AssetSchemeAddress::from_hash(asset_type) {
-            Some(address) => self.client.get_asset_scheme(address).map_err(errors::parcel_state),
+            Some(address) => self.client()?.get_asset_scheme(address).map_err(errors::parcel_state),
             None => Ok(None),
         }
     }
 
     fn get_asset(&self, transaction_hash: H256, index: usize, block_number: Option<u64>) -> Result<Option<Asset>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        self.client.get_asset(transaction_hash, index, block_id).map_err(errors::parcel_state)
+        self.client()?.get_asset(transaction_hash, index, block_id).map_err(errors::parcel_state)
     }
 
     fn is_asset_spent(
@@ -128,78 +136,78 @@ where
         block_number: Option<u64>,
     ) -> Result<Option<bool>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        self.client.is_asset_spent(transaction_hash, index, shard_id, block_id).map_err(errors::parcel_state)
+        self.client()?.is_asset_spent(transaction_hash, index, shard_id, block_id).map_err(errors::parcel_state)
     }
 
     fn get_nonce(&self, address: H160, block_number: Option<u64>) -> Result<Option<U256>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        Ok(self.client.nonce(&address.into(), block_id))
+        Ok(self.client()?.nonce(&address.into(), block_id))
     }
 
     fn get_balance(&self, address: H160, block_number: Option<u64>) -> Result<Option<U256>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        Ok(self.client.balance(&address.into(), block_id.into()))
+        Ok(self.client()?.balance(&address.into(), block_id.into()))
     }
 
     fn get_regular_key(&self, address: H160, block_number: Option<u64>) -> Result<Option<Public>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        Ok(self.client.regular_key(&address.into(), block_id.into()))
+        Ok(self.client()?.regular_key(&address.into(), block_id.into()))
     }
 
 
     fn get_number_of_shards(&self, block_number: Option<u64>) -> Result<Option<ShardId>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        Ok(self.client.number_of_shards(block_id.into()))
+        Ok(self.client()?.number_of_shards(block_id.into()))
     }
 
     fn get_shard_root(&self, shard_id: ShardId, block_number: Option<u64>) -> Result<Option<H256>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        Ok(self.client.shard_root(shard_id, block_id.into()))
+        Ok(self.client()?.shard_root(shard_id, block_id.into()))
     }
 
     fn get_best_block_number(&self) -> Result<BlockNumber> {
-        Ok(self.client.chain_info().best_block_number)
+        Ok(self.client()?.chain_info().best_block_number)
     }
 
     fn get_best_block_id(&self) -> Result<BlockNumberAndHash> {
         Ok(BlockNumberAndHash {
-            number: self.client.chain_info().best_block_number,
-            hash: self.client.chain_info().best_block_hash,
+            number: self.client()?.chain_info().best_block_number,
+            hash: self.client()?.chain_info().best_block_hash,
         })
     }
 
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>> {
-        Ok(self.client.block_hash(BlockId::Number(block_number)))
+        Ok(self.client()?.block_hash(BlockId::Number(block_number)))
     }
 
     fn get_block_by_number(&self, block_number: u64) -> Result<Option<Block>> {
-        Ok(self.client.block(BlockId::Number(block_number)).map(|block| block.decode().into()))
+        Ok(self.client()?.block(BlockId::Number(block_number)).map(|block| block.decode().into()))
     }
 
     fn get_block_by_hash(&self, block_hash: H256) -> Result<Option<Block>> {
-        Ok(self.client.block(BlockId::Hash(block_hash)).map(|block| block.decode().into()))
+        Ok(self.client()?.block(BlockId::Hash(block_hash)).map(|block| block.decode().into()))
     }
 
     fn get_pending_parcels(&self) -> Result<Vec<Parcel>> {
-        Ok(self.client.ready_parcels().into_iter().map(|signed| signed.into()).collect())
+        Ok(self.client()?.ready_parcels().into_iter().map(|signed| signed.into()).collect())
     }
 
     fn get_coinbase(&self) -> Result<Option<Address>> {
-        if self.miner.author().is_zero() {
+        if self.miner()?.author().is_zero() {
             Ok(None)
         } else {
-            Ok(Some(self.miner.author()))
+            Ok(Some(self.miner()?.author()))
         }
     }
 
     fn get_network_id(&self) -> Result<u64> {
-        Ok(self.client.common_params().network_id)
+        Ok(self.client()?.common_params().network_id)
     }
 
     fn execute_change_shard_state(&self, raw: Bytes) -> Result<Vec<ChangeShard>> {
         let transactions: Vec<Transaction> =
             UntrustedRlp::new(&raw.into_vec()).as_list().map_err(errors::rlp).map(Into::into)?;
 
-        Ok(self.client.execute_transactions(&transactions).map_err(errors::core)?)
+        Ok(self.client()?.execute_transactions(&transactions).map_err(errors::core)?)
     }
 }

--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use cnetwork::{NetworkControl, SocketAddr};
 use jsonrpc_core::Result;
@@ -24,34 +24,40 @@ use super::super::errors;
 use super::super::traits::Net;
 
 pub struct NetClient {
-    network_control: Arc<NetworkControl>,
+    network_control: Weak<NetworkControl>,
 }
 
 impl NetClient {
     pub fn new(network_control: &Arc<NetworkControl>) -> Self {
         Self {
-            network_control: network_control.clone(),
+            network_control: Arc::downgrade(network_control),
         }
+    }
+
+    fn network_control(&self) -> Result<Arc<NetworkControl>> {
+        self.network_control.upgrade().ok_or_else(|| errors::internal("Cannot get network_control", ""))
     }
 }
 
 impl Net for NetClient {
     fn share_secret(&self, secret: H256, address: ::std::net::IpAddr, port: u16) -> Result<()> {
-        self.network_control.register_secret(secret, SocketAddr::new(address, port)).map_err(errors::network_control)?;
+        self.network_control()?
+            .register_secret(secret, SocketAddr::new(address, port))
+            .map_err(errors::network_control)?;
         Ok(())
     }
 
     fn connect(&self, address: ::std::net::IpAddr, port: u16) -> Result<()> {
-        self.network_control.connect(SocketAddr::new(address, port)).map_err(errors::network_control)?;
+        self.network_control()?.connect(SocketAddr::new(address, port)).map_err(errors::network_control)?;
         Ok(())
     }
 
     fn disconnect(&self, address: ::std::net::IpAddr, port: u16) -> Result<()> {
-        self.network_control.disconnect(SocketAddr::new(address, port)).map_err(errors::network_control)?;
+        self.network_control()?.disconnect(SocketAddr::new(address, port)).map_err(errors::network_control)?;
         Ok(())
     }
 
     fn is_connected(&self, address: ::std::net::IpAddr, port: u16) -> Result<bool> {
-        Ok(self.network_control.is_connected(&SocketAddr::new(address, port)).map_err(errors::network_control)?)
+        Ok(self.network_control()?.is_connected(&SocketAddr::new(address, port)).map_err(errors::network_control)?)
     }
 }


### PR DESCRIPTION
Codechain crashes on SIGINT if stratum is off.
The cause of the crash may be the ownership.
So use weak reference in RPC structs.

After this patch, we cannot see the segfault on SIGINT.

This fixes https://github.com/CodeChain-io/codechain/issues/348