### PR TITLE
Call on_initialize on the main thread

### DIFF
--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -90,7 +90,8 @@ impl Service {
     pub fn register_extension(&self, extension: Arc<NetworkExtension>) -> Result<(), String> {
         let extension_name = extension.name().to_string();
         self.client.register_extension(extension);
-        if let Err(err) = self.timer.send_message(timer::Message::InitializeExtension {
+
+        if let Err(err) = self.timer.channel().send_sync(timer::Message::InitializeExtension {
             extension_name,
         }) {
             Err(format!("{:?}", err))


### PR DESCRIPTION
Currently, `register_extension` enqueues a message and the worker called `on_initialize` method.
It makes a flaky bug that `on_initialize` method is called after other callbacks are called.
This makes `on_initialize` callback is called on the main thread.