### PR TITLE
Add sync test with multiple nodes

### DIFF
--- a/test/src/integration/sync.test.ts
+++ b/test/src/integration/sync.test.ts
@@ -216,6 +216,34 @@ describe("sync", () => {
       });
     });
 
+    if (numNodes > 3) {
+      describe("Connected in a star", () => {
+        describe("All connected", () => {
+          beforeEach(async () => {
+            for (let i = 1; i < numNodes; i++) {
+              nodes[0].connect(nodes[i]);
+            }
+          }, 5000 + 1500 * numNodes);
+    
+          test("It should be synced when the center node created a block", async () => {
+            const parcel = await nodes[0].sendSignedParcel();
+            for (let i = 1; i < numNodes; i++) {
+              await nodes[0].waitBlockNumberSync(nodes[i]);
+              expect(await nodes[i].getBestBlockHash()).toEqual(parcel.blockHash);
+            }
+          }, 5000 + 1500 * numNodes);
+
+          test("It should be synced when one of the outside node created a block", async () => {
+            const parcel = await nodes[numNodes - 1].sendSignedParcel();
+            for (let i = 0; i < numNodes - 1; i++) {
+              await nodes[numNodes - 1].waitBlockNumberSync(nodes[i]);
+              expect(await nodes[i].getBestBlockHash()).toEqual(parcel.blockHash);
+            }
+          }, 5000 + 1500 * numNodes);
+        });
+      });
+    }
+
     afterEach(async () => {
       await Promise.all(nodes.map(n => n.clean()));
       nodes = [];


### PR DESCRIPTION
Currently, it fails often.

The condition is:
Connect 4 solo-mod nodes in a row without discovering, and let's number them 0 to 3 from left to right.
The node 0 receives one parcel, and the node 3 receives one parcel. Those two parcels are different.

Then, the node 0 and the node 3 creates blocks. Call them block A and B each.
The block A will be propagated from the node 0 to the node 3, and block B from the node 3 to the node 0.
And, in somewhere in the middle, the problem occurs. Let's assume it's the node 1.
Currently the node 1 has no node, and it receives the block A from the left and also receives the block B from the right. Then it stops.

```
[ Node 0 ] - [ Node 1 ] - [ Node 2 ] - [ Node 3 ]
     A     ->    ?      <-     B     <-     B
```