### PR TITLE
Build a Docker image using multi-stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 /.git/
+/.idea/
 /target/
 /keys/
 /db/
+/docker/

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04 as builder
 WORKDIR /build
 
 # install tools and dependencies
@@ -38,8 +38,14 @@ RUN cd codechain && \
 
 RUN file /build/codechain/target/release/codechain
 
-WORKDIR /build/codechain
+
+FROM ubuntu:14.04
+WORKDIR /app/codechain
+COPY --from=builder /build/codechain/target/release/codechain ./target/release/codechain
+COPY --from=builder /build/codechain/codechain/config/presets/ ./codechain/config/presets
+
+# show backtraces
+ENV RUST_BACKTRACE 1
 
 EXPOSE 3485 8080
 ENTRYPOINT ["target/release/codechain"]
-


### PR DESCRIPTION
Issue: https://github.com/CodeChain-io/codechain/issues/541

It can reduce the size of the final image to 203MB from 1.81GB.