### PR TITLE
Implement the errors of chain_sendSignedParcel method

### DIFF
--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -128,6 +128,7 @@ A base32 string that starts with "ccc" or "tcc". See [the specification](https:/
 | -32042 | `Already Exists` | The account already exists |
 | -32043 | `Wrong Password` | The password does not match |
 | -32044 | `No Such Account` | There is no such account in the key store |
+| -32099 | `Unknown Error` | An unknown error occurred |
 | -32602 | `Invalid Params` | At least one of the parameters is invalid |
 
 # List of methods


### PR DESCRIPTION
This patch also reassigns the error code for UNKNOWN_ERROR.