### PR TITLE
Rename parcel's "sender" to "signer"

### DIFF
--- a/core/src/account_provider.rs
+++ b/core/src/account_provider.rs
@@ -146,6 +146,12 @@ impl AccountProvider {
         Ok(has)
     }
 
+    pub fn has_public(&self, public: &Public) -> Result<bool, SignError> {
+        let address = public_to_address(public);
+        let has = self.keystore.read().has_account(&address)?;
+        Ok(has)
+    }
+
     pub fn get_list(&self) -> Result<Vec<Address>, SignError> {
         let addresses = self.keystore.read().accounts()?;
         Ok(addresses)

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -153,7 +153,7 @@ impl<'x> OpenBlock<'x> {
             return Err(StateError::Parcel(ParcelError::ParcelAlreadyImported).into())
         }
 
-        let invoice = self.block.state.apply(&parcel, parcel.sender(), &parcel.public_key())?;
+        let invoice = self.block.state.apply(&parcel, &parcel.signer_public())?;
 
         self.block.parcels_set.insert(h.unwrap_or_else(|| parcel.hash()));
         self.block.parcels.push(parcel.into());

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -185,7 +185,7 @@ pub trait ImportBlock {
 pub trait BlockChain: ChainInfo + BlockInfo + ParcelInfo + TransactionInfo {}
 
 /// Blockchain database client. Owns and manages a blockchain and a block queue.
-pub trait BlockChainClient: Sync + Send + AccountData + BlockChain + ImportBlock {
+pub trait BlockChainClient: Sync + Send + AccountData + BlockChain + ImportBlock + RegularKeyOwner {
     /// Get block queue information.
     fn queue_info(&self) -> BlockQueueInfo;
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -35,7 +35,7 @@ use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrder};
 use std::sync::Arc;
 
-use ckey::{Address, Generator, NetworkId, Random};
+use ckey::{public_to_address, Address, Generator, NetworkId, Random};
 use cmerkle::skewed_merkle_root;
 use cnetwork::NodeId;
 use cstate::{ActionHandler, StateDB};
@@ -274,7 +274,8 @@ impl TestBlockChainClient {
             },
         };
         let signed_parcel = SignedParcel::new_with_sign(parcel, keypair.private());
-        self.set_balance(*signed_parcel.sender(), 10_000_000_000_000_000_000u64.into());
+        let sender_address = public_to_address(&signed_parcel.signer_public());
+        self.set_balance(sender_address, 10_000_000_000_000_000_000u64.into());
         let hash = signed_parcel.hash();
         let res = self.miner.import_external_parcels(self, vec![signed_parcel.into()]);
         let res = res.into_iter().next().unwrap().expect("Successful import");

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -35,7 +35,7 @@ use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrder};
 use std::sync::Arc;
 
-use ckey::{public_to_address, Address, Generator, NetworkId, Random};
+use ckey::{public_to_address, Address, Generator, NetworkId, Public, Random};
 use cmerkle::skewed_merkle_root;
 use cnetwork::NodeId;
 use cstate::{ActionHandler, StateDB};
@@ -55,8 +55,8 @@ use super::super::blockchain_info::BlockChainInfo;
 use super::super::client::ImportResult;
 use super::super::client::{
     AccountData, Balance, BlockChain, BlockChainClient, BlockInfo, BlockProducer, BlockStatus, ChainInfo, ImportBlock,
-    ImportSealedBlock, MiningBlockChainClient, Nonce, ParcelInfo, PrepareOpenBlock, ReopenBlock, StateOrBlock,
-    TransactionInfo,
+    ImportSealedBlock, MiningBlockChainClient, Nonce, ParcelInfo, PrepareOpenBlock, RegularKeyOwner, ReopenBlock,
+    StateOrBlock, TransactionInfo,
 };
 use super::super::db::{COL_STATE, NUM_COLUMNS};
 use super::super::encoded;
@@ -354,6 +354,12 @@ impl Balance for TestBlockChainClient {
 }
 
 impl AccountData for TestBlockChainClient {}
+
+impl RegularKeyOwner for TestBlockChainClient {
+    fn regular_key_owner(&self, _public: &Public, _state: StateOrBlock) -> Option<Address> {
+        return None
+    }
+}
 
 impl ChainInfo for TestBlockChainClient {
     fn chain_info(&self) -> BlockChainInfo {

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -29,7 +29,9 @@ pub use self::miner::{Miner, MinerOptions};
 pub use self::stratum::{Config as StratumConfig, Error as StratumError, Stratum};
 use super::account_provider::SignError;
 use super::block::ClosedBlock;
-use super::client::{AccountData, BlockChain, BlockProducer, ImportSealedBlock, MiningBlockChainClient};
+use super::client::{
+    AccountData, BlockChain, BlockProducer, ImportSealedBlock, MiningBlockChainClient, RegularKeyOwner,
+};
 use super::consensus::EngineType;
 use super::error::Error;
 use super::parcel::{SignedParcel, UnverifiedParcel};
@@ -69,7 +71,7 @@ pub trait MinerService: Send + Sync {
     /// Called when blocks are imported to chain, updates parcels queue.
     fn chain_new_blocks<C>(&self, chain: &C, imported: &[H256], invalid: &[H256], enacted: &[H256], retracted: &[H256])
     where
-        C: AccountData + BlockChain + BlockProducer + ImportSealedBlock;
+        C: AccountData + BlockChain + BlockProducer + ImportSealedBlock + RegularKeyOwner;
 
     /// PoW chain - can produce work package
     fn can_produce_work_package(&self) -> bool;
@@ -80,7 +82,7 @@ pub trait MinerService: Send + Sync {
     /// New chain head event. Restart mining operation.
     fn update_sealing<C>(&self, chain: &C)
     where
-        C: AccountData + BlockChain + BlockProducer + ImportSealedBlock;
+        C: AccountData + BlockChain + BlockProducer + ImportSealedBlock + RegularKeyOwner;
 
     /// Submit `seal` as a valid solution for the header of `pow_hash`.
     /// Will check the seal, but not actually insert the block into the chain.
@@ -89,7 +91,7 @@ pub trait MinerService: Send + Sync {
     /// Get the sealing work package and if `Some`, apply some transform.
     fn map_sealing_work<C, F, T>(&self, client: &C, f: F) -> Option<T>
     where
-        C: AccountData + BlockChain + BlockProducer,
+        C: AccountData + BlockChain + BlockProducer + RegularKeyOwner,
         F: FnOnce(&ClosedBlock) -> T,
         Self: Sized;
 

--- a/core/src/views/block.rs
+++ b/core/src/views/block.rs
@@ -85,7 +85,7 @@ impl<'a> BlockView<'a> {
                 block_hash: block_hash.clone(),
                 block_number,
                 parcel_index,
-                cached_sender: None,
+                cached_signer_public: None,
             })
             .collect()
     }
@@ -120,7 +120,7 @@ impl<'a> BlockView<'a> {
             block_hash,
             block_number,
             parcel_index,
-            cached_sender: None,
+            cached_signer_public: None,
         })
     }
 }

--- a/core/src/views/body.rs
+++ b/core/src/views/body.rs
@@ -62,7 +62,7 @@ impl<'a> BodyView<'a> {
                 block_hash: block_hash.clone(),
                 block_number,
                 parcel_index,
-                cached_sender: None,
+                cached_signer_public: None,
             })
             .collect()
     }
@@ -99,7 +99,7 @@ impl<'a> BodyView<'a> {
             block_hash: block_hash.clone(),
             block_number,
             parcel_index,
-            cached_sender: None,
+            cached_signer_public: None,
         })
     }
 }

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -129,8 +129,7 @@ impl TopStateInfo for TopLevelState {
 
     fn regular_key_owner(&self, public: &Public) -> TrieResult<Option<Address>> {
         let account = self.get_regular_account(public)?;
-        Ok(account.map_or(None, |regular_account|
-          Some(public_to_address(regular_account.owner_public()))))
+        Ok(account.map_or(None, |regular_account| Some(public_to_address(regular_account.owner_public()))))
     }
 
     fn number_of_shards(&self) -> TrieResult<ShardId> {
@@ -326,11 +325,7 @@ impl TopLevelState {
 
     /// Execute a given parcel, charging parcel fee.
     /// This will change the state accordingly.
-    pub fn apply(
-        &mut self,
-        parcel: &Parcel,
-        signer_public: &Public,
-    ) -> StateResult<ParcelInvoice> {
+    pub fn apply(&mut self, parcel: &Parcel, signer_public: &Public) -> StateResult<ParcelInvoice> {
         // Change the public to an owner address if it is a regular key.
         let fee_payer = if self.regular_account_exists_and_not_null(signer_public)? {
             let regular_account = self.get_regular_account_mut(signer_public)?;
@@ -1439,7 +1434,7 @@ mod tests_parcel {
     #[test]
     fn change_regular_key() {
         let (sender, sender_public) = address();
-        let (regular_address, regular_public) = address();
+        let (_, regular_public) = address();
         let (_, regular_public2) = address();
 
         let mut state = get_temp_state();
@@ -1466,7 +1461,7 @@ mod tests_parcel {
     #[test]
     fn pass_registrar_check_using_a_regular_key() {
         let (sender, sender_public) = address();
-        let (regular_address, regular_public) = address();
+        let (_, regular_public) = address();
 
         let network_id = "tc".into();
         let world_id = 0;

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -90,7 +90,8 @@ where
     fn account_exists_and_not_null(&self, a: &Address) -> TrieResult<bool>;
     fn account_exists_and_has_nonce(&self, a: &Address) -> TrieResult<bool>;
 
-    fn regular_account_exists_and_not_null(&self, a: &Address) -> TrieResult<bool>;
+    fn regular_account_exists_and_not_null(&self, p: &Public) -> TrieResult<bool>;
+    fn regular_account_exists_and_not_null_by_address(&self, a: &Address) -> TrieResult<bool>;
 
     /// Add `incr` to the balance of account `a`.
     fn add_balance(&mut self, a: &Address, incr: &U256) -> TrieResult<()>;


### PR DESCRIPTION
Parcel's sender field does not correctly mean sender because we cannot get sender address from regular key's signature.
So change the name to signer and change type to the public key.