### PR TITLE
Send a sync parcel message only when there are unsent parcels

### DIFF
--- a/sync/src/parcel/extension.rs
+++ b/sync/src/parcel/extension.rs
@@ -143,6 +143,9 @@ impl Extension {
                 .filter(|parcel| !peer.contains(&parcel.hash()))
                 .map(|signed| signed.clone().deconstruct().0)
                 .collect();
+            if unsent.is_empty() {
+                continue
+            }
             for unverified in unsent.iter() {
                 peer.push(&unverified.hash());
             }


### PR DESCRIPTION
@Kais-DkM 
Is there a reason that parcel-propagation extension should send a message when there are no parcels to sync?