### PR TITLE
Add RPCs to start/stop sealing by the miner

### DIFF
--- a/codechain/rpc_apis.rs
+++ b/codechain/rpc_apis.rs
@@ -33,7 +33,7 @@ impl ApiDependencies {
         use crpc::v1::*;
         handler.extend_with(ChainClient::new(&self.client, &self.miner).to_delegate());
         if enable_devel_api {
-            handler.extend_with(DevelClient::new(&self.client).to_delegate());
+            handler.extend_with(DevelClient::new(&self.client, &self.miner).to_delegate());
         }
         handler.extend_with(MinerClient::new(&self.client, &self.miner).to_delegate());
         handler.extend_with(NetClient::new(&self.network_control).to_delegate());

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -59,12 +59,8 @@ where
         EngineType::Solo
     }
 
-    fn generate_seal(&self, block: &M::LiveBlock, _parent: &M::Header) -> Seal {
-        if block.parcels().is_empty() {
-            Seal::None
-        } else {
-            Seal::Regular(Vec::new())
-        }
+    fn generate_seal(&self, _block: &M::LiveBlock, _parent: &M::Header) -> Seal {
+        Seal::Regular(Vec::new())
     }
 
     fn verify_local_seal(&self, _header: &M::Header) -> Result<(), M::Error> {

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -112,6 +112,12 @@ pub trait MinerService: Send + Sync {
 
     /// Get a list of all future parcels.
     fn future_parcels(&self) -> Vec<SignedParcel>;
+
+    /// Start sealing.
+    fn start_sealing<C: MiningBlockChainClient>(&self, client: &C);
+
+    /// Stop sealing.
+    fn stop_sealing(&self);
 }
 
 /// Mining status

--- a/rpc/src/v1/traits/devel.rs
+++ b/rpc/src/v1/traits/devel.rs
@@ -27,5 +27,11 @@ build_rpc_trait! {
 
         # [rpc(name = "devel_getStateTrieValue")]
         fn get_state_trie_value(&self, H256) -> Result<Vec<Bytes>>;
+
+        # [rpc(name = "devel_startSealing")]
+        fn start_sealing(&self) -> Result<()>;
+
+        # [rpc(name = "devel_stopSealing")]
+        fn stop_sealing(&self) -> Result<()>;
     }
 }

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -195,6 +195,8 @@ A base32 string that starts with "ccc" or "tcc". See [the specification](https:/
 ***
  * [devel_getStateTrieKeys](#devel_getstatetriekeys)
  * [devel_getStateTrieValue](#devel_getstatetrievalue)
+ * [devel_startSealing](#devel_startsealing)
+ * [devel_stopSealing](#devel_stopsealing)
 
 
 # Specification
@@ -1755,6 +1757,54 @@ Response Example
     "0x20d560025f3a1c6675cb32384355ae05b224a3473ae17d3d15b6aa164af7d717",
     "0xf84541a053000000000000002ab33f741ba153ff1ffdf1107845828637c864d5360e4932a00000000000000000000000000000000000000000000000000000000000000000c06f"
   ],
+  "id":null
+}
+```
+
+## devel_startSealing
+Starts and enables sealing blocks by the miner.
+
+Params: No parameters
+
+Return Type: `null`
+
+Request Example
+```
+  curl \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc": "2.0", "method": "devel_startSealing", "params": [], "id": null}' \
+    localhost:8080
+```
+
+Response Example
+```
+{
+  "jsonrpc":"2.0",
+  "result":null,
+  "id":null
+}
+```
+
+## devel_stopSealing
+Stops and disables sealing blocks by the miner.
+
+Params: No parameters
+
+Return Type: `null`
+
+Request Example
+```
+  curl \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc": "2.0", "method": "devel_stopSealing", "params": [], "id": null}' \
+    localhost:8080
+```
+
+Response Example
+```
+{
+  "jsonrpc":"2.0",
+  "result":null,
   "id":null
 }
 ```


### PR DESCRIPTION
These RPCs are going to be added ~~for debugging purpose~~. #640 

- `devel_startSealing`
Starts and enables sealing blocks by the miner.
Also, the command will start sealing immediately even if there's no parcel in the memory pool.
It should be ensured that the option `force_sealing` is `true` in the miner config, to seal a block with no parcels.
- `devel_stopSealing`
Stops and disables sealing blocks by the miner.