### PR TITLE
Pass whitelist/blacklist via file path

### DIFF
--- a/codechain/codechain.yml
+++ b/codechain/codechain.yml
@@ -222,18 +222,16 @@ args:
         takes_value: true
         conflicts_with:
             - no-shard-validator
-    - whitelist:
-        long: whitelist
-        value_name: WHITELIST
-        help: Whitelisted IP addresses.
+    - whitelist-path:
+        long: whitelist-path
+        value_name: PATH
+        help: Specify the path for the network blacklist file.
         takes_value: true
-        multiple: true
-    - blacklist:
-        long: blacklist
-        value_name: BLACKLIST
-        help: Blacklisted IP addresses.
+    - blacklist-path:
+        long: blacklist-path
+        value_name: PATH
+        help: Specify the path for the network blacklist file.
         takes_value: true
-        multiple: true
 subcommands:
     - account:
         about: account managing commands

--- a/codechain/config/presets/config.dev.toml
+++ b/codechain/config/presets/config.dev.toml
@@ -28,8 +28,8 @@ discovery = true
 discovery_type = "unstructured"
 discovery_refresh = 60000
 discovery_bucket_size = 10
-blacklist = []
-whitelist = []
+# whitelist_path = "whitelist.txt"
+# blacklist_path = "blacklist.txt"
 
 [rpc]
 disable = false

--- a/codechain/config/presets/config.prod.toml
+++ b/codechain/config/presets/config.prod.toml
@@ -27,8 +27,8 @@ discovery = true
 discovery_type = "unstructured"
 discovery_refresh = 60000
 discovery_bucket_size = 10
-blacklist = []
-whitelist = []
+# whitelist_path = "whitelist.txt"
+# blacklist_path = "blacklist.txt"
 
 [rpc]
 disable = false

--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -220,7 +220,7 @@ pub fn run_node(matches: ArgMatches) -> Result<(), String> {
 
     let network_service: Arc<NetworkControl> = {
         if !config.network.disable {
-            let network_config = config.network_config();
+            let network_config = config.network_config()?;
             let service = network_start(&network_config)?;
 
             if config.network.discovery {


### PR DESCRIPTION
Deleted whitelist/blacklist option, and added whitelist-path/blacklist-path option passing the file path.
The file should contain IP addresses seperated with whitespaces.