### PR TITLE
Remove the InvalidParams case from the account RPC tests

### DIFF
--- a/test/src/integration/account.test.ts
+++ b/test/src/integration/account.test.ts
@@ -151,15 +151,6 @@ describe("account", () => {
         await node.sdk.rpc.account.unlock(address, "123", 300);
       });
 
-      test("InvalidParams", async (done) => {
-        node.sdk.rpc.account.unlock(address, "123", -1)
-          .then(() => done.fail())
-          .catch(e => {
-            expect(e).toEqual(ERROR.INVALID_PARAMS);
-            done();
-          });
-      });
-
       test("WrongPassword", async (done) => {
         node.sdk.rpc.account.unlock(address, "456")
           .then(() => done.fail())


### PR DESCRIPTION
The InvalidParams error is a common error and the SDK no longer sends RPC call with invalid
parameters.