### PR TITLE
Wait before shutdown to avoid the crash

### DIFF
--- a/codechain/main.rs
+++ b/codechain/main.rs
@@ -30,6 +30,7 @@ extern crate serde_json;
 extern crate app_dirs;
 extern crate codechain_core as ccore;
 extern crate codechain_discovery as cdiscovery;
+extern crate codechain_finally as cfinally;
 extern crate codechain_key as ckey;
 extern crate codechain_keystore as ckeystore;
 #[macro_use]


### PR DESCRIPTION
This patch is the hotfix for #348.
I can't find the exact reason for the SIGINT yet, but this patch fixes
the crash.