### PR TITLE
Add invalid time stamp block propagation test

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -30,6 +30,7 @@
     "seedrandom": "^2.4.4",
     "ts-jest": "^22.4.6",
     "ts-node": "^7.0.0",
-    "typescript": "^2.9.2"
+    "typescript": "^2.9.2",
+    "codechain-test-helper": "https://github.com/CodeChain-io/codechain-test-helper-js.git#a4a9c26635a52395dfd17733eef66b18a144fd00"
   }
 }

--- a/test/src/integration/onChainBlock.test.ts
+++ b/test/src/integration/onChainBlock.test.ts
@@ -1,0 +1,140 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { TestHelper } from "codechain-test-helper/lib/testHelper";
+import { Header } from "codechain-test-helper/lib/cHeader";
+import CodeChain from "../helper/spawn";
+import { H256, U256, H160 } from "codechain-primitives/lib";
+
+describe("Test onChain block communication", async () => {
+    let nodeA: CodeChain;
+    let TH: TestHelper;
+    let soloGenesisBlock: Header;
+    let soloBlock1: Header;
+    let soloBlock2: Header;
+
+    let INVALID_TIMESTAMP: U256;
+
+    beforeAll(async () => {
+        const node = new CodeChain({
+            logFlag: true,
+            argv: ["--force-sealing"]
+        });
+        await node.start();
+
+        const sdk = node.sdk;
+
+        await sdk.rpc.devel.startSealing();
+        await sdk.rpc.devel.startSealing();
+
+        const genesisBlock = await sdk.rpc.chain.getBlock(0);
+        const block1 = await sdk.rpc.chain.getBlock(1);
+        const block2 = await sdk.rpc.chain.getBlock(2);
+
+        await node.clean();
+        soloGenesisBlock = new Header(
+            genesisBlock.parentHash,
+            new U256(genesisBlock.timestamp),
+            new U256(genesisBlock.number),
+            genesisBlock.author.accountId,
+            Buffer.from(genesisBlock.extraData),
+            genesisBlock.parcelsRoot,
+            genesisBlock.stateRoot,
+            genesisBlock.invoicesRoot,
+            genesisBlock.score,
+            genesisBlock.seal
+        );
+        soloBlock1 = new Header(
+            soloGenesisBlock.hashing(),
+            new U256(block1.timestamp),
+            new U256(block1.number),
+            block1.author.accountId,
+            Buffer.from(block1.extraData),
+            block1.parcelsRoot,
+            block1.stateRoot,
+            block1.invoicesRoot,
+            new U256(2222222222222),
+            block1.seal
+        );
+        soloBlock2 = new Header(
+            soloBlock1.hashing(),
+            new U256(block2.timestamp),
+            new U256(block2.number),
+            block2.author.accountId,
+            Buffer.from(block2.extraData),
+            block2.parcelsRoot,
+            block2.stateRoot,
+            block2.invoicesRoot,
+            new U256(33333333333333),
+            block2.seal
+        );
+
+        INVALID_TIMESTAMP = new U256(block1.timestamp - 1);
+    });
+
+    beforeEach(async () => {
+        nodeA = new CodeChain({ logFlag: true });
+        await nodeA.start();
+        TH = new TestHelper("0.0.0.0", nodeA.port);
+        await TH.establish();
+    });
+
+    afterEach(async () => {
+        await TH.end();
+        await nodeA.clean();
+    });
+
+    test(
+        "OnChain invalid timestamp block propagation test",
+        async () => {
+            const sdk = nodeA.sdk;
+
+            // Genesis block
+            const header = soloGenesisBlock;
+
+            // Block 1
+            const header1 = soloBlock1;
+
+            // Block 2
+            const header2 = soloBlock2;
+
+            const bestHash = header2.hashing();
+            const bestScore = header2.getScore();
+
+            header2.setTimestamp(INVALID_TIMESTAMP);
+
+            await TH.sendEncodedBlock(
+                [
+                    header.toEncodeObject(),
+                    header1.toEncodeObject(),
+                    header2.toEncodeObject()
+                ],
+                [[], []],
+                bestHash,
+                bestScore
+            );
+
+            await TH.waitStatusMessage();
+
+            const block1 = await sdk.rpc.chain.getBlock(1);
+            const block2 = await sdk.rpc.chain.getBlock(2);
+
+            expect(block1).toEqual(expect.anything());
+            expect(block2).toEqual(null);
+        },
+        30000
+    );
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,18 +1,12 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "types": [
-      "node"
-    ],
+    "types": ["ts-jest", "node"],
     "module": "commonjs",
     "declaration": true,
     "outDir": "lib",
     "strict": true
   },
-  "include": [
-    "./src/**/*",
-  ],
-  "exclude": [
-    "./src/**/*.test.ts"
-  ]
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/*.test.ts"]
 }


### PR DESCRIPTION
There are some issues in sending invalid timestamp onChain blocks.
---
Below is a test scenario.
1. Make block1 and block2.
2. The timestamp in Block2's header should be invalid. Simply make it smaller than block1.
2. Send a `status message` with block2's hash as the bestHash.
3. Send a `header response message` which is [genesisHeader, block1Header, block2Header].
4. Send a `body response message` == [[], []], which is correspond to block1's body and block2's body.
5. Block is accepted from the target node only for block1. So the target node should send a status message with block1's hash as bestHash.
---
And here are problems
1. The target node does not send `status message` if in the above situation. However, if I inserted `info!("55");` then the `status message` come properly.
2. In below `verify()` function, `Ok(verified)` is returned twice although the block2 is invalid.
3. `Header request` does not come from the target node anymore, even if after sending valid block1 and block2. -- Resolved, I misunderstood sync behaviour
```rust

    fn verify(
        verification: Arc<Verification<K>>,
        engine: Arc<CodeChainEngine>,
        ready_signal: Arc<QueueSignal>,
        empty: Arc<SCondvar>,
        more_to_verify: Arc<SCondvar>,
        _id: usize,
    ) {
        loop {
            // wait for work if empty.
            {
                let mut more_to_verify_mutex = verification.more_to_verify_mutex.lock().unwrap();

                if verification.unverified.lock().is_empty() && verification.verifying.lock().is_empty() {
                    empty.notify_all();
                }

                while verification.unverified.lock().is_empty() {
                    more_to_verify_mutex = more_to_verify.wait(more_to_verify_mutex).unwrap();
                }
            }

            // do work.
            let item = {
                // acquire these locks before getting the item to verify.
                let mut unverified = verification.unverified.lock();
                let mut verifying = verification.verifying.lock();

                let item = match unverified.pop_front() {
                    Some(item) => item,
                    None => continue,
                };

                verification.sizes.unverified.fetch_sub(item.heap_size_of_children(), AtomicOrdering::SeqCst);
                verifying.push_back(Verifying {
                    hash: item.hash(),
                    output: None,
                });
                item
            };

            let hash = item.hash();
            let is_ready = match K::verify(item, &*engine, verification.check_seal) {
                Ok(verified) => {
                    let mut verifying = verification.verifying.lock();
                    let mut idx = None;
                    for (i, e) in verifying.iter_mut().enumerate() {
                        if e.hash == hash {
                            idx = Some(i);

                            verification
                                .sizes
                                .verifying
                                .fetch_add(verified.heap_size_of_children(), AtomicOrdering::SeqCst);
                            e.output = Some(verified);
                            break
                        }
                    }

                    if idx == Some(0) {
                        // we're next!
                        let mut verified = verification.verified.lock();
                        let mut bad = verification.bad.lock();
                        VerificationQueue::drain_verifying(
                            &mut verifying,
                            &mut verified,
                            &mut bad,
                            &verification.sizes,
                        );
                        info!("111");
                        true
                    } else {
                        info!("222");
                        false
                    }
                }
                Err(_) => {
                    let mut verifying = verification.verifying.lock();
                    let mut verified = verification.verified.lock();
                    let mut bad = verification.bad.lock();

                    bad.insert(hash.clone());
                    verifying.retain(|e| e.hash != hash);

                    if verifying.front().map_or(false, |x| x.output.is_some()) {
                        VerificationQueue::drain_verifying(
                            &mut verifying,
                            &mut verified,
                            &mut bad,
                            &verification.sizes,
                        );
                        info!("33");
                        true
                    } else {
                        info!("44");
                        false
                    }
                }
            };
            if is_ready {
                info!("55");
                // Import the block immediately
                ready_signal.set_sync();
            }
        }
    }
```
