### PR TITLE
Support tagging in a whitelist/blacklist

### DIFF
--- a/codechain/dummy_network_service.rs
+++ b/codechain/dummy_network_service.rs
@@ -16,7 +16,7 @@
 
 use std::net::IpAddr;
 
-use cnetwork::{NetworkControl, NetworkControlError, SocketAddr};
+use cnetwork::{FilterEntry, NetworkControl, NetworkControlError, SocketAddr};
 use primitives::H256;
 
 pub struct DummyNetworkService {}
@@ -56,7 +56,7 @@ impl NetworkControl for DummyNetworkService {
         Err(NetworkControlError::Disabled)
     }
 
-    fn add_to_whitelist(&self, _addr: IpAddr) -> Result<(), NetworkControlError> {
+    fn add_to_whitelist(&self, _addr: IpAddr, _tag: Option<String>) -> Result<(), NetworkControlError> {
         Err(NetworkControlError::Disabled)
     }
 
@@ -64,7 +64,7 @@ impl NetworkControl for DummyNetworkService {
         Err(NetworkControlError::Disabled)
     }
 
-    fn add_to_blacklist(&self, _addr: IpAddr) -> Result<(), NetworkControlError> {
+    fn add_to_blacklist(&self, _addr: IpAddr, _tag: Option<String>) -> Result<(), NetworkControlError> {
         Err(NetworkControlError::Disabled)
     }
 
@@ -88,11 +88,11 @@ impl NetworkControl for DummyNetworkService {
         Err(NetworkControlError::Disabled)
     }
 
-    fn get_whitelist(&self) -> Result<(Vec<IpAddr>, bool), NetworkControlError> {
+    fn get_whitelist(&self) -> Result<(Vec<FilterEntry>, bool), NetworkControlError> {
         Err(NetworkControlError::Disabled)
     }
 
-    fn get_blacklist(&self) -> Result<(Vec<IpAddr>, bool), NetworkControlError> {
+    fn get_blacklist(&self) -> Result<(Vec<FilterEntry>, bool), NetworkControlError> {
         Err(NetworkControlError::Disabled)
     }
 }

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use super::filters::FilterEntry;
 use super::SocketAddr;
-use std::net::IpAddr;
 
 pub struct Config {
     pub address: String,
@@ -23,6 +23,6 @@ pub struct Config {
     pub bootstrap_addresses: Vec<SocketAddr>,
     pub min_peers: usize,
     pub max_peers: usize,
-    pub whitelist: Vec<IpAddr>,
-    pub blacklist: Vec<IpAddr>,
+    pub whitelist: Vec<FilterEntry>,
+    pub blacklist: Vec<FilterEntry>,
 }

--- a/network/src/control.rs
+++ b/network/src/control.rs
@@ -20,6 +20,7 @@ use std::result::Result;
 use primitives::H256;
 
 use super::addr::SocketAddr;
+use super::filters::FilterEntry;
 
 pub trait Control: Send + Sync {
     fn register_secret(&self, secret: H256, addr: SocketAddr) -> Result<(), Error>;
@@ -30,10 +31,10 @@ pub trait Control: Send + Sync {
     fn get_peer_count(&self) -> Result<usize, Error>;
     fn established_peers(&self) -> Result<Vec<SocketAddr>, Error>;
 
-    fn add_to_whitelist(&self, addr: IpAddr) -> Result<(), Error>;
+    fn add_to_whitelist(&self, addr: IpAddr, tag: Option<String>) -> Result<(), Error>;
     fn remove_from_whitelist(&self, addr: &IpAddr) -> Result<(), Error>;
 
-    fn add_to_blacklist(&self, addr: IpAddr) -> Result<(), Error>;
+    fn add_to_blacklist(&self, addr: IpAddr, tag: Option<String>) -> Result<(), Error>;
     fn remove_from_blacklist(&self, addr: &IpAddr) -> Result<(), Error>;
 
     fn enable_whitelist(&self) -> Result<(), Error>;
@@ -42,8 +43,8 @@ pub trait Control: Send + Sync {
     fn enable_blacklist(&self) -> Result<(), Error>;
     fn disable_blacklist(&self) -> Result<(), Error>;
 
-    fn get_whitelist(&self) -> Result<(Vec<IpAddr>, bool), Error>;
-    fn get_blacklist(&self) -> Result<(Vec<IpAddr>, bool), Error>;
+    fn get_whitelist(&self) -> Result<(Vec<FilterEntry>, bool), Error>;
+    fn get_blacklist(&self) -> Result<(Vec<FilterEntry>, bool), Error>;
 }
 
 #[derive(Clone, Debug)]

--- a/network/src/filters/control.rs
+++ b/network/src/filters/control.rs
@@ -16,11 +16,13 @@
 
 use std::net::IpAddr;
 
+use super::filter::FilterEntry;
+
 pub trait Control: Send + Sync {
-    fn add_to_whitelist(&self, addr: IpAddr);
+    fn add_to_whitelist(&self, addr: IpAddr, tag: Option<String>);
     fn remove_from_whitelist(&self, addr: &IpAddr);
 
-    fn add_to_blacklist(&self, addr: IpAddr);
+    fn add_to_blacklist(&self, addr: IpAddr, tag: Option<String>);
     fn remove_from_blacklist(&self, addr: &IpAddr);
 
     fn enable_whitelist(&self);
@@ -28,8 +30,8 @@ pub trait Control: Send + Sync {
     fn enable_blacklist(&self);
     fn disable_blacklist(&self);
 
-    fn get_whitelist(&self) -> (Vec<IpAddr>, bool);
-    fn get_blacklist(&self) -> (Vec<IpAddr>, bool);
+    fn get_whitelist(&self) -> (Vec<FilterEntry>, bool);
+    fn get_blacklist(&self) -> (Vec<FilterEntry>, bool);
 
     fn is_allowed(&self, addr: &IpAddr) -> bool;
 }

--- a/network/src/filters/filters.rs
+++ b/network/src/filters/filters.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use super::control::Control;
-use super::filter::Filter;
+use super::filter::{Filter, FilterEntry};
 
 pub struct Filters {
     whitelist: RwLock<Filter>,
@@ -28,7 +28,7 @@ pub struct Filters {
 }
 
 impl Filters {
-    pub fn new(whitelist_vector: Vec<IpAddr>, blacklist_vector: Vec<IpAddr>) -> Arc<Self> {
+    pub fn new(whitelist_vector: Vec<FilterEntry>, blacklist_vector: Vec<FilterEntry>) -> Arc<Self> {
         let whitelist = Filter::new(whitelist_vector);
         let blacklist = Filter::new(blacklist_vector);
 
@@ -49,9 +49,9 @@ impl Default for Filters {
 }
 
 impl Control for Filters {
-    fn add_to_whitelist(&self, addr: IpAddr) {
+    fn add_to_whitelist(&self, addr: IpAddr, tag: Option<String>) {
         let mut whitelist = self.whitelist.write();
-        whitelist.add(addr);
+        whitelist.add(addr, tag);
         cinfo!(NETFILTER, "{:?} is added to the whitelist", addr);
     }
 
@@ -61,9 +61,9 @@ impl Control for Filters {
         cinfo!(NETFILTER, "{:?} is removed from the whitelist", addr);
     }
 
-    fn add_to_blacklist(&self, addr: IpAddr) {
+    fn add_to_blacklist(&self, addr: IpAddr, tag: Option<String>) {
         let mut blacklist = self.blacklist.write();
-        blacklist.add(addr);
+        blacklist.add(addr, tag);
         cinfo!(NETFILTER, "{:?} is added to the blacklist", addr);
     }
 
@@ -97,12 +97,12 @@ impl Control for Filters {
         cinfo!(NETFILTER, "The blacklist is disabled");
     }
 
-    fn get_whitelist(&self) -> (Vec<IpAddr>, bool) {
+    fn get_whitelist(&self) -> (Vec<FilterEntry>, bool) {
         let whitelist = self.whitelist.read();
         whitelist.status()
     }
 
-    fn get_blacklist(&self) -> (Vec<IpAddr>, bool) {
+    fn get_blacklist(&self) -> (Vec<FilterEntry>, bool) {
         let blacklist = self.blacklist.read();
         blacklist.status()
     }

--- a/network/src/filters/mod.rs
+++ b/network/src/filters/mod.rs
@@ -19,4 +19,5 @@ mod filter;
 mod filters;
 
 pub use self::control::Control as FiltersControl;
+pub use self::filter::FilterEntry;
 pub use self::filters::Filters;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -68,5 +68,5 @@ pub use self::node_id::{IntoSocketAddr, NodeId};
 pub use self::service::{Error as NetworkServiceError, Service as NetworkService};
 pub use self::test::{Call as TestNetworkCall, TestClient as TestNetworkClient};
 
-pub use self::filters::{Filters, FiltersControl};
+pub use self::filters::{FilterEntry, Filters, FiltersControl};
 pub use self::routing_table::RoutingTable;

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -23,7 +23,7 @@ use primitives::H256;
 
 use super::client::Client;
 use super::control::{Control, Error as ControlError};
-use super::filters::FiltersControl;
+use super::filters::{FilterEntry, FiltersControl};
 use super::p2p;
 use super::routing_table::RoutingTable;
 use super::session_initiator;
@@ -150,8 +150,8 @@ impl Control for Service {
         Ok(self.p2p_handler.established_peers())
     }
 
-    fn add_to_whitelist(&self, addr: IpAddr) -> Result<(), ControlError> {
-        self.filters_control.add_to_whitelist(addr);
+    fn add_to_whitelist(&self, addr: IpAddr, tag: Option<String>) -> Result<(), ControlError> {
+        self.filters_control.add_to_whitelist(addr, tag);
         Ok(())
     }
 
@@ -163,8 +163,8 @@ impl Control for Service {
         Ok(())
     }
 
-    fn add_to_blacklist(&self, addr: IpAddr) -> Result<(), ControlError> {
-        self.filters_control.add_to_blacklist(addr);
+    fn add_to_blacklist(&self, addr: IpAddr, tag: Option<String>) -> Result<(), ControlError> {
+        self.filters_control.add_to_blacklist(addr, tag);
         if let Err(err) = self.p2p.send_message(p2p::Message::ApplyFilters) {
             cerror!(NETWORK, "Error occurred while apply filters: {:?}", err);
         }
@@ -202,11 +202,11 @@ impl Control for Service {
         Ok(())
     }
 
-    fn get_whitelist(&self) -> Result<(Vec<IpAddr>, bool), ControlError> {
+    fn get_whitelist(&self) -> Result<(Vec<FilterEntry>, bool), ControlError> {
         Ok(self.filters_control.get_whitelist())
     }
 
-    fn get_blacklist(&self) -> Result<(Vec<IpAddr>, bool), ControlError> {
+    fn get_blacklist(&self) -> Result<(Vec<FilterEntry>, bool), ControlError> {
         Ok(self.filters_control.get_blacklist())
     }
 }

--- a/network/src/session_initiator/handler.rs
+++ b/network/src/session_initiator/handler.rs
@@ -414,7 +414,7 @@ impl IoHandler<Message> for Handler {
             }
             Message::ManuallyConnectTo(socket_address) => {
                 let mut session_initiator = self.session_initiator.write();
-                session_initiator.filters.add_to_whitelist(socket_address.ip());
+                session_initiator.filters.add_to_whitelist(socket_address.ip(), None);
                 session_initiator.routing_table.unban(&socket_address);
                 session_initiator.routing_table.add_candidate(*socket_address);
                 session_initiator.requests.manually_connected_address.insert(*socket_address);

--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -69,16 +69,16 @@ impl Net for NetClient {
         Ok(peers.into_iter().map(Into::into).collect())
     }
 
-    fn add_to_whitelist(&self, addr: ::std::net::IpAddr) -> Result<()> {
-        self.network_control.add_to_whitelist(addr).map_err(errors::network_control)
+    fn add_to_whitelist(&self, addr: ::std::net::IpAddr, tag: Option<String>) -> Result<()> {
+        self.network_control.add_to_whitelist(addr, tag).map_err(errors::network_control)
     }
 
     fn remove_from_whitelist(&self, addr: ::std::net::IpAddr) -> Result<()> {
         self.network_control.remove_from_whitelist(&addr).map_err(errors::network_control)
     }
 
-    fn add_to_blacklist(&self, addr: ::std::net::IpAddr) -> Result<()> {
-        self.network_control.add_to_blacklist(addr).map_err(errors::network_control)
+    fn add_to_blacklist(&self, addr: ::std::net::IpAddr, tag: Option<String>) -> Result<()> {
+        self.network_control.add_to_blacklist(addr, tag).map_err(errors::network_control)
     }
 
     fn remove_from_blacklist(&self, addr: ::std::net::IpAddr) -> Result<()> {
@@ -104,7 +104,7 @@ impl Net for NetClient {
     fn get_whitelist(&self) -> Result<FilterStatus> {
         let (list, enabled) = self.network_control.get_whitelist().map_err(errors::network_control)?;
         Ok(FilterStatus {
-            list: list.into_iter().map(Into::into).collect(),
+            list: list.into_iter().map(|x| (x.addr, x.tag)).collect(),
             enabled,
         })
     }
@@ -112,7 +112,7 @@ impl Net for NetClient {
     fn get_blacklist(&self) -> Result<FilterStatus> {
         let (list, enabled) = self.network_control.get_blacklist().map_err(errors::network_control)?;
         Ok(FilterStatus {
-            list: list.into_iter().map(Into::into).collect(),
+            list: list.into_iter().map(|x| (x.addr, x.tag)).collect(),
             enabled,
         })
     }

--- a/rpc/src/v1/traits/net.rs
+++ b/rpc/src/v1/traits/net.rs
@@ -43,13 +43,13 @@ build_rpc_trait! {
         fn get_established_peers(&self) -> Result<Vec<::std::net::SocketAddr>>;
 
         #[rpc(name = "net_addToWhitelist")]
-        fn add_to_whitelist(&self, ::std::net::IpAddr) -> Result<()>;
+        fn add_to_whitelist(&self, ::std::net::IpAddr, Option<String>) -> Result<()>;
 
         #[rpc(name = "net_removeFromWhitelist")]
         fn remove_from_whitelist(&self, ::std::net::IpAddr) -> Result<()>;
 
         #[rpc(name = "net_addToBlacklist")]
-        fn add_to_blacklist(&self, ::std::net::IpAddr) -> Result<()>;
+        fn add_to_blacklist(&self, ::std::net::IpAddr, Option<String>) -> Result<()>;
 
         #[rpc(name = "net_removeFromBlacklist")]
         fn remove_from_blacklist(&self, ::std::net::IpAddr) -> Result<()>;

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -31,6 +31,6 @@ pub use self::work::Work;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FilterStatus {
-    pub list: Vec<::std::net::IpAddr>,
+    pub list: Vec<(::std::net::IpAddr, String)>,
     pub enabled: bool,
 }

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1305,6 +1305,7 @@ Adds the address to the whitelist.
 
 Params:
  1. address: `string`
+ 2. tag: `null` | `string`
 
 Return Type: `null`
 
@@ -1312,7 +1313,7 @@ Request Example
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "net_addToWhitelist", "params": ["1.2.3.4"], "id": 6}' \
+    -d '{"jsonrpc": "2.0", "method": "net_addToWhitelist", "params": ["1.2.3.4", "tag"], "id": 6}' \
     localhost:8080
 ```
 
@@ -1355,6 +1356,7 @@ Adds the address to the blacklist.
 
 Params:
  1. address: `string`
+ 2. tag: `null` | `string`
 
 Return Type: `null`
 
@@ -1362,7 +1364,7 @@ Request Example
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "net_addToBlacklist", "params": ["1.2.3.4"], "id": 6}' \
+    -d '{"jsonrpc": "2.0", "method": "net_addToBlacklist", "params": ["1.2.3.4", "tag"], "id": 6}' \
     localhost:8080
 ```
 
@@ -1495,10 +1497,9 @@ Response Example
 ## net_getWhitelist
 Gets the address in the whitelist.
 
-Params:
- 1. address: `string`
+Params: No parameters
 
-Return Type: { list: `string[]`, enabled: `bool` }
+Return Type: { list: `string[][]`, enabled: `bool` }
 
 Request Example
 ```
@@ -1512,7 +1513,7 @@ Response Example
 ```
 {
   "jsonrpc":"2.0",
-  "result": { "list": ["1.2.3.4", "1.2.3.5", "1.2.3.6"], "enabled": true },
+  "result": { "list": [["1.2.3.4", "tag1"], ["1.2.3.5", "tag2"], ["1.2.3.6", "tag3"]], "enabled": true },
   "id":6
 }
 ```
@@ -1520,10 +1521,9 @@ Response Example
 ## net_getBlacklist
 Gets the address in the blacklist.
 
-Params:
- 1. address: `string`
+Params: No parameters
 
-Return Type: { list: `string[]`, enabled: `bool` }
+Return Type: { list: `string[][]`, enabled: `bool` }
 
 Request Example
 ```
@@ -1537,7 +1537,7 @@ Response Example
 ```
 {
   "jsonrpc":"2.0",
-  "result": { "list": ["1.2.3.4", "1.2.3.5", "1.2.3.6"], "enabled": false },
+  "result": { "list": [["1.2.3.4", "tag1"], ["1.2.3.5", "tag2"], ["1.2.3.6", "tag3"]], "enabled": false },
   "id":6
 }
 ```


### PR DESCRIPTION
This implements #668.
Only one IP address is allowed in one line, and you can comment/tag by `'#'`.
For example,
Whitelist:
```
127.0.0.1 # Wow
128.0.0.1 # Nice
# This is a pure comment
130.0.0.1
# IP address with no tag
129.0.0.1 #Yes
```
The result of `net_getWhitelist`:
```
{"jsonrpc":"2.0",
 "result":{
    "enabled":true,
    "list":[["127.0.0.1","Wow"],["128.0.0.1","Nice"],["129.0.0.1","Yes"],["130.0.0.1",null]]
}}
```