### PR TITLE
Improve the integration test in timeout/gitignore

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 yarn-error.log
+keystore.db
+yarn.lock

--- a/test/src/integration/transactions.test.ts
+++ b/test/src/integration/transactions.test.ts
@@ -584,6 +584,7 @@ describe("transactions", () => {
             test.each([[5], [10], [100], [504]])(
                 "%p + 1 outputs",
                 async length => {
+                    jest.setTimeout(length * 10 + 5000);
                     const tx = node.sdk.core
                         .createAssetTransferTransaction()
                         .addInputs(assets[0])


### PR DESCRIPTION
1. Lengthen the timeout of the test case `transactions - Partial signature - many output` of `transactions.test.ts`.
2. Add files to the .gitignore:
  - keystore.db
    - It is created from `transactions - Partial signature` of `transactions.test.ts`. I think it should use the database defined in the node.
  - yarn.lock
    - There's no reason to include this.

It is quite small to split those two patches into different PRs, so do like this.