### PR TITLE
Closing a block can fail

### DIFF
--- a/core/src/consensus/simple_poa/mod.rs
+++ b/core/src/consensus/simple_poa/mod.rs
@@ -231,7 +231,7 @@ mod tests {
         let b = OpenBlock::new(engine, db, &genesis_header, Default::default(), vec![], false).unwrap();
         let parent_parcels_root = genesis_header.parcels_root().clone();
         let parent_invoices_root = genesis_header.invoices_root().clone();
-        let b = b.close_and_lock(parent_parcels_root, parent_invoices_root);
+        let b = b.close_and_lock(parent_parcels_root, parent_invoices_root).unwrap();
         if let Seal::Regular(seal) = engine.generate_seal(b.block(), &genesis_header) {
             assert!(b.try_seal(engine, seal).is_ok());
         }

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -93,7 +93,7 @@ mod tests {
         let b = OpenBlock::new(engine, db, &genesis_header, Default::default(), vec![], false).unwrap();
         let parent_parcels_root = genesis_header.parcels_root().clone();
         let parent_invoices_root = genesis_header.invoices_root().clone();
-        let b = b.close_and_lock(parent_parcels_root, parent_invoices_root);
+        let b = b.close_and_lock(parent_parcels_root, parent_invoices_root).unwrap();
         if let Seal::Regular(seal) = engine.generate_seal(b.block(), &genesis_header) {
             assert!(b.try_seal(engine, seal).is_ok());
         }

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -1012,7 +1012,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let b = b.close(*genesis_header.parcels_root(), *genesis_header.invoices_root());
+        let b = b.close(*genesis_header.parcels_root(), *genesis_header.invoices_root()).unwrap();
         if let Seal::Proposal(seal) = scheme.engine.generate_seal(b.block(), &genesis_header) {
             (b, seal)
         } else {

--- a/core/src/miner/sealing_queue.rs
+++ b/core/src/miner/sealing_queue.rs
@@ -88,7 +88,7 @@ mod tests {
         let b = OpenBlock::new(&*scheme.engine, db, &genesis_header, address, vec![], false).unwrap();
         let parent_parcels_root = genesis_header.parcels_root().clone();
         let parent_invoices_root = genesis_header.invoices_root().clone();
-        b.close(parent_parcels_root, parent_invoices_root)
+        b.close(parent_parcels_root, parent_invoices_root).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
`on_close_block` callback and `commit` method of `StateDB` are called in `close` method.
Both of them can fail, but the current code doesn't handle them.