### PR TITLE
Make InvalidNetworkId hold the Network ID

### DIFF
--- a/core/src/parcel.rs
+++ b/core/src/parcel.rs
@@ -129,7 +129,7 @@ impl UnverifiedParcel {
     /// Verify basic signature params. Does not attempt sender recovery.
     pub fn verify_basic(&self, params: &CommonParams) -> Result<(), ParcelError> {
         if self.network_id != params.network_id {
-            return Err(ParcelError::InvalidNetworkId)
+            return Err(ParcelError::InvalidNetworkId(self.network_id))
         }
         let byte_size = rlp::encode(self).to_vec().len();
         if byte_size >= params.max_body_size {
@@ -145,7 +145,7 @@ impl UnverifiedParcel {
                 for t in transactions {
                     t.verify()?;
                     if t.network_id() != self.network_id {
-                        return Err(ParcelError::InvalidNetworkId)
+                        return Err(ParcelError::InvalidNetworkId(t.network_id()))
                     }
                     for shard_id in t.related_shards() {
                         if !shard_ids.contains(&shard_id) {

--- a/key/src/error.rs
+++ b/key/src/error.rs
@@ -19,13 +19,15 @@ use std::fmt;
 use bech32::Error as Bech32Error;
 use secp256k1::Error as SecpError;
 
+use super::NetworkId;
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     InvalidPublic,
     InvalidSecret,
     InvalidMessage,
     InvalidSignature,
-    InvalidNetwork,
+    InvalidNetworkId(NetworkId),
     InvalidChecksum,
     InvalidPrivate,
     InvalidAddress,
@@ -47,7 +49,7 @@ impl fmt::Display for Error {
             Error::InvalidSecret => "Invalid Secret".into(),
             Error::InvalidMessage => "Invalid Message".into(),
             Error::InvalidSignature => "Invalid Signature".into(),
-            Error::InvalidNetwork => "Invalid Network".into(),
+            Error::InvalidNetworkId(network_id) => format!("{} is an invalid network id", network_id),
             Error::InvalidChecksum => "Invalid Checksum".into(),
             Error::InvalidPrivate => "Invalid Private".into(),
             Error::InvalidAddress => "Invalid Address".into(),

--- a/key/src/platform_address.rs
+++ b/key/src/platform_address.rs
@@ -71,14 +71,14 @@ impl PlatformAddress {
 
     pub fn try_address(&self) -> Result<&Address, Error> {
         if !check_network_id(&self.network_id) {
-            return Err(Error::InvalidNetwork)
+            return Err(Error::InvalidNetworkId(self.network_id))
         }
         Ok(&self.address)
     }
 
     pub fn try_into_address(self) -> Result<Address, Error> {
         if !check_network_id(&self.network_id) {
-            return Err(Error::InvalidNetwork)
+            return Err(Error::InvalidNetworkId(self.network_id))
         }
         Ok(self.address)
     }
@@ -143,7 +143,7 @@ impl FromStr for PlatformAddress {
             .parse::<NetworkId>()
             .map_err(|_| Error::Bech32UnknownHRP)?;
         if !check_network_id(&network_id) {
-            return Err(Error::InvalidNetwork)
+            return Err(Error::InvalidNetworkId(network_id))
         }
         if Some("c") != decoded.hrp.get(2..3) {
             return Err(Error::Bech32UnknownHRP)

--- a/rpc/src/v1/errors.rs
+++ b/rpc/src/v1/errors.rs
@@ -93,7 +93,7 @@ pub fn parcel_core<T: Into<CoreError>>(error: T) -> Error {
                 message: "Verification Failed".into(),
                 data: Some(Value::String(format!("{:?}", error))),
             },
-            KeyError::InvalidNetwork => Error {
+            KeyError::InvalidNetworkId(_) => Error {
                 code: ErrorCode::ServerError(codes::INVALID_NETWORK_ID),
                 message: "Invalid NetworkId".into(),
                 data: Some(Value::String(format!("{:?}", error))),
@@ -106,7 +106,7 @@ pub fn parcel_core<T: Into<CoreError>>(error: T) -> Error {
                 message: "Verification Failed".into(),
                 data: Some(Value::String(format!("{:?}", error))),
             },
-            ParcelError::InvalidNetworkId => Error {
+            ParcelError::InvalidNetworkId(_) => Error {
                 code: ErrorCode::ServerError(codes::INVALID_NETWORK_ID),
                 message: "Invalid NetworkId".into(),
                 data: Some(Value::String(format!("{:?}", error))),


### PR DESCRIPTION
Currently, CodeChain says the Network ID is invalid but doesn't show which ID is used. This patch makes the error show which ID is used.