### PR TITLE
Remove (not implemented) note for net_getPort from the spec

### DIFF
--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1114,7 +1114,7 @@ Response Example
 
 
 ## net_getPort
-(not implemented) Return the port number on which the client is listening for peers.
+Return the port number on which the client is listening for peers.
 
 Params: No parameters
 


### PR DESCRIPTION
It was implemented in https://github.com/CodeChain-io/codechain/pull/536 