### PR TITLE
Add sync test on no-parcel-relay

### DIFF
--- a/test/src/integration/sync.test.ts
+++ b/test/src/integration/sync.test.ts
@@ -331,6 +331,49 @@ describe.skip("sync", () => {
         });
     });
 
+    describe("2 nodes with no parcel relay", () => {
+        let nodeA: CodeChain;
+        let nodeB: CodeChain;
+        const testSize: number = 5;
+
+        beforeEach(async () => {
+            nodeA = new CodeChain();
+            nodeB = new CodeChain();
+
+            await nodeA.start(["--no-parcel-relay"]);
+            await nodeB.start(["--no-parcel-relay"]);
+            await nodeA.connect(nodeB);
+
+            await nodeA.sdk.rpc.devel.stopSealing();
+            await nodeB.sdk.rpc.devel.stopSealing();
+        });
+
+        test(
+            "parcels must not be propagated",
+            async () => {
+                for (let i = 0; i < testSize; i++) {
+                    await nodeA.sendSignedParcel({
+                        nonce: i,
+                        awaitInvoice: false
+                    });
+                    expect(
+                        (await nodeA.sdk.rpc.chain.getPendingParcels()).length
+                    ).toBe(i + 1);
+                }
+                await wait(2000);
+                expect(
+                    (await nodeB.sdk.rpc.chain.getPendingParcels()).length
+                ).toBe(0);
+            },
+            500 * testSize + 4000
+        );
+
+        afterEach(async () => {
+            await nodeA.clean();
+            await nodeB.clean();
+        });
+    });
+
     describe.each([[3], [5]])(`%p nodes`, numNodes => {
         let nodes: CodeChain[] = [];
 


### PR DESCRIPTION
It is skipped because it contains `connect()`.