### PR TITLE
Add BLAKE160 opcode

### DIFF
--- a/spec/CodeChain-Virtual-Machine.md
+++ b/spec/CodeChain-Virtual-Machine.md
@@ -84,6 +84,7 @@ Leading zeros must be truncated. Note that it is allowed to decode value with le
 * SHA256(0x91): Pop one value from stack, and push sha-256 hash of it.
 * RIPEMD160(0x92): Pop one value from stack, and push ripemd160 hash of it.
 * KECCAK256(0x93): Pop one value from stack, and push keccak-256 hash of it.
+* BLAKE160(0x94): Pop one value from stack, and push blake-160 hash of it. Blake-160 here refers to blake2b with 20 byte output.
 
 ## Environment
 * BLKNUM(0xa0): Push block number specified in parcel to stack as integer. If there's no specified block number, machine must fail immediately.

--- a/vm/src/decoder.rs
+++ b/vm/src/decoder.rs
@@ -75,6 +75,7 @@ pub fn decode(bytes: &[u8]) -> Result<Vec<Instruction>, DecoderError> {
             opcode::SHA256 => result.push(Instruction::Sha256),
             opcode::RIPEMD160 => result.push(Instruction::Ripemd160),
             opcode::KECCAK256 => result.push(Instruction::Keccak256),
+            opcode::BLAKE160 => result.push(Instruction::Blake160),
             invalid_opcode => return Err(DecoderError::InvalidOpCode(invalid_opcode)),
         }
     }

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ccrypto::{blake256, keccak256, ripemd160, sha256};
+use ccrypto::{blake256, keccak256, ripemd160, sha256, Blake};
 use ckey::{verify, Public, Signature, SIGNATURE_LENGTH};
-use primitives::H256;
+use primitives::{H160, H256};
 
 use instruction::{has_expensive_opcodes, is_valid_unlock_script, Instruction};
 
@@ -237,6 +237,10 @@ pub fn execute(
             Instruction::Keccak256 => {
                 let value = stack.pop()?;
                 stack.push(Item(keccak256(value).to_vec()))?;
+            }
+            Instruction::Blake160 => {
+                let value = stack.pop()?;
+                stack.push(Item(H160::blake(value).to_vec()))?;
             }
         }
         pc += 1;

--- a/vm/src/instruction.rs
+++ b/vm/src/instruction.rs
@@ -37,6 +37,7 @@ pub enum Instruction {
     Sha256,
     Ripemd160,
     Keccak256,
+    Blake160,
 }
 
 pub fn is_valid_unlock_script(instrs: &[Instruction]) -> bool {

--- a/vm/src/opcode.rs
+++ b/vm/src/opcode.rs
@@ -35,3 +35,4 @@ pub const BLAKE256: u8 = 0x90;
 pub const SHA256: u8 = 0x91;
 pub const RIPEMD160: u8 = 0x92;
 pub const KECCAK256: u8 = 0x93;
+pub const BLAKE160: u8 = 0x94;

--- a/vm/src/tests/decoder.rs
+++ b/vm/src/tests/decoder.rs
@@ -68,6 +68,7 @@ test_no_argument_opcode!(BLAKE256, Blake256);
 test_no_argument_opcode!(SHA256, Sha256);
 test_no_argument_opcode!(RIPEMD160, Ripemd160);
 test_no_argument_opcode!(KECCAK256, Keccak256);
+test_no_argument_opcode!(BLAKE160, Blake160);
 
 #[test]
 #[allow(non_snake_case)]


### PR DESCRIPTION

Currently, P2PKH and P2PKHBurn use blake256 to create a public key hash.
I'm adding it to shorten AssetTransferAddress of the standard scripts.