### PR TITLE
Remove local message feature from NetworkExtension

### DIFF
--- a/network/src/client.rs
+++ b/network/src/client.rs
@@ -19,7 +19,6 @@ use std::sync::{Arc, Weak};
 
 use cio::IoChannel;
 use parking_lot::RwLock;
-use rlp::Encodable;
 use time::Duration;
 
 use super::p2p::Message as P2pMessage;
@@ -97,21 +96,6 @@ impl Api for ClientApi {
             })?)
         } else {
             Err(NetworkExtensionError::ExtensionDropped)
-        }
-    }
-
-    fn send_local_message(&self, message: &Encodable) {
-        if let Some(extension) = self.extension.upgrade() {
-            let extension_name = extension.name().to_string();
-            let message = message.rlp_bytes().into_vec();
-            if let Err(err) = self.timer_channel.send(TimerMessage::LocalMessage {
-                extension_name,
-                message,
-            }) {
-                cwarn!(NETAPI, "Cannot send local message: {:?}", err);
-            }
-        } else {
-            cdebug!(NETAPI, "The extension already dropped");
         }
     }
 }
@@ -208,8 +192,6 @@ impl Client {
     }
 
     define_method!(on_timeout; timer_id, TimerToken);
-
-    define_method!(on_local_message; message, &[u8]);
 }
 
 #[cfg(test)]
@@ -220,7 +202,6 @@ mod tests {
 
     use cio::IoService;
     use parking_lot::Mutex;
-    use rlp::Encodable;
     use time::Duration;
 
     use super::super::SocketAddr;
@@ -243,10 +224,6 @@ mod tests {
         }
 
         fn clear_timer(&self, _timer_id: usize) -> NetworkExtensionResult<()> {
-            unimplemented!()
-        }
-
-        fn send_local_message(&self, _message: &Encodable) {
             unimplemented!()
         }
     }

--- a/network/src/extension.rs
+++ b/network/src/extension.rs
@@ -18,7 +18,6 @@ use std::result;
 use std::sync::Arc;
 
 use cio::IoError;
-use rlp::Encodable;
 use time::Duration;
 
 use super::NodeId;
@@ -46,8 +45,6 @@ pub trait Api: Send + Sync {
     fn set_timer(&self, timer: TimerToken, d: Duration) -> Result<()>;
     fn set_timer_once(&self, timer: TimerToken, d: Duration) -> Result<()>;
     fn clear_timer(&self, timer: TimerToken) -> Result<()>;
-
-    fn send_local_message(&self, message: &Encodable);
 }
 
 pub trait Extension: Send + Sync {
@@ -63,6 +60,4 @@ pub trait Extension: Send + Sync {
     fn on_message(&self, _node: &NodeId, _message: &[u8]) {}
 
     fn on_timeout(&self, _timer: TimerToken) {}
-
-    fn on_local_message(&self, _message: &[u8]) {}
 }

--- a/network/src/test/client.rs
+++ b/network/src/test/client.rs
@@ -19,7 +19,6 @@ use std::ops::Deref;
 use std::sync::{Arc, Weak};
 
 use parking_lot::Mutex;
-use rlp::Encodable;
 use time::Duration;
 
 use super::super::extension::{Api, Extension, Result, TimerToken};
@@ -105,11 +104,6 @@ impl Api for TestApi {
         }
         self.calls.lock().push_back(Call::ClearTimer(token));
         Ok(())
-    }
-
-    fn send_local_message(&self, message: &Encodable) {
-        let message = message.rlp_bytes().into_vec();
-        self.calls.lock().push_back(Call::SendLocalMessage(message));
     }
 }
 

--- a/network/src/timer/handler.rs
+++ b/network/src/timer/handler.rs
@@ -42,10 +42,6 @@ pub enum Message {
         extension_name: String,
         timer_id: TimerId,
     },
-    LocalMessage {
-        extension_name: String,
-        message: Vec<u8>,
-    },
 }
 
 #[derive(Debug)]
@@ -128,13 +124,6 @@ impl IoHandler<Message> for Handler {
                 if let Some(token) = timer.remove_by_info(extension_name.clone(), *timer_id) {
                     io.clear_timer(token);
                 }
-                Ok(())
-            }
-            Message::LocalMessage {
-                extension_name,
-                message,
-            } => {
-                self.client.on_local_message(extension_name, message);
                 Ok(())
             }
         }


### PR DESCRIPTION
1. It is not necessary for current usage.
2. Its implementation is overloaded on top of the IoChannel<TimerMesssage>

We need to revisit it with an appropriate implementation when it is really needed.