### PR TITLE
Make CodeChain allow the duplicated transactions

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -42,7 +42,6 @@ use kvdb::KeyValueDB;
 use primitives::{Bytes, H256, U256};
 
 use super::block::{ClosedBlock, OpenBlock, SealedBlock};
-use super::blockchain::ParcelAddress;
 use super::blockchain_info::BlockChainInfo;
 use super::encoded;
 use super::error::{BlockImportError, Error as CoreError};
@@ -78,14 +77,14 @@ pub trait ParcelInfo {
 }
 
 pub trait TransactionInfo {
-    fn transaction_parcel(&self, hash: &H256) -> Option<ParcelAddress>;
+    fn transaction_header(&self, hash: &H256) -> Option<::encoded::Header>;
 
-    fn transaction_block_number(&self, hash: &H256) -> Option<BlockNumber>;
+    fn transaction_block_number(&self, hash: &H256) -> Option<BlockNumber> {
+        self.transaction_header(hash).map(|header| header.number())
+    }
 
-    fn transaction_block_timestamp(&self, hash: &H256) -> Option<u64>;
-
-    fn is_transaction_included(&self, transaction: &Option<H256>) -> bool {
-        transaction.map(|hash| self.transaction_parcel(&hash).is_some()).unwrap_or(false)
+    fn transaction_block_timestamp(&self, hash: &H256) -> Option<u64> {
+        self.transaction_header(hash).map(|header| header.timestamp())
     }
 }
 
@@ -230,7 +229,7 @@ pub trait BlockChainClient:
     /// Get the transaction with given hash.
     fn transaction(&self, hash: &H256) -> Option<Transaction>;
 
-    fn transaction_invoice(&self, hash: &H256) -> Option<Invoice>;
+    fn transaction_invoices(&self, hash: &H256) -> Vec<Invoice>;
 
     fn custom_handlers(&self) -> Vec<Arc<ActionHandler>>;
 }

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -51,7 +51,6 @@ use primitives::{Bytes, H256, U256};
 use rlp::*;
 
 use super::super::block::{ClosedBlock, OpenBlock, SealedBlock};
-use super::super::blockchain::ParcelAddress;
 use super::super::blockchain_info::BlockChainInfo;
 use super::super::client::ImportResult;
 use super::super::client::{
@@ -396,15 +395,7 @@ impl ParcelInfo for TestBlockChainClient {
 }
 
 impl TransactionInfo for TestBlockChainClient {
-    fn transaction_parcel(&self, _: &H256) -> Option<ParcelAddress> {
-        None
-    }
-
-    fn transaction_block_number(&self, _: &H256) -> Option<BlockNumber> {
-        None
-    }
-
-    fn transaction_block_timestamp(&self, _: &H256) -> Option<u64> {
+    fn transaction_header(&self, _hash: &H256) -> Option<::encoded::Header> {
         None
     }
 }
@@ -525,7 +516,7 @@ impl BlockChainClient for TestBlockChainClient {
         unimplemented!();
     }
 
-    fn transaction_invoice(&self, _: &H256) -> Option<Invoice> {
+    fn transaction_invoices(&self, _: &H256) -> Vec<Invoice> {
         unimplemented!();
     }
 

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -1481,7 +1481,6 @@ pub mod test {
                 amount: None,
             },
             registrar: None,
-            nonce: 0,
         };
         let parcel = Parcel {
             seq: 0.into(),
@@ -1508,7 +1507,6 @@ pub mod test {
             burns: vec![],
             inputs: vec![],
             outputs: vec![],
-            nonce: 0,
         };
         let parcel = Parcel {
             seq: 0.into(),
@@ -1593,7 +1591,6 @@ pub mod test {
     fn create_parcel_order(fee: U256, transaction_count: usize) -> ParcelOrder {
         let transaction = Transaction::AssetMint {
             network_id: "tc".into(),
-            nonce: 0,
             shard_id: 0,
             metadata: String::from_utf8(vec!['a' as u8; transaction_count]).unwrap(),
             registrar: None,

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -229,9 +229,6 @@ impl Miner {
                     cdebug!(MINER, "Rejected parcel {:?}: already in the blockchain", hash);
                     return Err(StateError::from(ParcelError::ParcelAlreadyImported).into())
                 }
-                if client.is_transaction_included(&parcel.asset_transaction_hash()) {
-                    return Err(StateError::from(ParcelError::TransactionAlreadyImported).into())
-                }
                 match self
                     .engine
                     .verify_parcel_basic(&parcel, &best_block_header)

--- a/core/src/parcel.rs
+++ b/core/src/parcel.rs
@@ -270,6 +270,12 @@ impl Deref for LocalizedParcel {
     }
 }
 
+impl From<LocalizedParcel> for Parcel {
+    fn from(parcel: LocalizedParcel) -> Self {
+        parcel.signed.into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ckey::{Address, Public, Signature};
@@ -308,7 +314,6 @@ mod tests {
                 amount: Some(10000),
             },
             registrar: None,
-            nonce: 0,
         });
     }
 
@@ -324,7 +329,6 @@ mod tests {
                 amount: Some(10000),
             },
             registrar: None,
-            nonce: 0,
         });
     }
 
@@ -339,7 +343,6 @@ mod tests {
             burns,
             inputs,
             outputs,
-            nonce: 0,
         });
     }
 

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -105,8 +105,8 @@ where
         Ok(self.client.transaction(&transaction_hash).map(Into::into))
     }
 
-    fn get_transaction_invoice(&self, transaction_hash: H256) -> Result<Option<Invoice>> {
-        Ok(self.client.transaction_invoice(&transaction_hash))
+    fn get_transaction_invoices(&self, transaction_hash: H256) -> Result<Vec<Invoice>> {
+        Ok(self.client.transaction_invoices(&transaction_hash))
     }
 
     fn get_asset_scheme_by_hash(&self, transaction_hash: H256, shard_id: ShardId) -> Result<Option<AssetScheme>> {

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -43,8 +43,8 @@ build_rpc_trait! {
         fn get_transaction(&self, H256) -> Result<Option<Transaction>>;
 
         /// Gets transaction invoice with given hash.
-        # [rpc(name = "chain_getTransactionInvoice")]
-        fn get_transaction_invoice(&self, H256) -> Result<Option<Invoice>>;
+        # [rpc(name = "chain_getTransactionInvoices")]
+        fn get_transaction_invoices(&self, H256) -> Result<Vec<Invoice>>;
 
         /// Gets asset scheme with given transaction hash.
         # [rpc(name = "chain_getAssetSchemeByHash")]

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -28,7 +28,6 @@ pub enum Transaction {
         shard_id: ShardId,
         metadata: String,
         registrar: Option<PlatformAddress>,
-        nonce: u64,
 
         output: AssetMintOutput,
         hash: H256,
@@ -39,14 +38,12 @@ pub enum Transaction {
         burns: Vec<AssetTransferInput>,
         inputs: Vec<AssetTransferInput>,
         outputs: Vec<AssetTransferOutput>,
-        nonce: u64,
         hash: H256,
     },
     #[serde(rename_all = "camelCase")]
     AssetCompose {
         network_id: NetworkId,
         shard_id: ShardId,
-        nonce: u64,
         metadata: String,
         registrar: Option<PlatformAddress>,
         inputs: Vec<AssetTransferInput>,
@@ -55,7 +52,6 @@ pub enum Transaction {
     #[serde(rename_all = "camelCase")]
     AssetDecompose {
         network_id: NetworkId,
-        nonce: u64,
         input: AssetTransferInput,
         outputs: Vec<AssetTransferOutput>,
     },
@@ -70,14 +66,12 @@ impl From<TransactionType> for Transaction {
                 shard_id,
                 metadata,
                 registrar,
-                nonce,
                 output,
             } => Transaction::AssetMint {
                 network_id,
                 shard_id,
                 metadata,
                 registrar: registrar.map(|registrar| PlatformAddress::new_v1(network_id, registrar)),
-                nonce,
                 output,
                 hash,
             },
@@ -86,19 +80,16 @@ impl From<TransactionType> for Transaction {
                 burns,
                 inputs,
                 outputs,
-                nonce,
             } => Transaction::AssetTransfer {
                 network_id,
                 burns,
                 inputs,
                 outputs,
-                nonce,
                 hash,
             },
             TransactionType::AssetCompose {
                 network_id,
                 shard_id,
-                nonce,
                 metadata,
                 registrar,
                 inputs,
@@ -106,7 +97,6 @@ impl From<TransactionType> for Transaction {
             } => Transaction::AssetCompose {
                 network_id,
                 shard_id,
-                nonce,
                 metadata,
                 registrar: registrar.map(|registrar| PlatformAddress::new_v1(network_id, registrar)),
                 inputs,
@@ -114,12 +104,10 @@ impl From<TransactionType> for Transaction {
             },
             TransactionType::AssetDecompose {
                 network_id,
-                nonce,
                 input,
                 outputs,
             } => Transaction::AssetDecompose {
                 network_id,
-                nonce,
                 input,
                 outputs,
             },
@@ -136,7 +124,6 @@ impl From<Transaction> for Result<TransactionType, KeyError> {
                 shard_id,
                 metadata,
                 registrar,
-                nonce,
                 output,
                 ..
             } => {
@@ -149,7 +136,6 @@ impl From<Transaction> for Result<TransactionType, KeyError> {
                     shard_id,
                     metadata,
                     registrar,
-                    nonce,
                     output,
                 }
             }
@@ -158,19 +144,16 @@ impl From<Transaction> for Result<TransactionType, KeyError> {
                 burns,
                 inputs,
                 outputs,
-                nonce,
                 ..
             } => TransactionType::AssetTransfer {
                 network_id,
                 burns,
                 inputs,
                 outputs,
-                nonce,
             },
             Transaction::AssetCompose {
                 network_id,
                 shard_id,
-                nonce,
                 metadata,
                 registrar,
                 inputs,
@@ -183,7 +166,6 @@ impl From<Transaction> for Result<TransactionType, KeyError> {
                 TransactionType::AssetCompose {
                     network_id,
                     shard_id,
-                    nonce,
                     metadata,
                     registrar,
                     inputs,
@@ -192,12 +174,10 @@ impl From<Transaction> for Result<TransactionType, KeyError> {
             }
             Transaction::AssetDecompose {
                 network_id,
-                nonce,
                 input,
                 outputs,
             } => TransactionType::AssetDecompose {
                 network_id,
-                nonce,
                 input,
                 outputs,
             },

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -153,7 +153,7 @@ A base32 string that starts with "ccc" or "tcc". See [the specification](https:/
  * [chain_getParcel](#chain_getparcel)
  * [chain_getParcelInvoice](#chain_getparcelinvoice)
  * [chain_getTransaction](#chain_gettransaction)
- * [chain_getTransactionInvoice](#chain_gettransactioninvoice)
+ * [chain_getTransactionInvoices](#chain_gettransactioninvoices)
  * [chain_getAssetSchemeByHash](#chain_getassetschemebyhash)
  * [chain_getAssetSchemeByType](#chain_getassetschemebytype)
  * [chain_getAsset](#chain_getasset)
@@ -606,13 +606,13 @@ Response Example
 }
 ```
 
-## chain_getTransactionInvoice
-Gets a transaction invoice with the given hash.
+## chain_getTransactionInvoices
+Gets transaction invoices with the given hash.
 
 Params:
  1. transaction hash - `H256`
 
-Return Type: `null` | "Success" | "Failed"
+Return Type: `("Success" | "Failed")[]`
 
 Errors: `Invalid Params`
 
@@ -628,7 +628,7 @@ Response Example
 ```
 {
   "jsonrpc":"2.0",
-  "result":"Success",
+  "result": ["Failed", "Success"],
   "id":null
 }
 ```

--- a/spec/Parcel.md
+++ b/spec/Parcel.md
@@ -71,7 +71,6 @@ AssetMint {
     shard_id: u32,
     metadata: String,
     registrar: Option<Address>,
-    nonce: u32,
     output: AssetMintOutput
 }
 

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -607,7 +607,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
 
         let result = state.apply(&transaction, &sender, &[sender], &get_test_client());
@@ -643,7 +642,6 @@ mod tests {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
 
         let result = state.apply(&transaction, &sender, &[sender], &get_test_client());
@@ -682,7 +680,6 @@ mod tests {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
 
         let result = state.apply(&transaction, &sender, &[sender], &get_test_client());
@@ -713,7 +710,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
 
@@ -749,7 +745,6 @@ mod tests {
                 asset_type,
                 amount: 30,
             }],
-            nonce: 0,
         };
 
         assert_eq!(
@@ -785,7 +780,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
 
@@ -838,7 +832,6 @@ mod tests {
                     amount: 15,
                 },
             ],
-            nonce: 0,
         };
         let transfer_hash = transfer.hash();
 
@@ -878,7 +871,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         assert_eq!(Ok(Invoice::Success), state.apply(&mint, &sender, &[], &get_test_client()));
@@ -889,7 +881,6 @@ mod tests {
         let compose = Transaction::AssetCompose {
             network_id,
             shard_id,
-            nonce: 0,
             metadata: "composed".to_string(),
             registrar,
             inputs: vec![AssetTransferInput {
@@ -953,7 +944,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         assert_eq!(Ok(Invoice::Success), state.apply(&mint, &sender, &[], &get_test_client()));
@@ -963,7 +953,6 @@ mod tests {
         let compose = Transaction::AssetCompose {
             network_id,
             shard_id,
-            nonce: 0,
             metadata: "composed".to_string(),
             registrar,
             inputs: vec![AssetTransferInput {
@@ -1008,7 +997,6 @@ mod tests {
         let random_lock_script_hash = H160::random();
         let decompose = Transaction::AssetDecompose {
             network_id,
-            nonce: 0,
             input: AssetTransferInput {
                 prev_out: AssetOutPoint {
                     transaction_hash: compose_hash,
@@ -1061,7 +1049,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         assert_eq!(Ok(Invoice::Success), state.apply(&mint, &sender, &[], &get_test_client()));
@@ -1078,7 +1065,6 @@ mod tests {
                 amount: Some(1),
             },
             registrar,
-            nonce: 0,
         };
         let mint2_hash = mint2.hash();
         let asset_scheme_address2 = AssetSchemeAddress::new(mint_hash, shard_id);
@@ -1088,7 +1074,6 @@ mod tests {
         let compose = Transaction::AssetCompose {
             network_id,
             shard_id,
-            nonce: 0,
             metadata: "composed".to_string(),
             registrar,
             inputs: vec![AssetTransferInput {
@@ -1133,7 +1118,6 @@ mod tests {
         let random_lock_script_hash = H160::random();
         let decompose = Transaction::AssetDecompose {
             network_id,
-            nonce: 0,
             input: AssetTransferInput {
                 prev_out: AssetOutPoint {
                     transaction_hash: mint2_hash,
@@ -1186,7 +1170,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         assert_eq!(Ok(Invoice::Success), state.apply(&mint, &sender, &[], &get_test_client()));
@@ -1203,7 +1186,6 @@ mod tests {
                 amount: Some(1),
             },
             registrar,
-            nonce: 0,
         };
         let mint2_hash = mint2.hash();
         let asset_scheme_address2 = AssetSchemeAddress::new(mint2_hash, shard_id);
@@ -1213,7 +1195,6 @@ mod tests {
         let compose = Transaction::AssetCompose {
             network_id,
             shard_id,
-            nonce: 0,
             metadata: "composed".to_string(),
             registrar,
             inputs: vec![
@@ -1260,7 +1241,6 @@ mod tests {
         let random_lock_script_hash = H160::random();
         let decompose = Transaction::AssetDecompose {
             network_id,
-            nonce: 0,
             input: AssetTransferInput {
                 prev_out: AssetOutPoint {
                     transaction_hash: compose_hash,
@@ -1315,7 +1295,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         assert_eq!(Ok(Invoice::Success), state.apply(&mint, &sender, &[], &get_test_client()));
@@ -1332,7 +1311,6 @@ mod tests {
                 amount: Some(1),
             },
             registrar,
-            nonce: 0,
         };
         let mint2_hash = mint2.hash();
         let asset_scheme_address2 = AssetSchemeAddress::new(mint2_hash, shard_id);
@@ -1342,7 +1320,6 @@ mod tests {
         let compose = Transaction::AssetCompose {
             network_id,
             shard_id,
-            nonce: 0,
             metadata: "composed".to_string(),
             registrar,
             inputs: vec![
@@ -1389,7 +1366,6 @@ mod tests {
         let random_lock_script_hash = H160::random();
         let decompose = Transaction::AssetDecompose {
             network_id,
-            nonce: 0,
             input: AssetTransferInput {
                 prev_out: AssetOutPoint {
                     transaction_hash: compose_hash,
@@ -1452,7 +1428,6 @@ mod tests {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
 
@@ -1491,7 +1466,6 @@ mod tests {
                 asset_type,
                 amount: 30,
             }],
-            nonce: 0,
         };
 
         let sender = address();
@@ -1542,7 +1516,6 @@ mod tests {
                     amount: 15,
                 },
             ],
-            nonce: 0,
         };
         let successful_transfer_hash = successful_transfer.hash();
 
@@ -1581,7 +1554,6 @@ mod tests {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
 
         let result = state.apply(&transaction, &sender, &[sender], &get_test_client());
@@ -1620,7 +1592,6 @@ mod tests {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
 
         let shard_user = address();
@@ -1657,7 +1628,6 @@ mod tests {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
 
         let result = state.apply(&transaction, &sender, &[], &get_test_client());

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -382,9 +382,6 @@ impl TopLevelState {
             Err(StateError::Parcel(ParcelError::ParcelAlreadyImported)) => {
                 unreachable!();
             }
-            Err(StateError::Parcel(ParcelError::TransactionAlreadyImported)) => {
-                unreachable!();
-            }
             Err(StateError::Parcel(ParcelError::Old)) => {
                 unreachable!();
             }
@@ -1354,7 +1351,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
         let asset_scheme_address = AssetSchemeAddress::new(mint_hash, shard_id);
@@ -1380,7 +1376,6 @@ mod tests_parcel {
                 asset_type,
                 amount: 30,
             }],
-            nonce: 0,
         };
         let mint_parcel = Parcel {
             fee: 11.into(),
@@ -1510,7 +1505,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let transaction_hash = transaction.hash();
         let parcel = Parcel {
@@ -1561,7 +1555,6 @@ mod tests_parcel {
                 amount: None,
             },
             registrar,
-            nonce: 0,
         };
         let transaction_hash = transaction.hash();
         let parcel = Parcel {
@@ -1615,7 +1608,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
 
@@ -1674,7 +1666,6 @@ mod tests_parcel {
                     amount: 15,
                 },
             ],
-            nonce: 0,
         };
         let transfer_hash = transfer.hash();
 
@@ -1737,7 +1728,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let parcel = Parcel {
             fee: 11.into(),
@@ -1875,7 +1865,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let parcel = Parcel {
             fee: 11.into(),
@@ -1935,7 +1924,6 @@ mod tests_parcel {
                     amount: 15,
                 },
             ],
-            nonce: 0,
         };
 
         let parcel = Parcel {
@@ -2206,7 +2194,6 @@ mod tests_parcel {
                 amount: Some(amount),
             },
             registrar,
-            nonce: 0,
         };
         let mint_hash = mint.hash();
 

--- a/test/package.json
+++ b/test/package.json
@@ -23,7 +23,7 @@
     "tslint": "^5.10.0"
   },
   "dependencies": {
-    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#group-lib",
+    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#nonce-lib",
     "jest": "^23.1.0",
     "mkdirp": "^0.5.1",
     "rlp": "^2.0.0",

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -368,7 +368,7 @@ export default class CodeChain {
             });
         await this.sdk.rpc.chain.sendSignedParcel(parcel);
         if (awaitInvoice) {
-            return this.sdk.rpc.chain.getTransactionInvoice(tx.hash(), {
+            return this.sdk.rpc.chain.getTransactionInvoices(tx.hash(), {
                 timeout: 300 * 1000
             });
         }

--- a/test/src/integration/chain.test.ts
+++ b/test/src/integration/chain.test.ts
@@ -230,14 +230,12 @@ describe("solo - 1 node", () => {
             ).toBeNull();
         });
 
-        test("getTransactionInvoice", async () => {
-            const invoice = await node.sdk.rpc.chain.getTransactionInvoice(
+        test("getTransactionInvoices", async () => {
+            const invoices = await node.sdk.rpc.chain.getTransactionInvoices(
                 tx.hash()
             );
-            if (invoice == null) {
-                throw Error("Cannot get the invoice");
-            }
-            expect(invoice.success).toBe(true);
+            expect(invoices!.length).toBe(1);
+            expect(invoices[0].success).toBe(true);
         });
 
         test("getAsset", async () => {
@@ -329,11 +327,9 @@ describe("solo - 1 node", () => {
             amount: 10
         });
         await node.signTransferInput(tx, 0);
-        const invoice = await node.sendTransaction(tx);
-        if (invoice == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice.success).toBe(true);
+        const invoices = await node.sendTransaction(tx);
+        expect(invoices!.length).toBe(1);
+        expect(invoices![0].success).toBe(true);
         expect(
             await node.sdk.rpc.chain.isAssetSpent(
                 asset.outPoint.transactionHash,

--- a/test/src/integration/sync.test.ts
+++ b/test/src/integration/sync.test.ts
@@ -243,11 +243,9 @@ describeSkippedInTravis("sync", () => {
                     );
 
                     await nodeA.signTransferInput(tx1, 0);
-                    const invoice1 = await nodeA.sendTransaction(tx1);
-                    if (invoice1 == null) {
-                        throw Error("Cannot send a transaction to node A");
-                    }
-                    expect(invoice1.success).toBe(true);
+                    const invoices1 = await nodeA.sendTransaction(tx1);
+                    expect(invoices1!.length).toBe(1);
+                    expect(invoices1![0].success).toBe(true);
 
                     tx2 = nodeA.sdk.core.createAssetTransferTransaction();
                     tx2.addInputs(asset);
@@ -258,16 +256,12 @@ describeSkippedInTravis("sync", () => {
                     });
 
                     await nodeA.signTransferInput(tx2, 0);
-                    const invoiceA = await nodeA.sendTransaction(tx2);
-                    if (invoiceA == null) {
-                        throw Error("Cannot get the invoice from node A");
-                    }
-                    expect(invoiceA.success).toBe(false);
-                    const invoiceB = await nodeB.sendTransaction(tx2);
-                    if (invoiceB == null) {
-                        throw Error("Cannot get the invoice from node B");
-                    }
-                    expect(invoiceB.success).toBe(true);
+                    const invoicesA = await nodeA.sendTransaction(tx2);
+                    expect(invoicesA!.length).toBe(1);
+                    expect(invoicesA![0].success).toBe(false);
+                    const invoicesB = await nodeB.sendTransaction(tx2);
+                    expect(invoicesB!.length).toBe(1);
+                    expect(invoicesB![0].success).toBe(true);
 
                     expect(await nodeA.getBestBlockNumber()).toEqual(
                         (await nodeB.getBestBlockNumber()) + 1
@@ -284,25 +278,17 @@ describeSkippedInTravis("sync", () => {
                             expect(await nodeA.getBestBlockHash()).toEqual(
                                 await nodeB.getBestBlockHash()
                             );
-                            const invoiceA = await nodeA.sdk.rpc.chain.getTransactionInvoice(
+                            const invoicesA = await nodeA.sdk.rpc.chain.getTransactionInvoices(
                                 tx2.hash()
                             );
-                            if (invoiceA == null) {
-                                throw Error(
-                                    "Cannot get the invoice from node A"
-                                );
-                            }
-                            expect(invoiceA.success).toBe(false);
+                            expect(invoicesA!.length).toBe(1);
+                            expect(invoicesA![0].success).toBe(false);
 
-                            const invoiceB = await nodeB.sdk.rpc.chain.getTransactionInvoice(
+                            const invoicesB = await nodeB.sdk.rpc.chain.getTransactionInvoices(
                                 tx2.hash()
                             );
-                            if (invoiceB == null) {
-                                throw Error(
-                                    "Cannot get the invoice from node A"
-                                );
-                            }
-                            expect(invoiceB.success).toBe(false);
+                            expect(invoicesB!.length).toBe(1);
+                            expect(invoicesB![0].success).toBe(false);
                         },
                         30000
                     );
@@ -326,25 +312,17 @@ describeSkippedInTravis("sync", () => {
                                 await nodeB.getBestBlockHash()
                             );
 
-                            const invoiceA = await nodeA.sdk.rpc.chain.getTransactionInvoice(
+                            const invoicesA = await nodeA.sdk.rpc.chain.getTransactionInvoices(
                                 tx2.hash()
                             );
-                            if (invoiceA == null) {
-                                throw Error(
-                                    "Cannot get the invoice from node A"
-                                );
-                            }
-                            expect(invoiceA.success).toBe(true);
+                            expect(invoicesA!.length).toBe(1);
+                            expect(invoicesA![0].success).toBe(true);
 
-                            const invoiceB = await nodeB.sdk.rpc.chain.getTransactionInvoice(
+                            const invoicesB = await nodeB.sdk.rpc.chain.getTransactionInvoices(
                                 tx2.hash()
                             );
-                            if (invoiceB == null) {
-                                throw Error(
-                                    "Cannot get the invoice from node A"
-                                );
-                            }
-                            expect(invoiceB.success).toBe(true);
+                            expect(invoicesB!.length).toBe(1);
+                            expect(invoicesB![0].success).toBe(true);
                         },
                         30000
                     );

--- a/test/src/integration/transactions.test.ts
+++ b/test/src/integration/transactions.test.ts
@@ -43,11 +43,9 @@ describe("transactions", () => {
                 scheme,
                 recipient
             });
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(true);
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(true);
         });
 
         test("Mint unsuccessful - mint amount 0", async () => {
@@ -93,8 +91,9 @@ describe("transactions", () => {
                     }))
                 );
                 await node.signTransferInput(tx, 0);
-                const invoice = await node.sendTransaction(tx);
-                expect(invoice.success).toBe(true);
+                const invoices = await node.sendTransaction(tx);
+                expect(invoices!.length).toBe(1);
+                expect(invoices![0].success).toBe(true);
             }
         );
 
@@ -193,8 +192,9 @@ describe("transactions", () => {
                 );
                 await node.signTransferInput(tx, 0);
                 await node.signTransferInput(tx, 1);
-                const invoice = await node.sendTransaction(tx);
-                expect(invoice.success).toBe(true);
+                const invoices = await node.sendTransaction(tx);
+                expect(invoices!.length).toBe(1);
+                expect(invoices![0].success).toBe(true);
             }
         );
     });
@@ -209,21 +209,17 @@ describe("transactions", () => {
             amount: 1
         });
         await node.signTransferInput(tx1, 0);
-        const invoice1 = await node.sendTransaction(tx1);
-        if (invoice1 == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice1.success).toBe(true);
+        const invoices1 = await node.sendTransaction(tx1);
+        expect(invoices1!.length).toBe(1);
+        expect(invoices1![0].success).toBe(true);
 
         const transferredAsset = tx1.getTransferredAsset(0);
         const tx2 = node.sdk.core.createAssetTransferTransaction();
         tx2.addBurns(transferredAsset);
         await node.signTransferBurn(tx2, 0);
-        const invoice2 = await node.sendTransaction(tx2);
-        if (invoice2 == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice2.success).toBe(true);
+        const invoices2 = await node.sendTransaction(tx2);
+        expect(invoices2!.length).toBe(1);
+        expect(invoices2![0].success).toBe(true);
 
         expect(await node.sdk.rpc.chain.getAsset(tx2.hash(), 0)).toBe(null);
     });
@@ -238,11 +234,9 @@ describe("transactions", () => {
             amount: 1
         });
         await node.signTransferInput(tx1, 0);
-        const invoice = await node.sendTransaction(tx1);
-        if (invoice == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice.success).toBe(true);
+        const invoices = await node.sendTransaction(tx1);
+        expect(invoices!.length).toBe(1);
+        expect(invoices![0].success).toBe(true);
 
         const tx2 = node.sdk.core.createAssetTransferTransaction();
         const {
@@ -278,11 +272,9 @@ describe("transactions", () => {
             amount: 1
         });
         await node.signTransferInput(tx1, 0);
-        const invoice1 = await node.sendTransaction(tx1);
-        if (invoice1 == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice1.success).toBe(true);
+        const invoices1 = await node.sendTransaction(tx1);
+        expect(invoices1!.length).toBe(1);
+        expect(invoices1![0].success).toBe(true);
 
         const transferredAsset = tx1.getTransferredAsset(0);
         const tx2 = node.sdk.core.createAssetTransferTransaction();
@@ -296,11 +288,9 @@ describe("transactions", () => {
             tx2.inputs[0],
             tx2.hashWithoutScript()
         );
-        const invoice2 = await node.sendTransaction(tx2);
-        if (invoice2 == null) {
-            throw Error("Cannot send a transaction");
-        }
-        expect(invoice2.success).toBe(false);
+        const invoices2 = await node.sendTransaction(tx2);
+        expect(invoices2!.length).toBe(1);
+        expect(invoices2![0].success).toBe(false);
 
         expect(await node.sdk.rpc.chain.getAsset(tx1.hash(), 0)).not.toBe(null);
     });
@@ -311,12 +301,9 @@ describe("transactions", () => {
         tx.addBurns(asset);
         await node.signTransactionP2PKH(tx.burns[0], tx.hashWithoutScript());
 
-        const invoice = await node.sendTransaction(tx);
-        if (invoice == null) {
-            throw Error("Cannot send a transaction");
-        }
-
-        expect(invoice.success).toBe(false);
+        const invoices = await node.sendTransaction(tx);
+        expect(invoices!.length).toBe(1);
+        expect(invoices![0].success).toBe(false);
     });
 
     describe("registrar", () => {
@@ -470,10 +457,11 @@ describe("transactions", () => {
             await node.sdk.key.signTransactionInput(tx, 0);
             tx.addBurns(assets[2]);
             await node.sdk.key.signTransactionBurn(tx, 0);
-            const invoice = await node.sendTransaction(tx);
-            expect(invoice.success).toBe(false);
-            expect(invoice.error!.type).toBe("InvalidTransaction");
-            expect(invoice.error!.content.type).toBe("FailedToUnlock");
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(false);
+            expect(invoices![0].error!.type).toBe("InvalidTransaction");
+            expect(invoices![0].error!.content.type).toBe("FailedToUnlock");
         });
 
         test("Can add burns after signing with the signature tag of single input", async () => {
@@ -490,11 +478,9 @@ describe("transactions", () => {
             });
             tx.addBurns(assets[2]);
             await node.sdk.key.signTransactionBurn(tx, 0);
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(true);
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(true);
         });
 
         // FIXME: (WIP) It fails
@@ -510,13 +496,11 @@ describe("transactions", () => {
             await node.sdk.key.signTransactionInput(tx, 0);
             tx.addInputs(assets[1]);
             await node.sdk.key.signTransactionInput(tx, 1);
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(false);
-            expect(invoice.error!.type).toBe("InvalidTransaction");
-            expect(invoice.error!.content.type).toBe("FailedToUnlock");
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(false);
+            expect(invoices![0].error!.type).toBe("InvalidTransaction");
+            expect(invoices![0].error!.content.type).toBe("FailedToUnlock");
         });
 
         test("Can add inputs after signing with the signature tag of single input", async () => {
@@ -533,11 +517,9 @@ describe("transactions", () => {
             });
             tx.addInputs(assets[1]);
             await node.sdk.key.signTransactionInput(tx, 1);
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(true);
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(true);
         });
 
         test("Can't add outputs after signing the signature tag of all outputs", async () => {
@@ -551,13 +533,11 @@ describe("transactions", () => {
                 });
             await node.sdk.key.signTransactionInput(tx, 0);
             tx.addOutputs({ assetType, amount: 500, recipient: address2 });
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(false);
-            expect(invoice.error!.type).toBe("InvalidTransaction");
-            expect(invoice.error!.content.type).toBe("FailedToUnlock");
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(false);
+            expect(invoices![0].error!.type).toBe("InvalidTransaction");
+            expect(invoices![0].error!.content.type).toBe("FailedToUnlock");
         });
 
         test("Can add outputs after signing the signature tag of some outputs", async () => {
@@ -576,11 +556,9 @@ describe("transactions", () => {
                 }
             });
             tx.addOutputs({ assetType, amount: 500, recipient: address2 });
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(true);
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(true);
         });
 
         test("Can only change the output protected by signature", async () => {
@@ -608,11 +586,9 @@ describe("transactions", () => {
             const address1Param = tx.outputs[0].parameters;
             const address2Param = tx.outputs[1].parameters;
             (tx.outputs[0].parameters as any) = address2Param;
-            const invoice = await node.sendTransaction(tx);
-            if (invoice == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice.success).toBe(false);
+            const invoices = await node.sendTransaction(tx);
+            expect(invoices!.length).toBe(1);
+            expect(invoices![0].success).toBe(false);
 
             (tx.outputs[0].parameters as any) = address1Param;
             (tx.seq as any) = 1;
@@ -624,11 +600,9 @@ describe("transactions", () => {
             });
 
             (tx.outputs[1].parameters as any) = address1Param;
-            const invoice2 = await node.sendTransaction(tx);
-            if (invoice2 == null) {
-                throw Error("Cannot send a transaction");
-            }
-            expect(invoice2.success).toBe(true);
+            const invoices2 = await node.sendTransaction(tx);
+            expect(invoices2!.length).toBe(1);
+            expect(invoices2![0].success).toBe(true);
         });
 
         describe("many outputs", () => {
@@ -658,11 +632,9 @@ describe("transactions", () => {
                         amount: 1000 - length,
                         recipient: address1
                     });
-                    const invoice = await node.sendTransaction(tx);
-                    if (invoice == null) {
-                        throw Error("Cannot send a transaction");
-                    }
-                    expect(invoice.success).toBe(true);
+                    const invoices = await node.sendTransaction(tx);
+                    expect(invoices!.length).toBe(1);
+                    expect(invoices![0].success).toBe(true);
                 }
             );
         });

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -835,9 +835,9 @@ codechain-sdk@^0.2.0-alpha.2:
     request-promise "^4.2.2"
     rlp "^2.0.0"
 
-"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#group-lib":
+"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#nonce-lib":
   version "0.5.1"
-  resolved "https://github.com/sgkim126/codechain-sdk-js.git#8f3e25224fc8c9191799e6dd0d8160a989b2cd34"
+  resolved "https://github.com/sgkim126/codechain-sdk-js.git#c63c57a201cdd6e6f77e5c5fb17a8ab475375e1d"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.5.4"

--- a/types/src/parcel/error.rs
+++ b/types/src/parcel/error.rs
@@ -30,8 +30,6 @@ use super::super::ShardId;
 pub enum Error {
     /// Parcel is already imported to the queue
     ParcelAlreadyImported,
-    /// Transaction is already imported in blockchain
-    TransactionAlreadyImported,
     /// Parcel is not valid anymore (state already has higher seq)
     Old,
     /// Parcel has too low fee
@@ -81,7 +79,6 @@ pub enum Error {
 }
 
 const ERROR_ID_PARCEL_ALREADY_IMPORTED: u8 = 1u8;
-const ERROR_ID_TRANSACTION_ALREADY_IMPORTED: u8 = 2u8;
 const ERROR_ID_OLD: u8 = 3u8;
 const ERROR_ID_TOO_CHEAP_TO_REPLACE: u8 = 4u8;
 const ERROR_ID_INVALID_NETWORK_ID: u8 = 5u8;
@@ -106,7 +103,6 @@ impl Error {
     fn item_count(&self) -> usize {
         match self {
             Error::ParcelAlreadyImported => 1,
-            Error::TransactionAlreadyImported => 1,
             Error::Old => 1,
             Error::TooCheapToReplace => 1,
             Error::InvalidNetworkId(_) => 2,
@@ -140,7 +136,6 @@ impl Encodable for Error {
         s.begin_list(self.item_count());
         match self {
             Error::ParcelAlreadyImported => s.append(&ERROR_ID_PARCEL_ALREADY_IMPORTED),
-            Error::TransactionAlreadyImported => s.append(&ERROR_ID_TRANSACTION_ALREADY_IMPORTED),
             Error::Old => s.append(&ERROR_ID_OLD),
             Error::TooCheapToReplace => s.append(&ERROR_ID_TOO_CHEAP_TO_REPLACE),
             Error::InvalidNetworkId(network_id) => s.append(&ERROR_ID_INVALID_NETWORK_ID).append(network_id),
@@ -181,7 +176,6 @@ impl Decodable for Error {
         let tag = rlp.val_at::<u8>(0)?;
         let error = match tag {
             ERROR_ID_PARCEL_ALREADY_IMPORTED => Error::ParcelAlreadyImported,
-            ERROR_ID_TRANSACTION_ALREADY_IMPORTED => Error::TransactionAlreadyImported,
             ERROR_ID_OLD => Error::Old,
             ERROR_ID_TOO_CHEAP_TO_REPLACE => Error::TooCheapToReplace,
             ERROR_ID_INVALID_NETWORK_ID => Error::InvalidNetworkId(rlp.val_at(1)?),
@@ -224,7 +218,6 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> FormatResult {
         let msg: String = match self {
             Error::ParcelAlreadyImported => "The parcel is already imported".into(),
-            Error::TransactionAlreadyImported => "The transaction is already imported".into(),
             Error::Old => "No longer valid".into(),
             Error::TooCheapToReplace => "Fee too low to replace".into(),
             Error::InvalidNetworkId(network_id) => format!("{} is an invalid network id", network_id),

--- a/vm/src/tests/executor_tests/chk_multi_sig.rs
+++ b/vm/src/tests/executor_tests/chk_multi_sig.rs
@@ -35,7 +35,6 @@ fn valid_multi_sig_0_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -76,7 +75,6 @@ fn valid_multi_sig_1_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -99,7 +97,6 @@ fn valid_multi_sig_1_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -129,7 +126,6 @@ fn valid_multi_sig_2_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -152,7 +148,6 @@ fn valid_multi_sig_2_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -184,7 +179,6 @@ fn invalid_multi_sig_1_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -207,7 +201,6 @@ fn invalid_multi_sig_1_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -238,7 +231,6 @@ fn invalid_multi_sig_2_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -261,7 +253,6 @@ fn invalid_multi_sig_2_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -293,7 +284,6 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -316,7 +306,6 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -327,7 +316,6 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -359,7 +347,6 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -382,7 +369,6 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -414,7 +400,6 @@ fn invalid_multi_sig_with_less_sig_than_m() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -437,7 +422,6 @@ fn invalid_multi_sig_with_less_sig_than_m() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -467,7 +451,6 @@ fn invalid_multi_sig_with_more_sig_than_m() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -490,7 +473,6 @@ fn invalid_multi_sig_with_more_sig_than_m() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -522,7 +504,6 @@ fn invalid_multi_sig_with_too_many_arg() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -543,7 +524,6 @@ fn invalid_multi_sig_with_too_many_arg() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),

--- a/vm/src/tests/executor_tests/chk_sig.rs
+++ b/vm/src/tests/executor_tests/chk_sig.rs
@@ -35,7 +35,6 @@ fn valid_pay_to_public_key() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -56,7 +55,6 @@ fn valid_pay_to_public_key() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -79,7 +77,6 @@ fn invalid_pay_to_public_key() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -100,7 +97,6 @@ fn invalid_pay_to_public_key() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -165,7 +161,6 @@ fn sign_all_input_all_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -177,7 +172,6 @@ fn sign_all_input_all_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone(), input1],
             outputs: vec![output0, output1],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -241,7 +235,6 @@ fn sign_single_input_all_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -253,7 +246,6 @@ fn sign_single_input_all_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0, output1],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b10 as u8]),
@@ -316,7 +308,6 @@ fn sign_all_input_partial_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -328,7 +319,6 @@ fn sign_all_input_partial_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone(), input1],
             outputs: vec![output0],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b1, 0b00000101 as u8]),
@@ -391,7 +381,6 @@ fn sign_single_input_partial_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -403,7 +392,6 @@ fn sign_single_input_partial_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b1, 0b00000100 as u8]),
@@ -446,7 +434,6 @@ fn distinguish_sign_single_input_with_sign_all() {
         burns: Vec::new(),
         inputs: vec![input0.clone()],
         outputs: vec![output0.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -458,7 +445,6 @@ fn distinguish_sign_single_input_with_sign_all() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -502,7 +488,6 @@ fn distinguish_sign_single_output_with_sign_all() {
         burns: Vec::new(),
         inputs: vec![input0.clone()],
         outputs: vec![output0.clone()],
-        nonce: 0,
     };
 
     // Execute sciprt in input0
@@ -514,7 +499,6 @@ fn distinguish_sign_single_output_with_sign_all() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
-            nonce: 0,
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),

--- a/vm/src/tests/executor_tests/executor.rs
+++ b/vm/src/tests/executor_tests/executor.rs
@@ -83,7 +83,6 @@ fn simple_success() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -115,7 +114,6 @@ fn simple_failure() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -146,7 +144,6 @@ fn simple_burn() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -173,7 +170,6 @@ fn underflow() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -200,7 +196,6 @@ fn out_of_memory() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -239,7 +234,6 @@ fn invalid_unlock_script() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -266,7 +260,6 @@ fn conditional_burn() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -316,7 +309,6 @@ fn _blake256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -392,7 +384,6 @@ fn _ripemd160() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -476,7 +467,6 @@ fn _sha256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -560,7 +550,6 @@ fn _keccak256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -643,7 +632,6 @@ fn dummy_tx() -> Transaction {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     }
 }
 
@@ -887,7 +875,6 @@ fn copy_stack_underflow() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
-        nonce: 0,
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {


### PR DESCRIPTION
Currently, CodeChain rejects the duplicated transactions, so asset
transactions have meaningless nonce to change the hash of the
transaction.

This patch makes CodeChain allow the duplicated transactions. So the
nonce of asset transactions are removed and changes
chain_getTransactionInvoice to to chain_getTransactionInvoices.