### PR TITLE
Send body request in random order with the length limit

### DIFF
--- a/sync/src/block/downloader/body.rs
+++ b/sync/src/block/downloader/body.rs
@@ -37,10 +37,14 @@ impl BodyDownloader {
     }
 
     pub fn create_request(&mut self) -> Option<RequestMessage> {
+        const MAX_BODY_REQEUST_LENGTH: usize = 128;
         let mut hashes = Vec::new();
         for (hash, ..) in &self.targets {
             if !self.downloading.contains(hash) && !self.downloaded.contains_key(hash) {
                 hashes.push(*hash);
+            }
+            if hashes.len() >= MAX_BODY_REQEUST_LENGTH {
+                break
             }
         }
         if hashes.len() != 0 {

--- a/sync/src/block/downloader/body.rs
+++ b/sync/src/block/downloader/body.rs
@@ -54,6 +54,7 @@ impl BodyDownloader {
     pub fn import_bodies(&mut self, hashes: Vec<H256>, bodies: Vec<Vec<UnverifiedParcel>>) {
         for (hash, body) in hashes.into_iter().zip(bodies) {
             if self.downloading.contains(&hash) {
+                self.downloading.remove(&hash);
                 if body.len() == 0 {
                     let (_, prev_root, parcels_root) =
                         self.targets.iter().find(|(h, ..)| *h == hash).expect("Downloading target must exist");
@@ -61,7 +62,6 @@ impl BodyDownloader {
                         continue
                     }
                 }
-                self.downloading.remove(&hash);
                 self.downloaded.insert(hash, body);
             }
         }

--- a/sync/src/block/downloader/body.rs
+++ b/sync/src/block/downloader/body.rs
@@ -83,6 +83,12 @@ impl BodyDownloader {
         }
     }
 
+    pub fn reset_downloading(&mut self, hashes: &[H256]) {
+        for hash in hashes {
+            self.downloading.remove(&hash);
+        }
+    }
+
     pub fn drain(&mut self) -> Vec<(H256, Vec<UnverifiedParcel>)> {
         let mut result = Vec::new();
         let mut new_targets = Vec::new();

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -28,6 +28,7 @@ use cnetwork::{Api, NetworkExtension, NodeId, TimerToken};
 use ctypes::parcel::Action;
 use ctypes::BlockNumber;
 use primitives::{H256, U256};
+use rand::{thread_rng, Rng};
 use rlp::{Encodable, UntrustedRlp};
 use time::Duration;
 
@@ -154,7 +155,9 @@ impl NetworkExtension for Extension {
         match token {
             SYNC_TIMER_TOKEN => {
                 let total_score = self.client.chain_info().total_score;
-                let peer_ids: Vec<_> = self.header_downloaders.read().keys().cloned().collect();
+                let mut peer_ids: Vec<_> = self.header_downloaders.read().keys().cloned().collect();
+                thread_rng().shuffle(&mut peer_ids);
+
                 for id in peer_ids {
                     if let Some(peer) = self.header_downloaders.write().get_mut(&id) {
                         if let Some(request) = peer.create_request() {
@@ -512,7 +515,9 @@ impl Extension {
         self.body_downloader.lock().remove_target(exists);
 
         let total_score = self.client.chain_info().total_score;
-        let peer_ids: Vec<_> = self.header_downloaders.read().keys().cloned().collect();
+        let mut peer_ids: Vec<_> = self.header_downloaders.read().keys().cloned().collect();
+        thread_rng().shuffle(&mut peer_ids);
+
         for id in peer_ids {
             let peer_score = if let Some(peer) = self.header_downloaders.read().get(&id) {
                 peer.total_score()


### PR DESCRIPTION
This is the fix of #658. Also, it will stabilize sync.
In synchronization, a client will send body requests to its peers in random order to prevent asking specific hashes to one fixed peer. Also, a client limits the length of each body request, therefore it will send hashes evenly to its peers. Finally, the downloading queue of the body downloader will be flushed every timeout.