### PR TITLE
Use crate keyword

### DIFF
--- a/codechain/config/mod.rs
+++ b/codechain/config/mod.rs
@@ -24,7 +24,7 @@ use ccore::{MinerOptions, StratumConfig};
 use ckey::PlatformAddress;
 use clap;
 use cnetwork::{FilterEntry, NetworkConfig, SocketAddr};
-use rpc::{RpcHttpConfig, RpcIpcConfig, RpcWsConfig};
+use crate::rpc::{RpcHttpConfig, RpcIpcConfig, RpcWsConfig};
 use toml;
 
 pub use self::chain_type::ChainType;

--- a/codechain/main.rs
+++ b/codechain/main.rs
@@ -63,8 +63,8 @@ mod subcommand;
 
 use app_dirs::AppInfo;
 
-use self::run_node::run_node;
-use self::subcommand::run_subcommand;
+use crate::run_node::run_node;
+use crate::subcommand::run_subcommand;
 
 pub const APP_INFO: AppInfo = AppInfo {
     name: "codechain",

--- a/codechain/rpc.rs
+++ b/codechain/rpc.rs
@@ -18,9 +18,9 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::rpc_apis;
 use crpc::{start_http, start_ipc, start_ws, HttpServer, IpcServer, WsError, WsErrorKind, WsServer};
 use crpc::{Compatibility, MetaIoHandler};
-use rpc_apis;
 
 #[derive(Debug, PartialEq)]
 pub struct RpcHttpConfig {

--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -39,12 +39,12 @@ use ctrlc::CtrlC;
 use fdlimit::raise_fd_limit;
 use parking_lot::{Condvar, Mutex};
 
-use super::config::{self, load_config};
-use super::constants::DEFAULT_KEYS_PATH;
-use super::dummy_network_service::DummyNetworkService;
-use super::json::PasswordFile;
-use super::rpc::{rpc_http_start, rpc_ipc_start, rpc_ws_start};
-use super::rpc_apis::ApiDependencies;
+use crate::config::{self, load_config};
+use crate::constants::DEFAULT_KEYS_PATH;
+use crate::dummy_network_service::DummyNetworkService;
+use crate::json::PasswordFile;
+use crate::rpc::{rpc_http_start, rpc_ipc_start, rpc_ws_start};
+use crate::rpc_apis::ApiDependencies;
 
 fn network_start(timer_loop: TimerLoop, cfg: &NetworkConfig) -> Result<Arc<NetworkService>, String> {
     cinfo!(NETWORK, "Handshake Listening on {}:{}", cfg.address, cfg.port);

--- a/codechain/subcommand/account_command.rs
+++ b/codechain/subcommand/account_command.rs
@@ -27,8 +27,8 @@ use clap::ArgMatches;
 use clogger::{self, LoggerConfig};
 use primitives::clean_0x;
 
-use super::super::config::ChainType;
-use super::super::constants::DEFAULT_KEYS_PATH;
+use crate::config::ChainType;
+use crate::constants::DEFAULT_KEYS_PATH;
 
 pub fn run_account_command(matches: ArgMatches) -> Result<(), String> {
     if matches.subcommand.is_none() {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -28,10 +28,10 @@ use cvm::ChainTimeInfo;
 use primitives::{Bytes, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::consensus::CodeChainEngine;
-use super::error::{BlockError, Error};
-use super::header::{Header, Seal};
-use super::parcel::{SignedParcel, UnverifiedParcel};
+use crate::consensus::CodeChainEngine;
+use crate::error::{BlockError, Error};
+use crate::header::{Header, Seal};
+use crate::parcel::{SignedParcel, UnverifiedParcel};
 
 /// A block, encoded as it is on the block chain.
 #[derive(Debug, Clone, PartialEq)]
@@ -434,8 +434,8 @@ pub fn enact<C: ChainTimeInfo>(
 
 #[cfg(test)]
 mod tests {
-    use super::super::scheme::Scheme;
-    use super::super::tests::helpers::get_temp_state_db;
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     use super::*;
 

--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -26,18 +26,18 @@ use parking_lot::RwLock;
 use primitives::H256;
 use rlp::RlpStream;
 
-use super::super::blockchain_info::BlockChainInfo;
-use super::super::consensus::epoch::{PendingTransition as PendingEpochTransition, Transition as EpochTransition};
-use super::super::db::{self, Readable, Writable};
-use super::super::encoded;
-use super::super::parcel::LocalizedParcel;
-use super::super::views::{BlockView, HeaderView};
 use super::block_info::BlockLocation;
 use super::body_db::{BodyDB, BodyProvider};
 use super::extras::{BlockDetails, EpochTransitions, ParcelAddress, TransactionAddress, EPOCH_KEY_PREFIX};
 use super::headerchain::{HeaderChain, HeaderProvider};
 use super::invoice_db::{InvoiceDB, InvoiceProvider};
 use super::route::{tree_route, ImportRoute};
+use crate::blockchain_info::BlockChainInfo;
+use crate::consensus::epoch::{PendingTransition as PendingEpochTransition, Transition as EpochTransition};
+use crate::db::{self, Readable, Writable};
+use crate::encoded;
+use crate::parcel::LocalizedParcel;
+use crate::views::{BlockView, HeaderView};
 
 const BEST_BLOCK_KEY: &[u8] = b"best-block";
 

--- a/core/src/blockchain/body_db.rs
+++ b/core/src/blockchain/body_db.rs
@@ -25,11 +25,11 @@ use primitives::{Bytes, H256};
 use rlp::RlpStream;
 use rlp_compress::{blocks_swapper, compress, decompress};
 
-use super::super::db::{self, CacheUpdatePolicy, Readable, Writable};
-use super::super::views::BlockView;
-use super::super::{encoded, UnverifiedParcel};
 use super::block_info::BlockLocation;
 use super::extras::{ParcelAddress, TransactionAddress};
+use crate::db::{self, CacheUpdatePolicy, Readable, Writable};
+use crate::views::BlockView;
+use crate::{encoded, UnverifiedParcel};
 
 pub struct BodyDB {
     // block cache

--- a/core/src/blockchain/extras.rs
+++ b/core/src/blockchain/extras.rs
@@ -23,9 +23,9 @@ use heapsize::HeapSizeOf;
 use kvdb::PREFIX_LEN as DB_PREFIX_LEN;
 use primitives::{H256, H264, U256};
 
-use super::super::consensus::epoch::{PendingTransition as PendingEpochTransition, Transition as EpochTransition};
-use super::super::db::Key;
-use super::super::types::ParcelId;
+use crate::consensus::epoch::{PendingTransition as PendingEpochTransition, Transition as EpochTransition};
+use crate::db::Key;
+use crate::types::ParcelId;
 
 /// Represents index of extra data in database
 #[derive(Copy, Debug, Hash, Eq, PartialEq, Clone)]

--- a/core/src/blockchain/headerchain.rs
+++ b/core/src/blockchain/headerchain.rs
@@ -24,13 +24,13 @@ use parking_lot::RwLock;
 use primitives::{Bytes, H256};
 use rlp_compress::{blocks_swapper, compress, decompress};
 
-use super::super::db::{self, CacheUpdatePolicy, Readable, Writable};
-use super::super::encoded;
-use super::super::header::Header;
-use super::super::views::HeaderView;
 use super::block_info::BlockLocation;
 use super::extras::BlockDetails;
 use super::route::tree_route;
+use crate::db::{self, CacheUpdatePolicy, Readable, Writable};
+use crate::encoded;
+use crate::header::Header;
+use crate::views::HeaderView;
 
 const BEST_HEADER_KEY: &[u8] = b"best-header";
 

--- a/core/src/blockchain/invoice_db.rs
+++ b/core/src/blockchain/invoice_db.rs
@@ -22,8 +22,8 @@ use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::RwLock;
 use primitives::H256;
 
-use super::super::db::{self, CacheUpdatePolicy, Readable, Writable};
 use super::extras::ParcelAddress;
+use crate::db::{self, CacheUpdatePolicy, Readable, Writable};
 
 /// Structure providing fast access to blockchain data.
 ///

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -36,18 +36,6 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use primitives::{Bytes, H256, U256};
 use rlp::UntrustedRlp;
 
-use super::super::block::{ClosedBlock, IsBlock, OpenBlock, SealedBlock};
-use super::super::blockchain::{
-    BlockChain, BlockProvider, BodyProvider, HeaderProvider, InvoiceProvider, ParcelAddress, TransactionAddress,
-};
-use super::super::consensus::CodeChainEngine;
-use super::super::encoded;
-use super::super::error::{BlockImportError, Error, ImportError, SchemeError};
-use super::super::miner::{Miner, MinerService};
-use super::super::parcel::{LocalizedParcel, SignedParcel, UnverifiedParcel};
-use super::super::scheme::{CommonParams, Scheme};
-use super::super::service::ClientIoMessage;
-use super::super::types::{BlockId, BlockStatus, ParcelId, VerificationQueueInfo as BlockQueueInfo};
 use super::importer::Importer;
 use super::{
     AccountData, AssetClient, Balance, BlockChain as BlockChainTrait, BlockChainClient, BlockChainInfo, BlockInfo,
@@ -55,6 +43,18 @@ use super::{
     Error as ClientError, ExecuteClient, ImportBlock, ImportResult, ImportSealedBlock, MiningBlockChainClient,
     ParcelInfo, PrepareOpenBlock, RegularKey, RegularKeyOwner, ReopenBlock, Seq, Shard, StateOrBlock, TransactionInfo,
 };
+use crate::block::{ClosedBlock, IsBlock, OpenBlock, SealedBlock};
+use crate::blockchain::{
+    BlockChain, BlockProvider, BodyProvider, HeaderProvider, InvoiceProvider, ParcelAddress, TransactionAddress,
+};
+use crate::consensus::CodeChainEngine;
+use crate::encoded;
+use crate::error::{BlockImportError, Error, ImportError, SchemeError};
+use crate::miner::{Miner, MinerService};
+use crate::parcel::{LocalizedParcel, SignedParcel, UnverifiedParcel};
+use crate::scheme::{CommonParams, Scheme};
+use crate::service::ClientIoMessage;
+use crate::types::{BlockId, BlockStatus, ParcelId, VerificationQueueInfo as BlockQueueInfo};
 
 const MAX_MEM_POOL_SIZE: usize = 4096;
 
@@ -410,8 +410,8 @@ impl TransactionInfo for Client {
 
 impl ImportBlock for Client {
     fn import_block(&self, bytes: Bytes) -> Result<H256, BlockImportError> {
-        use super::super::verification::queue::kind::blocks::Unverified;
-        use super::super::verification::queue::kind::BlockLike;
+        use crate::verification::queue::kind::blocks::Unverified;
+        use crate::verification::queue::kind::BlockLike;
 
         let unverified = Unverified::new(bytes);
         {

--- a/core/src/client/config.rs
+++ b/core/src/client/config.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 
 use kvdb_rocksdb::CompactionProfile;
 
-use super::super::verification::{QueueConfig, VerifierType};
+use crate::verification::{QueueConfig, VerifierType};
 
 /// Client state db compaction profile
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -24,20 +24,20 @@ use parking_lot::Mutex;
 use primitives::H256;
 use rlp::Encodable;
 
-use super::super::block::{enact, IsBlock, LockedBlock};
-use super::super::blockchain::{BlockChain, BodyProvider, HeaderProvider, ImportRoute};
-use super::super::consensus::epoch::Transition as EpochTransition;
-use super::super::consensus::CodeChainEngine;
-use super::super::error::Error;
-use super::super::header::Header;
-use super::super::miner::{Miner, MinerService};
-use super::super::service::ClientIoMessage;
-use super::super::types::BlockId;
-use super::super::verification::queue::{BlockQueue, HeaderQueue};
-use super::super::verification::{self, PreverifiedBlock, Verifier};
-use super::super::views::{BlockView, HeaderView};
 use super::BlockInfo;
 use super::{Client, ClientConfig};
+use crate::block::{enact, IsBlock, LockedBlock};
+use crate::blockchain::{BlockChain, BodyProvider, HeaderProvider, ImportRoute};
+use crate::consensus::epoch::Transition as EpochTransition;
+use crate::consensus::CodeChainEngine;
+use crate::error::Error;
+use crate::header::Header;
+use crate::miner::{Miner, MinerService};
+use crate::service::ClientIoMessage;
+use crate::types::BlockId;
+use crate::verification::queue::{BlockQueue, HeaderQueue};
+use crate::verification::{self, PreverifiedBlock, Verifier};
+use crate::views::{BlockView, HeaderView};
 
 pub struct Importer {
     /// Lock used during block import
@@ -268,13 +268,13 @@ impl Importer {
     // check for epoch end signal and write pending transition if it occurs.
     // state for the given block must be available.
     fn check_epoch_end_signal(&self, header: &Header, chain: &BlockChain, batch: &mut DBTransaction) {
-        use super::super::consensus::EpochChange;
+        use crate::consensus::EpochChange;
         let hash = header.hash();
 
         match self.engine.signals_epoch_end(header) {
             EpochChange::Yes(proof) => {
-                use super::super::consensus::epoch::PendingTransition;
-                use super::super::consensus::Proof;
+                use crate::consensus::epoch::PendingTransition;
+                use crate::consensus::Proof;
 
                 let Proof::Known(proof) = proof;
                 cdebug!(CLIENT, "Block {} signals epoch end.", hash);

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -41,13 +41,13 @@ use cvm::ChainTimeInfo;
 use kvdb::KeyValueDB;
 use primitives::{Bytes, H256, U256};
 
-use super::block::{ClosedBlock, OpenBlock, SealedBlock};
-use super::blockchain_info::BlockChainInfo;
-use super::encoded;
-use super::error::{BlockImportError, Error as CoreError};
-use super::parcel::{LocalizedParcel, SignedParcel};
-use super::scheme::CommonParams;
-use super::types::{BlockId, BlockStatus, ParcelId, VerificationQueueInfo as BlockQueueInfo};
+use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
+use crate::blockchain_info::BlockChainInfo;
+use crate::encoded;
+use crate::error::{BlockImportError, Error as CoreError};
+use crate::parcel::{LocalizedParcel, SignedParcel};
+use crate::scheme::CommonParams;
+use crate::types::{BlockId, BlockStatus, ParcelId, VerificationQueueInfo as BlockQueueInfo};
 
 /// Provides `chain_info` method
 pub trait ChainInfo {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -50,22 +50,22 @@ use parking_lot::RwLock;
 use primitives::{Bytes, H256, U256};
 use rlp::*;
 
-use super::super::block::{ClosedBlock, OpenBlock, SealedBlock};
-use super::super::blockchain_info::BlockChainInfo;
-use super::super::client::ImportResult;
-use super::super::client::{
+use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
+use crate::blockchain_info::BlockChainInfo;
+use crate::client::ImportResult;
+use crate::client::{
     AccountData, Balance, BlockChain, BlockChainClient, BlockInfo, BlockProducer, BlockStatus, ChainInfo, ImportBlock,
     ImportSealedBlock, MiningBlockChainClient, ParcelInfo, PrepareOpenBlock, RegularKeyOwner, ReopenBlock, Seq,
     StateOrBlock, TransactionInfo,
 };
-use super::super::db::{COL_STATE, NUM_COLUMNS};
-use super::super::encoded;
-use super::super::error::BlockImportError;
-use super::super::header::Header as BlockHeader;
-use super::super::miner::{Miner, MinerService, ParcelImportResult};
-use super::super::parcel::{LocalizedParcel, SignedParcel};
-use super::super::scheme::Scheme;
-use super::super::types::{BlockId, ParcelId, VerificationQueueInfo as QueueInfo};
+use crate::db::{COL_STATE, NUM_COLUMNS};
+use crate::encoded;
+use crate::error::BlockImportError;
+use crate::header::Header as BlockHeader;
+use crate::miner::{Miner, MinerService, ParcelImportResult};
+use crate::parcel::{LocalizedParcel, SignedParcel};
+use crate::scheme::Scheme;
+use crate::types::{BlockId, ParcelId, VerificationQueueInfo as QueueInfo};
 
 /// Test client.
 pub struct TestBlockChainClient {

--- a/core/src/codechain_machine.rs
+++ b/core/src/codechain_machine.rs
@@ -21,12 +21,12 @@ use ctypes::machine::{Machine, WithBalances};
 use ctypes::parcel::{Action, Error as ParcelError};
 use ctypes::transaction::{Error as TransactionError, Timelock, Transaction};
 
-use super::block::{ExecutedBlock, IsBlock};
-use super::client::{BlockInfo, TransactionInfo};
-use super::error::Error;
-use super::header::Header;
-use super::parcel::{SignedParcel, UnverifiedParcel};
-use super::scheme::CommonParams;
+use crate::block::{ExecutedBlock, IsBlock};
+use crate::client::{BlockInfo, TransactionInfo};
+use crate::error::Error;
+use crate::header::Header;
+use crate::parcel::{SignedParcel, UnverifiedParcel};
+use crate::scheme::CommonParams;
 
 pub struct CodeChainMachine {
     params: CommonParams,
@@ -168,7 +168,7 @@ impl CodeChainMachine {
 impl Machine for CodeChainMachine {
     type Header = Header;
     type LiveBlock = ExecutedBlock;
-    type EngineClient = super::client::EngineClient;
+    type EngineClient = crate::client::EngineClient;
 
     type Error = Error;
 }

--- a/core/src/consensus/blake_pow/mod.rs
+++ b/core/src/consensus/blake_pow/mod.rs
@@ -26,12 +26,12 @@ use primitives::U256;
 use rlp::UntrustedRlp;
 
 use self::params::BlakePoWParams;
-use super::super::block::{ExecutedBlock, IsBlock};
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::consensus::EngineType;
-use super::super::error::{BlockError, Error};
-use super::super::header::Header;
 use super::ConsensusEngine;
+use crate::block::{ExecutedBlock, IsBlock};
+use crate::codechain_machine::CodeChainMachine;
+use crate::consensus::EngineType;
+use crate::error::{BlockError, Error};
+use crate::header::Header;
 
 /// BlakePoW specific seal
 #[derive(Debug, PartialEq)]

--- a/core/src/consensus/cuckoo/mod.rs
+++ b/core/src/consensus/cuckoo/mod.rs
@@ -27,12 +27,12 @@ use primitives::U256;
 use rlp::UntrustedRlp;
 
 use self::params::CuckooParams;
-use super::super::block::{ExecutedBlock, IsBlock};
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::consensus::EngineType;
-use super::super::error::{BlockError, Error};
-use super::super::header::Header;
 use super::ConsensusEngine;
+use crate::block::{ExecutedBlock, IsBlock};
+use crate::codechain_machine::CodeChainMachine;
+use crate::consensus::EngineType;
+use crate::error::{BlockError, Error};
+use crate::header::Header;
 
 /// Cuckoo specific seal
 #[derive(Debug, PartialEq)]
@@ -184,9 +184,9 @@ impl ConsensusEngine<CodeChainMachine> for Cuckoo {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::block::OpenBlock;
-    use super::super::super::scheme::Scheme;
-    use super::super::super::tests::helpers::get_temp_state_db;
+    use crate::block::OpenBlock;
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     use super::*;
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -44,13 +44,13 @@ use ctypes::util::unexpected::{Mismatch, OutOfBounds};
 use primitives::{Bytes, H256, U256};
 
 use self::epoch::{EpochVerifier, NoOp, PendingTransition};
-use super::account_provider::AccountProvider;
-use super::block::SealedBlock;
-use super::codechain_machine::CodeChainMachine;
-use super::error::Error;
-use super::header::Header;
-use super::parcel::{SignedParcel, UnverifiedParcel};
-use super::scheme::CommonParams;
+use crate::account_provider::AccountProvider;
+use crate::block::SealedBlock;
+use crate::codechain_machine::CodeChainMachine;
+use crate::error::Error;
+use crate::header::Header;
+use crate::parcel::{SignedParcel, UnverifiedParcel};
+use crate::scheme::CommonParams;
 
 /// Seal type.
 #[derive(Debug, PartialEq, Eq)]

--- a/core/src/consensus/null_engine/mod.rs
+++ b/core/src/consensus/null_engine/mod.rs
@@ -19,9 +19,9 @@ mod params;
 use ctypes::machine::{Header, LiveBlock, Parcels, WithBalances};
 
 use self::params::NullEngineParams;
-use super::super::consensus::EngineType;
-use super::super::SignedParcel;
 use super::ConsensusEngine;
+use crate::consensus::EngineType;
+use crate::SignedParcel;
 
 /// An engine which does not provide any consensus mechanism and does not seal blocks.
 pub struct NullEngine<M> {

--- a/core/src/consensus/signer.rs
+++ b/core/src/consensus/signer.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use ckey::{Address, Password, Signature};
 use primitives::H256;
 
-use super::super::account_provider::{AccountProvider, SignError};
+use crate::account_provider::{AccountProvider, SignError};
 
 /// Everything that an Engine needs to sign messages.
 pub struct EngineSigner {

--- a/core/src/consensus/simple_poa/mod.rs
+++ b/core/src/consensus/simple_poa/mod.rs
@@ -24,17 +24,17 @@ use parking_lot::RwLock;
 use primitives::H256;
 
 use self::params::SimplePoAParams;
-use super::super::account_provider::AccountProvider;
-use super::super::block::{ExecutedBlock, IsBlock};
-use super::super::client::EngineClient;
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::consensus::EngineType;
-use super::super::error::{BlockError, Error};
-use super::super::header::Header;
 use super::signer::EngineSigner;
 use super::validator_set::validator_list::ValidatorList;
 use super::validator_set::ValidatorSet;
 use super::{ConsensusEngine, ConstructedVerifier, EngineError, Seal};
+use crate::account_provider::AccountProvider;
+use crate::block::{ExecutedBlock, IsBlock};
+use crate::client::EngineClient;
+use crate::codechain_machine::CodeChainMachine;
+use crate::consensus::EngineType;
+use crate::error::{BlockError, Error};
+use crate::header::Header;
 
 pub struct SimplePoA {
     machine: CodeChainMachine,
@@ -198,9 +198,9 @@ impl ConsensusEngine<CodeChainMachine> for SimplePoA {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::block::OpenBlock;
-    use super::super::super::scheme::Scheme;
-    use super::super::super::tests::helpers::get_temp_state_db;
+    use crate::block::OpenBlock;
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     use super::*;
 

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -19,9 +19,9 @@ mod params;
 use ctypes::machine::{Header, LiveBlock, Parcels, WithBalances};
 
 use self::params::SoloParams;
-use super::super::consensus::EngineType;
-use super::super::SignedParcel;
 use super::{ConsensusEngine, Seal};
+use crate::consensus::EngineType;
+use crate::SignedParcel;
 
 /// A consensus engine which does not provide any consensus mechanism.
 pub struct Solo<M> {
@@ -78,10 +78,10 @@ where
 mod tests {
     use primitives::H520;
 
-    use super::super::super::block::{IsBlock, OpenBlock};
-    use super::super::super::header::Header;
-    use super::super::super::scheme::Scheme;
-    use super::super::super::tests::helpers::get_temp_state_db;
+    use crate::block::{IsBlock, OpenBlock};
+    use crate::header::Header;
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     use super::*;
 

--- a/core/src/consensus/tendermint/message.rs
+++ b/core/src/consensus/tendermint/message.rs
@@ -21,10 +21,10 @@ use ckey::{public_to_address, recover, Address, Signature};
 use primitives::{Bytes, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::super::error::Error;
-use super::super::super::header::Header;
 use super::super::vote_collector::Message;
 use super::{BlockHash, Height, Step, View};
+use crate::error::Error;
+use crate::header::Header;
 
 /// Complete step of the consensus process.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -36,18 +36,18 @@ use time::Duration;
 
 use self::message::*;
 pub use self::params::{TendermintParams, TendermintTimeouts};
-use super::super::account_provider::AccountProvider;
-use super::super::block::*;
-use super::super::client::EngineClient;
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::consensus::EngineType;
-use super::super::error::{BlockError, Error};
-use super::super::header::Header;
 use super::signer::EngineSigner;
 use super::validator_set::validator_list::ValidatorList;
 use super::validator_set::ValidatorSet;
 use super::vote_collector::VoteCollector;
 use super::{ConsensusEngine, ConstructedVerifier, EngineError, EpochChange, Seal};
+use crate::account_provider::AccountProvider;
+use crate::block::*;
+use crate::client::EngineClient;
+use crate::codechain_machine::CodeChainMachine;
+use crate::consensus::EngineType;
+use crate::error::{BlockError, Error};
+use crate::header::Header;
 
 /// Timer token representing the consensus step timeouts.
 pub const ENGINE_TIMEOUT_TOKEN: TimerToken = 23;
@@ -972,10 +972,10 @@ impl TimeoutHandler for TendermintExtension {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::block::{ClosedBlock, IsBlock, OpenBlock};
-    use super::super::super::consensus::CodeChainEngine;
-    use super::super::super::scheme::Scheme;
-    use super::super::super::tests::helpers::get_temp_state_db;
+    use crate::block::{ClosedBlock, IsBlock, OpenBlock};
+    use crate::consensus::CodeChainEngine;
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     use super::*;
 

--- a/core/src/consensus/validator_set/mod.rs
+++ b/core/src/consensus/validator_set/mod.rs
@@ -21,11 +21,11 @@ use ctypes::BlockNumber;
 use primitives::{Bytes, H256};
 
 use self::validator_list::ValidatorList;
-use super::super::client::EngineClient;
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::error::Error;
-use super::super::header::Header;
 use super::EpochChange;
+use crate::client::EngineClient;
+use crate::codechain_machine::CodeChainMachine;
+use crate::error::Error;
+use crate::header::Header;
 
 pub mod validator_list;
 

--- a/core/src/consensus/validator_set/validator_list.rs
+++ b/core/src/consensus/validator_set/validator_list.rs
@@ -20,11 +20,11 @@ use ckey::Address;
 use ctypes::BlockNumber;
 use primitives::H256;
 
-use super::super::super::codechain_machine::CodeChainMachine;
-use super::super::super::error::Error;
-use super::super::super::header::Header;
 use super::super::EpochChange;
 use super::ValidatorSet;
+use crate::codechain_machine::CodeChainMachine;
+use crate::error::Error;
+use crate::header::Header;
 
 /// Validator set containing a known set of addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]

--- a/core/src/encoded.rs
+++ b/core/src/encoded.rs
@@ -30,10 +30,10 @@ use heapsize::HeapSizeOf;
 use primitives::{H256, U256};
 use rlp::Rlp;
 
-use super::block::Block as FullBlock;
-use super::header::Header as FullHeader;
-use super::parcel::UnverifiedParcel;
-use super::views;
+use crate::block::Block as FullBlock;
+use crate::header::Header as FullHeader;
+use crate::parcel::UnverifiedParcel;
+use crate::views;
 
 /// Owning header view.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -25,9 +25,9 @@ use primitives::{H256, U256};
 
 use util_error::UtilError;
 
-use super::account_provider::SignError as AccountsError;
-use super::client::Error as ClientError;
-use super::consensus::EngineError;
+use crate::account_provider::SignError as AccountsError;
+use crate::client::Error as ClientError;
+use crate::consensus::EngineError;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Import to the block queue result

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,19 +75,19 @@ mod views;
 #[cfg(test)]
 mod tests;
 
-pub use account_provider::{AccountProvider, SignError as AccountProviderError};
-pub use block::Block;
-pub use client::{
+pub use crate::account_provider::{AccountProvider, SignError as AccountProviderError};
+pub use crate::block::Block;
+pub use crate::client::{
     AssetClient, Balance, BlockChainClient, BlockInfo, ChainInfo, ChainNotify, Client, DatabaseClient, EngineClient,
     EngineInfo, ExecuteClient, ImportBlock, MiningBlockChainClient, RegularKey, RegularKeyOwner, Seq, Shard,
     TestBlockChainClient,
 };
-pub use consensus::EngineType;
-pub use db::COL_STATE;
-pub use error::{BlockImportError, Error, ImportError};
-pub use header::{Header, Seal};
-pub use miner::{Miner, MinerOptions, MinerService, Stratum, StratumConfig, StratumError};
-pub use parcel::{LocalizedParcel, SignedParcel, UnverifiedParcel};
-pub use scheme::Scheme;
-pub use service::ClientService;
-pub use types::{BlockId, ParcelId};
+pub use crate::consensus::EngineType;
+pub use crate::db::COL_STATE;
+pub use crate::error::{BlockImportError, Error, ImportError};
+pub use crate::header::{Header, Seal};
+pub use crate::miner::{Miner, MinerOptions, MinerService, Stratum, StratumConfig, StratumError};
+pub use crate::parcel::{LocalizedParcel, SignedParcel, UnverifiedParcel};
+pub use crate::scheme::Scheme;
+pub use crate::service::ClientService;
+pub use crate::types::{BlockId, ParcelId};

--- a/core/src/miner/local_parcels.rs
+++ b/core/src/miner/local_parcels.rs
@@ -18,7 +18,7 @@ use ctypes::parcel::Error as ParcelError;
 use linked_hash_map::LinkedHashMap;
 use primitives::H256;
 
-use super::super::parcel::SignedParcel;
+use crate::parcel::SignedParcel;
 
 /// Status of local parcel.
 /// Can indicate that the parcel is currently part of the queue (`Pending/Future`)

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -29,9 +29,9 @@ use rlp;
 use table::Table;
 use time::get_time;
 
-use super::super::parcel::SignedParcel;
 use super::local_parcels::{LocalParcelsList, Status as LocalParcelStatus};
 use super::ParcelImportResult;
+use crate::parcel::SignedParcel;
 
 /// Parcel with the same (sender, seq) can be replaced only if
 /// `new_fee > old_fee + old_fee >> SHIFT`

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -29,21 +29,21 @@ use cvm::ChainTimeInfo;
 use parking_lot::{Mutex, RwLock};
 use primitives::{Bytes, H256};
 
-use super::super::account_provider::{AccountProvider, SignError};
-use super::super::block::{Block, ClosedBlock, IsBlock};
-use super::super::client::{
-    AccountData, BlockChain, BlockProducer, ImportSealedBlock, MiningBlockChainClient, RegularKey, RegularKeyOwner,
-};
-use super::super::consensus::{CodeChainEngine, EngineType, Seal};
-use super::super::error::Error;
-use super::super::header::Header;
-use super::super::parcel::{SignedParcel, UnverifiedParcel};
-use super::super::scheme::Scheme;
-use super::super::types::{BlockId, ParcelId};
 use super::mem_pool::{AccountDetails, MemPool, ParcelOrigin, ParcelTimelock, RemovalReason};
 use super::sealing_queue::SealingQueue;
 use super::work_notify::{NotifyWork, WorkPoster};
 use super::{MinerService, MinerStatus, ParcelImportResult};
+use crate::account_provider::{AccountProvider, SignError};
+use crate::block::{Block, ClosedBlock, IsBlock};
+use crate::client::{
+    AccountData, BlockChain, BlockProducer, ImportSealedBlock, MiningBlockChainClient, RegularKey, RegularKeyOwner,
+};
+use crate::consensus::{CodeChainEngine, EngineType, Seal};
+use crate::error::Error;
+use crate::header::Header;
+use crate::parcel::{SignedParcel, UnverifiedParcel};
+use crate::scheme::Scheme;
+use crate::types::{BlockId, ParcelId};
 
 /// Configures the behaviour of the miner.
 #[derive(Debug, PartialEq)]

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -29,14 +29,14 @@ use primitives::{Bytes, H256};
 
 pub use self::miner::{AuthoringParams, Miner, MinerOptions};
 pub use self::stratum::{Config as StratumConfig, Error as StratumError, Stratum};
-use super::account_provider::{AccountProvider, SignError};
-use super::block::ClosedBlock;
-use super::client::{
+use crate::account_provider::{AccountProvider, SignError};
+use crate::block::ClosedBlock;
+use crate::client::{
     AccountData, BlockChain, BlockProducer, ImportSealedBlock, MiningBlockChainClient, RegularKey, RegularKeyOwner,
 };
-use super::consensus::EngineType;
-use super::error::Error;
-use super::parcel::{SignedParcel, UnverifiedParcel};
+use crate::consensus::EngineType;
+use crate::error::Error;
+use crate::parcel::{SignedParcel, UnverifiedParcel};
 
 /// Miner client API
 pub trait MinerService: Send + Sync {

--- a/core/src/miner/sealing_queue.rs
+++ b/core/src/miner/sealing_queue.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::block::ClosedBlock;
+use crate::block::ClosedBlock;
 
 pub struct SealingQueue {
     /// Not yet being sealed by a miner, but if one asks for work, we'd prefer they do this.
@@ -74,10 +74,10 @@ impl SealingQueue {
 mod tests {
     use ckey::Address;
 
-    use super::super::super::block::{ClosedBlock, OpenBlock};
-    use super::super::super::scheme::Scheme;
-    use super::super::super::tests::helpers::get_temp_state_db;
     use super::SealingQueue;
+    use crate::block::{ClosedBlock, OpenBlock};
+    use crate::scheme::Scheme;
+    use crate::tests::helpers::get_temp_state_db;
 
     const QUEUE_SIZE: usize = 2;
 

--- a/core/src/miner/stratum.rs
+++ b/core/src/miner/stratum.rs
@@ -19,13 +19,13 @@
 use std::net::{AddrParseError, SocketAddr};
 use std::sync::Arc;
 
-use super::super::error::Error as MinerError;
+use crate::error::Error as MinerError;
 use cstratum::{Error as StratumServiceError, JobDispatcher, PushWorkHandler, Stratum as StratumService};
 use primitives::{Bytes, H256, U256};
 
-use super::super::client::Client;
-use super::super::miner::work_notify::NotifyWork;
-use super::super::miner::{Miner, MinerService};
+use crate::client::Client;
+use crate::miner::work_notify::NotifyWork;
+use crate::miner::{Miner, MinerService};
 
 /// Configures stratum server options.
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/parcel.rs
+++ b/core/src/parcel.rs
@@ -25,7 +25,7 @@ use heapsize::HeapSizeOf;
 use primitives::H256;
 use rlp::{self, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::scheme::CommonParams;
+use crate::scheme::CommonParams;
 
 /// Signed parcel information without verified signature.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/core/src/scheme/scheme.rs
+++ b/core/src/scheme/scheme.rs
@@ -29,15 +29,15 @@ use parking_lot::RwLock;
 use primitives::{Bytes, H256, U256};
 use rlp::{Encodable, Rlp, RlpStream};
 
-use super::super::blockchain::HeaderProvider;
+use crate::blockchain::HeaderProvider;
 
-use super::super::codechain_machine::CodeChainMachine;
-use super::super::consensus::{BlakePoW, CodeChainEngine, Cuckoo, NullEngine, SimplePoA, Solo, Tendermint};
-use super::super::error::{Error, SchemeError};
-use super::super::header::Header;
 use super::pod_state::{PodAccounts, PodShards};
 use super::seal::Generic as GenericSeal;
 use super::Genesis;
+use crate::codechain_machine::CodeChainMachine;
+use crate::consensus::{BlakePoW, CodeChainEngine, Cuckoo, NullEngine, SimplePoA, Solo, Tendermint};
+use crate::error::{Error, SchemeError};
+use crate::header::Header;
 
 #[derive(Debug, PartialEq, Default, RlpEncodable)]
 pub struct CommonParams {

--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -22,10 +22,10 @@ use cnetwork::NodeId;
 use kvdb_rocksdb::{Database, DatabaseConfig};
 use primitives::Bytes;
 
-use super::client::{Client, ClientConfig};
-use super::error::Error;
-use super::miner::Miner;
-use super::scheme::Scheme;
+use crate::client::{Client, ClientConfig};
+use crate::error::Error;
+use crate::miner::Miner;
+use crate::scheme::Scheme;
 
 /// Client service setup.
 pub struct ClientService {
@@ -42,7 +42,7 @@ impl ClientService {
     ) -> Result<ClientService, Error> {
         let io_service = IoService::<ClientIoMessage>::start("Client")?;
 
-        let mut db_config = DatabaseConfig::with_columns(super::db::NUM_COLUMNS);
+        let mut db_config = DatabaseConfig::with_columns(crate::db::NUM_COLUMNS);
 
         db_config.memory_budget = config.db_cache_size;
         db_config.compaction = config.db_compaction.compaction_profile(client_path);

--- a/core/src/tests/helpers.rs
+++ b/core/src/tests/helpers.rs
@@ -18,9 +18,9 @@ use cstate::StateDB;
 use primitives::{Bytes, H256, U256};
 use rlp::{self, RlpStream};
 
-use super::super::header::Header;
-use super::super::parcel::SignedParcel;
-use super::super::scheme::Scheme;
+use crate::header::Header;
+use crate::parcel::SignedParcel;
+use crate::scheme::Scheme;
 
 pub fn create_test_block(header: &Header) -> Bytes {
     let mut rlp = RlpStream::new_list(2);

--- a/core/src/verification/canon_verifier.rs
+++ b/core/src/verification/canon_verifier.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::client::{BlockInfo, TransactionInfo};
-use super::super::consensus::CodeChainEngine;
-use super::super::error::Error;
-use super::super::header::Header;
 use super::verification;
 use super::Verifier;
+use crate::client::{BlockInfo, TransactionInfo};
+use crate::consensus::CodeChainEngine;
+use crate::error::Error;
+use crate::header::Header;
 
 /// A canonial verifier -- this does full verification.
 pub struct CanonVerifier;

--- a/core/src/verification/mod.rs
+++ b/core/src/verification/mod.rs
@@ -26,7 +26,7 @@ pub use self::queue::{BlockQueue, Config as QueueConfig};
 pub use self::verification::*;
 pub use self::verifier::Verifier;
 
-use super::client::{BlockInfo, TransactionInfo};
+use crate::client::{BlockInfo, TransactionInfo};
 
 /// Verifier type.
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/verification/noop_verifier.rs
+++ b/core/src/verification/noop_verifier.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::client::{BlockInfo, TransactionInfo};
-use super::super::consensus::CodeChainEngine;
-use super::super::error::Error;
-use super::super::header::Header;
 use super::{verification, Verifier};
+use crate::client::{BlockInfo, TransactionInfo};
+use crate::consensus::CodeChainEngine;
+use crate::error::Error;
+use crate::header::Header;
 
 /// A no-op verifier -- this will verify everything it's given immediately.
 pub struct NoopVerifier;

--- a/core/src/verification/queue/kind.rs
+++ b/core/src/verification/queue/kind.rs
@@ -20,9 +20,9 @@ use primitives::{H256, U256};
 pub use self::blocks::Blocks;
 pub use self::headers::Headers;
 
-use super::super::super::consensus::CodeChainEngine;
-use super::super::super::error::Error;
-use super::super::super::service::ClientIoMessage;
+use crate::consensus::CodeChainEngine;
+use crate::error::Error;
+use crate::service::ClientIoMessage;
 
 /// Something which can produce a hash and a parent hash.
 pub trait BlockLike {
@@ -74,12 +74,12 @@ pub mod headers {
 
     use primitives::{H256, U256};
 
-    use super::super::super::super::consensus::CodeChainEngine;
-    use super::super::super::super::error::Error;
-    use super::super::super::super::header::Header;
-    use super::super::super::super::service::ClientIoMessage;
     use super::super::super::verification::verify_header_params;
     use super::{BlockLike, Kind};
+    use crate::consensus::CodeChainEngine;
+    use crate::error::Error;
+    use crate::header::Header;
+    use crate::service::ClientIoMessage;
 
 
     impl BlockLike for Header {
@@ -127,12 +127,12 @@ pub mod blocks {
     use heapsize::HeapSizeOf;
     use primitives::{Bytes, H256, U256};
 
-    use super::super::super::super::consensus::CodeChainEngine;
-    use super::super::super::super::error::Error;
-    use super::super::super::super::header::Header;
-    use super::super::super::super::service::ClientIoMessage;
     use super::super::super::verification::{verify_block_basic, verify_block_unordered, PreverifiedBlock};
     use super::{BlockLike, Kind};
+    use crate::consensus::CodeChainEngine;
+    use crate::error::Error;
+    use crate::header::Header;
+    use crate::service::ClientIoMessage;
 
     /// A mode for verifying blocks.
     pub struct Blocks;
@@ -177,7 +177,7 @@ pub mod blocks {
     impl Unverified {
         /// Create an `Unverified` from raw bytes.
         pub fn new(bytes: Bytes) -> Self {
-            use views::BlockView;
+            use crate::views::BlockView;
 
             let header = BlockView::new(&bytes).header();
             Unverified {

--- a/core/src/verification/queue/mod.rs
+++ b/core/src/verification/queue/mod.rs
@@ -29,10 +29,10 @@ use parking_lot::{Mutex, RwLock};
 use primitives::{H256, U256};
 
 use self::kind::{BlockLike, Kind};
-use super::super::consensus::CodeChainEngine;
-use super::super::error::{BlockError, Error, ImportError};
-use super::super::service::ClientIoMessage;
-use super::super::types::{BlockStatus as Status, VerificationQueueInfo as QueueInfo};
+use crate::consensus::CodeChainEngine;
+use crate::error::{BlockError, Error, ImportError};
+use crate::service::ClientIoMessage;
+use crate::types::{BlockStatus as Status, VerificationQueueInfo as QueueInfo};
 
 const MIN_MEM_LIMIT: usize = 16384;
 const MIN_QUEUE_LIMIT: usize = 512;
@@ -506,10 +506,10 @@ mod tests {
     use cio::IoChannel;
     use tests::helpers::*;
 
-    use super::super::super::error::{Error, ImportError};
-    use super::super::super::scheme::Scheme;
     use super::kind::blocks::Unverified;
     use super::{BlockQueue, Config};
+    use crate::error::{Error, ImportError};
+    use crate::scheme::Scheme;
 
     // create a test block queue.
     // auto_scaling enables verifier adjustment.

--- a/core/src/verification/verification.rs
+++ b/core/src/verification/verification.rs
@@ -23,13 +23,13 @@ use heapsize::HeapSizeOf;
 use primitives::{Bytes, H256};
 use rlp::UntrustedRlp;
 
-use super::super::blockchain::BlockProvider;
-use super::super::client::{BlockInfo, TransactionInfo};
-use super::super::consensus::CodeChainEngine;
-use super::super::error::{BlockError, Error};
-use super::super::header::Header;
-use super::super::parcel::{SignedParcel, UnverifiedParcel};
-use super::super::views::BlockView;
+use crate::blockchain::BlockProvider;
+use crate::client::{BlockInfo, TransactionInfo};
+use crate::consensus::CodeChainEngine;
+use crate::error::{BlockError, Error};
+use crate::header::Header;
+use crate::parcel::{SignedParcel, UnverifiedParcel};
+use crate::views::BlockView;
 
 /// Preprocessed block data gathered in `verify_block_unordered` call
 pub struct PreverifiedBlock {

--- a/core/src/verification/verifier.rs
+++ b/core/src/verification/verifier.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::client::{BlockInfo, TransactionInfo};
-use super::super::consensus::CodeChainEngine;
-use super::super::error::Error;
-use super::super::header::Header;
 use super::verification;
+use crate::client::{BlockInfo, TransactionInfo};
+use crate::consensus::CodeChainEngine;
+use crate::error::Error;
+use crate::header::Header;
 
 /// Should be used to verify blocks.
 pub trait Verifier<C>: Send + Sync

--- a/core/src/views/block.rs
+++ b/core/src/views/block.rs
@@ -18,9 +18,9 @@ use ccrypto::blake256;
 use primitives::H256;
 use rlp::Rlp;
 
-use super::super::header::Header;
-use super::super::parcel::{LocalizedParcel, UnverifiedParcel};
 use super::{HeaderView, ParcelView};
+use crate::header::Header;
+use crate::parcel::{LocalizedParcel, UnverifiedParcel};
 
 /// View onto block rlp.
 pub struct BlockView<'a> {

--- a/core/src/views/body.rs
+++ b/core/src/views/body.rs
@@ -19,8 +19,8 @@ use ctypes::BlockNumber;
 use primitives::H256;
 use rlp::Rlp;
 
-use super::super::parcel::{LocalizedParcel, UnverifiedParcel};
 use super::ParcelView;
+use crate::parcel::{LocalizedParcel, UnverifiedParcel};
 
 /// View onto block rlp.
 pub struct BodyView<'a> {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -27,15 +27,15 @@ mod hash;
 pub mod pbkdf2;
 pub mod scrypt;
 
-pub use error::Error;
+pub use crate::error::Error;
 
 pub const KEY_LENGTH: usize = 32;
 pub const KEY_ITERATIONS: usize = 10240;
 pub const KEY_LENGTH_AES: usize = KEY_LENGTH / 2;
 
-pub use self::blake::*;
+pub use crate::blake::*;
 
-pub use self::hash::{keccak256, ripemd160, sha1, sha256};
+pub use crate::hash::{keccak256, ripemd160, sha1, sha256};
 
 pub fn derive_key_iterations(password: &str, salt: &[u8; 32], c: u32) -> (Vec<u8>, Vec<u8>) {
     let mut derived_key = [0u8; KEY_LENGTH];

--- a/crypto/src/scrypt.rs
+++ b/crypto/src/scrypt.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{KEY_LENGTH, KEY_LENGTH_AES};
-use error::ScryptError;
+use crate::error::ScryptError;
+use crate::{KEY_LENGTH, KEY_LENGTH_AES};
 use rcrypto::scrypt::{scrypt, ScryptParams};
 
 pub fn derive_key(pass: &str, salt: &[u8; 32], n: u32, p: u32, r: u32) -> Result<(Vec<u8>, Vec<u8>), ScryptError> {

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -33,5 +33,5 @@ extern crate codechain_network as cnetwork;
 mod kademlia;
 mod unstructured;
 
-pub use kademlia::{Config as KademliaConfig, Extension as KademliaExtension};
-pub use unstructured::{Config as UnstructuredConfig, Extension as UnstructuredExtension};
+pub use crate::kademlia::{Config as KademliaConfig, Extension as KademliaExtension};
+pub use crate::unstructured::{Config as UnstructuredConfig, Extension as UnstructuredExtension};

--- a/json/src/bytes.rs
+++ b/json/src/bytes.rs
@@ -100,7 +100,7 @@ impl<'a> Visitor<'a> for BytesVisitor {
 
 #[cfg(test)]
 mod test {
-    use bytes::Bytes;
+    use crate::bytes::Bytes;
     use serde_json;
 
     #[test]

--- a/json/src/scheme/account.rs
+++ b/json/src/scheme/account.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Scheme account.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -37,8 +37,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::Account;
+    use crate::uint::Uint;
 
     #[test]
     fn account_deserialization() {

--- a/json/src/scheme/blake_pow.rs
+++ b/json/src/scheme/blake_pow.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,8 +35,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::*;
+    use crate::uint::Uint;
 
     #[test]
     fn blake_pow_deserialization() {

--- a/json/src/scheme/cuckoo.rs
+++ b/json/src/scheme/cuckoo.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,8 +38,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::*;
+    use crate::uint::Uint;
 
     #[test]
     fn cuckoo_deserialization() {

--- a/json/src/scheme/genesis.rs
+++ b/json/src/scheme/genesis.rs
@@ -16,10 +16,10 @@
 
 use ckey::PlatformAddress;
 
-use super::super::bytes::Bytes;
-use super::super::hash::H256;
-use super::super::uint::Uint;
 use super::Seal;
+use crate::bytes::Bytes;
+use crate::hash::H256;
+use crate::uint::Uint;
 
 /// Scheme genesis.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -54,11 +54,11 @@ mod tests {
     use primitives::{H256 as Core256, H520 as Core520, U256};
     use serde_json;
 
-    use super::super::super::bytes::Bytes;
-    use super::super::super::hash::{H256, H520};
-    use super::super::super::uint::Uint;
     use super::super::{Seal, TendermintSeal};
     use super::Genesis;
+    use crate::bytes::Bytes;
+    use crate::hash::{H256, H520};
+    use crate::uint::Uint;
 
     #[test]
     fn genesis_deserialization() {

--- a/json/src/scheme/null_engine.rs
+++ b/json/src/scheme/null_engine.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -35,8 +35,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::*;
+    use crate::uint::Uint;
 
     #[test]
     fn null_engine_deserialization() {

--- a/json/src/scheme/params.rs
+++ b/json/src/scheme/params.rs
@@ -16,7 +16,7 @@
 
 use ckey::NetworkId;
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Scheme params.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -42,8 +42,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::Params;
+    use crate::uint::Uint;
 
     #[test]
     fn params_deserialization() {

--- a/json/src/scheme/seal.rs
+++ b/json/src/scheme/seal.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::bytes::Bytes;
-use super::super::hash::H520;
-use super::super::uint::Uint;
+use crate::bytes::Bytes;
+use crate::hash::H520;
+use crate::uint::Uint;
 
 /// Tendermint seal.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -44,10 +44,10 @@ mod tests {
     use primitives::{H520 as Core520, U256};
     use serde_json;
 
-    use super::super::super::bytes::Bytes;
-    use super::super::super::hash::H520;
-    use super::super::super::uint::Uint;
     use super::{Seal, TendermintSeal};
+    use crate::bytes::Bytes;
+    use crate::hash::H520;
+    use crate::uint::Uint;
 
     #[test]
     fn seal_deserialization() {

--- a/json/src/scheme/shard.rs
+++ b/json/src/scheme/shard.rs
@@ -16,7 +16,7 @@
 
 use ckey::PlatformAddress;
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Shard {

--- a/json/src/scheme/simple_poa.rs
+++ b/json/src/scheme/simple_poa.rs
@@ -16,7 +16,7 @@
 
 use ckey::PlatformAddress;
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Authority params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -42,8 +42,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::SimplePoA;
+    use crate::uint::Uint;
 
     #[test]
     fn basic_authority_deserialization() {

--- a/json/src/scheme/solo.rs
+++ b/json/src/scheme/solo.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Solo params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -35,8 +35,8 @@ mod tests {
     use primitives::U256;
     use serde_json;
 
-    use super::super::super::uint::Uint;
     use super::Solo;
+    use crate::uint::Uint;
 
     #[test]
     fn basic_authority_deserialization() {

--- a/json/src/scheme/tendermint.rs
+++ b/json/src/scheme/tendermint.rs
@@ -16,7 +16,7 @@
 
 use ckey::PlatformAddress;
 
-use super::super::uint::Uint;
+use crate::uint::Uint;
 
 /// Tendermint params deserialization.
 #[derive(Debug, PartialEq, Deserialize)]

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -137,9 +137,9 @@ where
 
 #[cfg(test)]
 mod test {
+    use super::Uint;
     use primitives::U256;
     use serde_json;
-    use uint::Uint;
 
     #[test]
     fn uint_deserialization() {

--- a/key/src/ecdsa.rs
+++ b/key/src/ecdsa.rs
@@ -42,7 +42,7 @@ use rustc_hex::{FromHex, ToHex};
 use secp256k1::{key, Error as SecpError, Message as SecpMessage, RecoverableSignature, RecoveryId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{public_to_address, Address, Error, Message, Private, Public, SECP256K1};
+use crate::{public_to_address, Address, Error, Message, Private, Public, SECP256K1};
 
 pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
 
@@ -280,8 +280,8 @@ pub fn recover_ecdsa(signature: &ECDSASignature, message: &Message) -> Result<Pu
 
 #[cfg(test)]
 mod tests {
-    use super::super::{Generator, Message, Random};
     use super::{recover_ecdsa, sign_ecdsa, verify_ecdsa, verify_ecdsa_address, ECDSASignature};
+    use crate::{Generator, Message, Random};
     use std::str::FromStr;
 
     #[test]

--- a/key/src/error.rs
+++ b/key/src/error.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use bech32::Error as Bech32Error;
 use secp256k1::Error as SecpError;
 
-use super::NetworkId;
+use crate::NetworkId;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {

--- a/key/src/exchange.rs
+++ b/key/src/exchange.rs
@@ -18,7 +18,7 @@ use std::result;
 
 use secp256k1::{ecdh, key};
 
-use super::{Error, Private, Public, Secret, SECP256K1};
+use crate::{Error, Private, Public, Secret, SECP256K1};
 
 pub fn exchange(public: &Public, private: &Private) -> result::Result<Secret, Error> {
     let public = {
@@ -36,8 +36,8 @@ pub fn exchange(public: &Public, private: &Private) -> result::Result<Secret, Er
 
 #[cfg(test)]
 mod tests {
-    use super::super::{Generator, KeyPair, Random};
     use super::exchange;
+    use crate::{Generator, KeyPair, Random};
 
     #[test]
     fn exchange_makes_same_private_key() {

--- a/key/src/keypair.rs
+++ b/key/src/keypair.rs
@@ -21,7 +21,7 @@ use primitives::H160;
 use rustc_hex::ToHex;
 use secp256k1::key;
 
-use super::{Address, Error, Private, Public, SECP256K1};
+use crate::{Address, Error, Private, Public, SECP256K1};
 
 pub fn public_to_address(public: &Public) -> Address {
     H160::blake(public).into()

--- a/key/src/lib.rs
+++ b/key/src/lib.rs
@@ -44,24 +44,24 @@ mod private;
 mod random;
 mod schnorr;
 
-pub use address::Address;
-pub use ecdsa::{
+pub use crate::address::Address;
+pub use crate::ecdsa::{
     recover_ecdsa as recover, sign_ecdsa as sign, verify_ecdsa as verify, verify_ecdsa_address as verify_address,
     ECDSASignature as Signature, ECDSA_SIGNATURE_LENGTH as SIGNATURE_LENGTH,
 };
-pub use error::Error;
-pub use exchange::exchange;
-pub use keypair::{public_to_address, KeyPair};
-pub use network::NetworkId;
-pub use password::Password;
-pub use platform_address::PlatformAddress;
-use primitives::{H256, H512};
-pub use private::Private;
-pub use random::Random;
-pub use rustc_serialize::hex;
-pub use schnorr::{
+pub use crate::error::Error;
+pub use crate::exchange::exchange;
+pub use crate::keypair::{public_to_address, KeyPair};
+pub use crate::network::NetworkId;
+pub use crate::password::Password;
+pub use crate::platform_address::PlatformAddress;
+pub use crate::private::Private;
+pub use crate::random::Random;
+pub use crate::schnorr::{
     recover_schnorr, sign_schnorr, verify_schnorr, verify_schnorr_address, SchnorrSignature, SCHNORR_SIGNATURE_LENGTH,
 };
+use primitives::{H256, H512};
+pub use rustc_serialize::hex;
 
 /// 32 bytes long signable message
 pub type Message = H256;

--- a/key/src/platform_address.rs
+++ b/key/src/platform_address.rs
@@ -24,7 +24,7 @@ use primitives::H160;
 use serde::de::{Error as SerdeError, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{Address, Error, NetworkId};
+use crate::{Address, Error, NetworkId};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub struct PlatformAddress {

--- a/key/src/private.rs
+++ b/key/src/private.rs
@@ -22,7 +22,7 @@ use hex::ToHex;
 use primitives::H256;
 use secp256k1::key;
 
-use super::Error;
+use crate::Error;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Private(H256);

--- a/key/src/random.rs
+++ b/key/src/random.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::{Generator, KeyPair, SECP256K1};
+use crate::{Generator, KeyPair, SECP256K1};
 use rand::os::OsRng;
 
 pub struct Random;

--- a/key/src/schnorr.rs
+++ b/key/src/schnorr.rs
@@ -26,7 +26,7 @@ use rustc_hex::{FromHex, ToHex};
 use secp256k1::{key, schnorr, Error as SecpError, Message as SecpMessage};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{public_to_address, Address, Error, Message, Private, Public, SECP256K1};
+use crate::{public_to_address, Address, Error, Message, Private, Public, SECP256K1};
 
 pub const SCHNORR_SIGNATURE_LENGTH: usize = 64;
 
@@ -233,8 +233,8 @@ pub fn recover_schnorr(signature: &SchnorrSignature, message: &Message) -> Resul
 mod tests {
     use std::str::FromStr;
 
-    use super::super::{Generator, Message, Random};
     use super::{recover_schnorr, sign_schnorr, verify_schnorr, verify_schnorr_address, SchnorrSignature};
+    use crate::{Generator, Message, Random};
 
     #[test]
     fn signature_to_and_from_str() {

--- a/keystore/src/account/cipher.rs
+++ b/keystore/src/account/cipher.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::super::json;
+use crate::json;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Aes128Ctr {

--- a/keystore/src/account/crypto.rs
+++ b/keystore/src/account/crypto.rs
@@ -20,9 +20,9 @@ use ccrypto;
 use ckey::{public_to_address, Address, KeyPair, Password, Private, Secret};
 use smallvec::SmallVec;
 
-use super::super::account::{Aes128Ctr, Cipher, Kdf, Pbkdf2, Prf};
-use super::super::random::Random;
-use super::super::{json, Error};
+use crate::account::{Aes128Ctr, Cipher, Kdf, Pbkdf2, Prf};
+use crate::random::Random;
+use crate::{json, Error};
 
 /// Encrypted data
 #[derive(Debug, PartialEq, Clone)]

--- a/keystore/src/account/kdf.rs
+++ b/keystore/src/account/kdf.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::super::json;
+use crate::json;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Prf {

--- a/keystore/src/account/safe_account.rs
+++ b/keystore/src/account/safe_account.rs
@@ -17,9 +17,9 @@
 use ccrypto;
 use ckey::{sign, Address, KeyPair, Message, Password, Public, Signature};
 
-use super::super::account::Version;
-use super::super::{json, Error};
 use super::crypto::Crypto;
+use crate::account::Version;
+use crate::{json, Error};
 
 /// Account representation.
 #[derive(Debug, PartialEq, Clone)]
@@ -145,8 +145,8 @@ mod tests {
     use std::str::FromStr;
 
     use ckey::{verify, Generator, Random};
-    use json;
-    use json::{Aes128Ctr, Cipher, Crypto, Kdf, KeyFile, Scrypt, Uuid};
+    use crate::json;
+    use crate::json::{Aes128Ctr, Cipher, Crypto, Kdf, KeyFile, Scrypt, Uuid};
 
     use super::*;
 

--- a/keystore/src/account/version.rs
+++ b/keystore/src/account/version.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::super::json;
+use crate::json;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Version {

--- a/keystore/src/accounts_dir/disk.rs
+++ b/keystore/src/accounts_dir/disk.rs
@@ -21,9 +21,9 @@ use std::{fs, io};
 
 use time;
 
-use super::super::json::Uuid;
-use super::super::{json, Error, SafeAccount};
 use super::KeyDirectory;
+use crate::json::Uuid;
+use crate::{json, Error, SafeAccount};
 
 const IGNORED_FILES: &'static [&'static str] = &["thumbs.db"];
 

--- a/keystore/src/accounts_dir/memory.rs
+++ b/keystore/src/accounts_dir/memory.rs
@@ -20,8 +20,8 @@ use ckey::Address;
 use itertools;
 use parking_lot::RwLock;
 
-use super::super::{Error, SafeAccount};
 use super::KeyDirectory;
+use crate::{Error, SafeAccount};
 
 /// Accounts in-memory storage.
 #[derive(Default)]

--- a/keystore/src/accounts_dir/mod.rs
+++ b/keystore/src/accounts_dir/mod.rs
@@ -18,7 +18,7 @@
 
 use std::path::PathBuf;
 
-use super::{Error, SafeAccount};
+use crate::{Error, SafeAccount};
 
 mod disk;
 mod memory;

--- a/keystore/src/ckeys.rs
+++ b/keystore/src/ckeys.rs
@@ -16,7 +16,7 @@
 
 pub use ckey::*;
 
-use super::json;
+use crate::json;
 
 impl From<Address> for json::H160 {
     fn from(addr: Address) -> Self {

--- a/keystore/src/import.rs
+++ b/keystore/src/import.rs
@@ -20,8 +20,8 @@ use std::path::Path;
 
 use ckey::Address;
 
-use super::accounts_dir::{DiskKeyFileManager, KeyDirectory, KeyFileManager};
-use super::Error;
+use crate::accounts_dir::{DiskKeyFileManager, KeyDirectory, KeyFileManager};
+use crate::Error;
 
 /// Import an account from a file.
 pub fn import_account(path: &Path, dst: &KeyDirectory) -> Result<Address, Error> {

--- a/keystore/src/json/key_file.rs
+++ b/keystore/src/json/key_file.rs
@@ -75,7 +75,7 @@ mod tests {
 
     use serde_json;
 
-    use super::super::super::json::{Aes128Ctr, Cipher, Crypto, Kdf, KeyFile, Scrypt, Uuid, Version};
+    use crate::json::{Aes128Ctr, Cipher, Crypto, Kdf, KeyFile, Scrypt, Uuid, Version};
 
     #[test]
     fn basic_keyfile() {

--- a/keystore/src/keystore.rs
+++ b/keystore/src/keystore.rs
@@ -23,11 +23,11 @@ use ccrypto::KEY_ITERATIONS;
 use ckey::{Address, KeyPair, Message, Password, Public, Secret, Signature};
 use parking_lot::{Mutex, RwLock};
 
-use super::account::SafeAccount;
-use super::accounts_dir::KeyDirectory;
-use super::json::{self, OpaqueKeyFile, Uuid};
-use super::random::Random;
-use super::{Error, OpaqueSecret, SecretStore, SimpleSecretStore};
+use crate::account::SafeAccount;
+use crate::accounts_dir::KeyDirectory;
+use crate::json::{self, OpaqueKeyFile, Uuid};
+use crate::random::Random;
+use crate::{Error, OpaqueSecret, SecretStore, SimpleSecretStore};
 
 /// Accounts store.
 pub struct KeyStore {
@@ -394,8 +394,8 @@ mod tests {
     use ckey::{Generator, Random};
     use primitives::H256;
 
-    use super::super::accounts_dir::MemoryDirectory;
     use super::*;
+    use crate::accounts_dir::MemoryDirectory;
 
     fn keypair() -> KeyPair {
         Random.generate().unwrap()

--- a/keystore/src/lib.rs
+++ b/keystore/src/lib.rs
@@ -70,13 +70,13 @@ mod keystore;
 mod random;
 mod secret_store;
 
-pub use self::account::{Crypto, SafeAccount};
-pub use self::error::Error;
-pub use self::import::{import_account, import_accounts};
-pub use self::json::OpaqueKeyFile as KeyFile;
-pub use self::keystore::{KeyMultiStore, KeyStore};
-pub use self::random::random_string;
-pub use self::secret_store::{SecretStore, SimpleSecretStore};
+pub use crate::account::{Crypto, SafeAccount};
+pub use crate::error::Error;
+pub use crate::import::{import_account, import_accounts};
+pub use crate::json::OpaqueKeyFile as KeyFile;
+pub use crate::keystore::{KeyMultiStore, KeyStore};
+pub use crate::random::random_string;
+pub use crate::secret_store::{SecretStore, SimpleSecretStore};
 
 /// An opaque wrapper for secret.
 pub struct OpaqueSecret(::ckey::Secret);

--- a/keystore/src/secret_store.rs
+++ b/keystore/src/secret_store.rs
@@ -34,8 +34,8 @@ use std::path::PathBuf;
 
 use ckey::{Address, Message, Password, Public, Secret, Signature};
 
-use super::json::{OpaqueKeyFile, Uuid};
-use super::{Error, OpaqueSecret};
+use crate::json::{OpaqueKeyFile, Uuid};
+use crate::{Error, OpaqueSecret};
 
 
 /// Simple Secret Store API

--- a/network/src/addr.rs
+++ b/network/src/addr.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::NodeId;
+use crate::NodeId;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SocketAddr {

--- a/network/src/client.rs
+++ b/network/src/client.rs
@@ -22,8 +22,8 @@ use ctimer::{TimerApi, TimerLoop, TimerToken};
 use parking_lot::RwLock;
 use time::Duration;
 
-use super::p2p::Message as P2pMessage;
-use super::{Api, IntoSocketAddr, NetworkExtension, NetworkExtensionResult, NodeId};
+use crate::p2p::Message as P2pMessage;
+use crate::{Api, IntoSocketAddr, NetworkExtension, NetworkExtensionResult, NodeId};
 
 struct ClientApi {
     extension: Weak<NetworkExtension>,
@@ -172,8 +172,8 @@ mod tests {
     use parking_lot::Mutex;
     use time::Duration;
 
-    use super::super::SocketAddr;
     use super::{Api, Client, NetworkExtension, NetworkExtensionResult, NodeId};
+    use crate::SocketAddr;
 
     #[allow(dead_code)]
     struct TestApi;

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::filters::FilterEntry;
-use super::SocketAddr;
+use crate::filters::FilterEntry;
+use crate::SocketAddr;
 
 pub struct Config {
     pub address: String,

--- a/network/src/control.rs
+++ b/network/src/control.rs
@@ -19,8 +19,8 @@ use std::result::Result;
 
 use primitives::H256;
 
-use super::addr::SocketAddr;
-use super::filters::FilterEntry;
+use crate::addr::SocketAddr;
+use crate::filters::FilterEntry;
 
 pub trait Control: Send + Sync {
     fn register_secret(&self, secret: H256, addr: SocketAddr) -> Result<(), Error>;

--- a/network/src/discovery.rs
+++ b/network/src/discovery.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use super::RoutingTable;
+use crate::RoutingTable;
 
 pub trait Api: Send + Sync {
     fn set_routing_table(&self, routing_table: Arc<RoutingTable>);

--- a/network/src/extension.rs
+++ b/network/src/extension.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use cio::IoError;
 use time::Duration;
 
-use super::NodeId;
+use crate::NodeId;
 pub use ctimer::{TimeoutHandler, TimerScheduleError, TimerToken};
 
 #[derive(Debug)]

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -56,17 +56,17 @@ pub mod control;
 mod p2p;
 pub mod session;
 
-pub use self::addr::SocketAddr;
-pub use self::config::Config as NetworkConfig;
-pub use self::control::{Control as NetworkControl, Error as NetworkControlError};
-pub use self::discovery::Api as DiscoveryApi;
-pub use self::extension::{
+pub use crate::addr::SocketAddr;
+pub use crate::config::Config as NetworkConfig;
+pub use crate::control::{Control as NetworkControl, Error as NetworkControlError};
+pub use crate::discovery::Api as DiscoveryApi;
+pub use crate::extension::{
     Api, Error as NetworkExtensionError, Extension as NetworkExtension, Result as NetworkExtensionResult,
     TimeoutHandler, TimerToken,
 };
-pub use self::node_id::{IntoSocketAddr, NodeId};
-pub use self::service::{Error as NetworkServiceError, Service as NetworkService};
-pub use self::test::{Call as TestNetworkCall, TestClient as TestNetworkClient};
+pub use crate::node_id::{IntoSocketAddr, NodeId};
+pub use crate::service::{Error as NetworkServiceError, Service as NetworkService};
+pub use crate::test::{Call as TestNetworkCall, TestClient as TestNetworkClient};
 
-pub use self::filters::{FilterEntry, Filters, FiltersControl};
-pub use self::routing_table::RoutingTable;
+pub use crate::filters::{FilterEntry, Filters, FiltersControl};
+pub use crate::routing_table::RoutingTable;

--- a/network/src/node_id.rs
+++ b/network/src/node_id.rs
@@ -17,7 +17,7 @@
 use std::fmt;
 use std::net::IpAddr;
 
-use super::SocketAddr;
+use crate::SocketAddr;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, RlpEncodableWrapper, RlpDecodableWrapper)]
 pub struct NodeId {

--- a/network/src/p2p/connection.rs
+++ b/network/src/p2p/connection.rs
@@ -26,11 +26,11 @@ use mio::{PollOpt, Ready, Token};
 use parking_lot::RwLock;
 use rlp::{DecoderError, UntrustedRlp};
 
-use super::super::session::Session;
-use super::super::{NodeId, SocketAddr};
 use super::message::{HandshakeMessage, Message, Seq, SignedMessage, Version};
 use super::stream::{Error as StreamError, SignedStream, Stream};
 use super::{ExtensionMessage, NegotiationMessage};
+use crate::session::Session;
+use crate::{NodeId, SocketAddr};
 
 struct EstablishedConnection {
     stream: SignedStream,

--- a/network/src/p2p/connections.rs
+++ b/network/src/p2p/connections.rs
@@ -22,11 +22,11 @@ use mio::deprecated::EventLoop;
 use mio::Token;
 use parking_lot::RwLock;
 
-use super::super::node_id::IntoSocketAddr;
-use super::super::session::Session;
-use super::super::{FiltersControl, NodeId, SocketAddr};
 use super::connection::{Connection, Result};
 use super::stream::Stream;
+use crate::node_id::IntoSocketAddr;
+use crate::session::Session;
+use crate::{FiltersControl, NodeId, SocketAddr};
 
 pub use super::connection::{ConnectionType, ReceivedMessage};
 

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -27,14 +27,14 @@ use mio::{PollOpt, Ready, Token};
 use parking_lot::Mutex;
 use rlp::UntrustedRlp;
 
-use super::super::addr::convert_to_node_id;
-use super::super::client::Client;
-use super::super::{FiltersControl, IntoSocketAddr, NodeId, RoutingTable, SocketAddr};
 use super::connections::{ConnectionType, Connections, ReceivedMessage};
 use super::listener::Listener;
 use super::message::{HandshakeMessage, Message as NetworkMessage, Version};
 use super::stream::Stream;
 use super::NegotiationBody;
+use crate::addr::convert_to_node_id;
+use crate::client::Client;
+use crate::{FiltersControl, IntoSocketAddr, NodeId, RoutingTable, SocketAddr};
 
 pub const MAX_CONNECTIONS: usize = 200;
 

--- a/network/src/p2p/listener.rs
+++ b/network/src/p2p/listener.rs
@@ -20,8 +20,8 @@ use mio::event::Evented;
 use mio::net::TcpListener;
 use mio::{Poll, PollOpt, Ready, Token};
 
-use super::super::SocketAddr;
 use super::stream::Stream;
+use crate::SocketAddr;
 
 pub struct Listener {
     listener: TcpListener,

--- a/network/src/p2p/message/extension.rs
+++ b/network/src/p2p/message/extension.rs
@@ -17,9 +17,9 @@
 use ccrypto::aes::{self, SymmetricCipherError};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::super::session::Session;
 use super::ProtocolId;
 use super::Version;
+use crate::session::Session;
 
 use super::ENCRYPTED_ID;
 use super::UNENCRYPTED_ID;

--- a/network/src/p2p/message/handshake.rs
+++ b/network/src/p2p/message/handshake.rs
@@ -22,7 +22,7 @@ use super::Version;
 use super::ACK_ID;
 use super::SYNC_ID;
 
-use super::super::super::NodeId;
+use crate::NodeId;
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Message {
@@ -116,8 +116,8 @@ impl Decodable for Message {
 mod tests {
     use rlp::rlp_encode_and_decode_test;
 
-    use super::super::super::super::SocketAddr;
     use super::*;
+    use crate::SocketAddr;
 
     #[test]
     fn protocol_id_of_sync_is_0() {

--- a/network/src/p2p/message/mod.rs
+++ b/network/src/p2p/message/mod.rs
@@ -27,7 +27,7 @@ pub use self::handshake::Message as HandshakeMessage;
 pub use self::message::Message;
 pub use self::negotiation::{Body as NegotiationBody, Message as NegotiationMessage};
 pub use self::signed_message::SignedMessage;
-pub use super::super::session::Nonce;
+pub use crate::session::Nonce;
 
 pub type Version = u64;
 pub type ProtocolId = u64;

--- a/network/src/p2p/message/signed_message.rs
+++ b/network/src/p2p/message/signed_message.rs
@@ -16,8 +16,8 @@
 
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::super::session::Session;
 use super::Signature;
+use crate::session::Session;
 
 #[derive(Debug, PartialEq)]
 pub struct SignedMessage {

--- a/network/src/p2p/stream.rs
+++ b/network/src/p2p/stream.rs
@@ -25,9 +25,9 @@ use mio::net::TcpStream;
 use mio::{Poll, PollOpt, Ready, Token};
 use rlp::{Decodable, DecoderError, Encodable, UntrustedRlp};
 
-use super::super::session::Session;
-use super::super::SocketAddr;
 use super::SignedMessage;
+use crate::session::Session;
+use crate::SocketAddr;
 
 #[derive(Debug)]
 pub enum Error {

--- a/network/src/routing_table.rs
+++ b/network/src/routing_table.rs
@@ -22,8 +22,8 @@ use parking_lot::{Mutex, RwLock};
 use rand::{OsRng, Rng};
 use rlp::{Decodable, Encodable, UntrustedRlp};
 
-use super::session::{Nonce, Session};
-use super::{IntoSocketAddr, NodeId, SocketAddr};
+use crate::session::{Nonce, Session};
+use crate::{IntoSocketAddr, NodeId, SocketAddr};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum SecretOrigin {

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -22,14 +22,14 @@ use cio::{IoError, IoService};
 use ctimer::TimerLoop;
 use primitives::H256;
 
-use super::client::Client;
-use super::control::{Control, Error as ControlError};
-use super::filters::{FilterEntry, FiltersControl};
-use super::p2p;
-use super::routing_table::RoutingTable;
-use super::session_initiator;
-use super::DiscoveryApi;
-use super::{NetworkExtension, SocketAddr};
+use crate::client::Client;
+use crate::control::{Control, Error as ControlError};
+use crate::filters::{FilterEntry, FiltersControl};
+use crate::p2p;
+use crate::routing_table::RoutingTable;
+use crate::session_initiator;
+use crate::DiscoveryApi;
+use crate::{NetworkExtension, SocketAddr};
 
 pub struct Service {
     session_initiator: IoService<session_initiator::Message>,

--- a/network/src/session_initiator/handler.rs
+++ b/network/src/session_initiator/handler.rs
@@ -28,9 +28,9 @@ use mio::Token;
 use parking_lot::RwLock;
 use rlp::DecoderError;
 
-use super::super::{p2p, FiltersControl, IntoSocketAddr, RoutingTable, SocketAddr};
 use super::message;
 use super::server::{Error as ServerError, Server};
+use crate::{p2p, FiltersControl, IntoSocketAddr, RoutingTable, SocketAddr};
 
 const REFRESH_TIMER_TOKEN: TimerToken = 0;
 const BEGIN_OF_REQUEST_TOKEN: TimerToken = 1;

--- a/network/src/session_initiator/message.rs
+++ b/network/src/session_initiator/message.rs
@@ -17,7 +17,7 @@
 use ckey::Public;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::NodeId;
+use crate::NodeId;
 
 type Version = u32;
 type Raw = Vec<u8>;
@@ -232,9 +232,9 @@ impl Decodable for Message {
 mod tests {
     use rlp::rlp_encode_and_decode_test;
 
-    use super::super::super::session::Nonce;
-    use super::super::super::SocketAddr;
     use super::*;
+    use crate::session::Nonce;
+    use crate::SocketAddr;
 
     #[test]
     fn encode_and_decode_node_id_request() {

--- a/network/src/session_initiator/server.rs
+++ b/network/src/session_initiator/server.rs
@@ -23,9 +23,9 @@ use cio::IoManager;
 use mio::deprecated::EventLoop;
 use mio::{PollOpt, Ready, Token};
 
-use super::super::SocketAddr;
 use super::message::Message;
 use super::socket::{Error as SocketError, Socket};
+use crate::SocketAddr;
 
 #[derive(Debug)]
 pub enum Error {

--- a/network/src/session_initiator/socket.rs
+++ b/network/src/session_initiator/socket.rs
@@ -23,7 +23,7 @@ use mio::net::UdpSocket;
 use mio::{Poll, PollOpt, Ready, Token};
 use rlp::{Decodable, DecoderError, Encodable, UntrustedRlp};
 
-use super::super::SocketAddr;
+use crate::SocketAddr;
 
 #[derive(Debug)]
 pub enum Error {

--- a/network/src/test/client.rs
+++ b/network/src/test/client.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, Weak};
 use parking_lot::Mutex;
 use time::Duration;
 
-use super::super::extension::{Api, Extension, Result, TimerToken};
-use super::super::NodeId;
+use crate::extension::{Api, Extension, Result, TimerToken};
+use crate::NodeId;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Call {

--- a/state/src/action_handler/hit.rs
+++ b/state/src/action_handler/hit.rs
@@ -20,8 +20,8 @@ use ctypes::invoice::Invoice;
 use primitives::{Bytes, H256};
 use rlp::{self, Decodable, DecoderError, Encodable, UntrustedRlp};
 
-use super::super::{StateResult, TopLevelState, TopState, TopStateView};
 use super::ActionHandler;
+use crate::{StateResult, TopLevelState, TopState, TopStateView};
 
 const ACTION_ID: u8 = 0;
 

--- a/state/src/action_handler/mod.rs
+++ b/state/src/action_handler/mod.rs
@@ -20,7 +20,7 @@ use cmerkle::TrieMut;
 use ctypes::invoice::Invoice;
 use primitives::Bytes;
 
-use super::{StateResult, TopLevelState};
+use crate::{StateResult, TopLevelState};
 
 pub trait ActionHandler: Send + Sync {
     fn init(&self, state: &mut TrieMut) -> StateResult<()>;

--- a/state/src/cache/global_cache.rs
+++ b/state/src/cache/global_cache.rs
@@ -16,9 +16,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::super::{Account, ActionData, AssetScheme, Metadata, OwnedAsset, RegularAccount, Shard};
 use super::lru_cache::LruCache;
 use super::{ShardCache, TopCache};
+use crate::{Account, ActionData, AssetScheme, Metadata, OwnedAsset, RegularAccount, Shard};
 
 use ctypes::ShardId;
 

--- a/state/src/cache/lru_cache.rs
+++ b/state/src/cache/lru_cache.rs
@@ -16,7 +16,7 @@
 
 use lru_cache::LruCache as LruCacheImpl;
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 pub struct LruCache<Item: CacheableItem> {
     cache: LruCacheImpl<Item::Address, Item>,

--- a/state/src/cache/shard_cache.rs
+++ b/state/src/cache/shard_cache.rs
@@ -18,8 +18,8 @@ use std::cell::RefMut;
 
 use cmerkle::{Result as TrieResult, TrieDB, TrieMut};
 
-use super::super::{AssetScheme, AssetSchemeAddress, OwnedAsset, OwnedAssetAddress};
 use super::WriteBack;
+use crate::{AssetScheme, AssetSchemeAddress, OwnedAsset, OwnedAssetAddress};
 
 pub struct ShardCache {
     asset_scheme: WriteBack<AssetScheme>,

--- a/state/src/cache/top_cache.rs
+++ b/state/src/cache/top_cache.rs
@@ -20,10 +20,10 @@ use ckey::Address;
 use cmerkle::{Result as TrieResult, TrieDB, TrieMut};
 use primitives::H256;
 
-use super::super::{
+use super::WriteBack;
+use crate::{
     Account, ActionData, Metadata, MetadataAddress, RegularAccount, RegularAccountAddress, Shard, ShardAddress,
 };
-use super::WriteBack;
 
 pub struct TopCache {
     account: WriteBack<Account>,

--- a/state/src/db/state_db.rs
+++ b/state/src/db/state_db.rs
@@ -41,9 +41,9 @@ use kvdb_memorydb;
 use primitives::H256;
 use util_error::UtilError;
 
-use super::super::cache::{GlobalCache, ShardCache, TopCache};
-use super::super::impls::TopLevelState;
-use super::super::ActionHandler;
+use crate::cache::{GlobalCache, ShardCache, TopCache};
+use crate::impls::TopLevelState;
+use crate::ActionHandler;
 
 /// State database abstraction.
 pub struct StateDB {

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -31,10 +31,10 @@ use cvm::{decode, execute, ChainTimeInfo, ScriptResult, VMConfig};
 use hashdb::AsHashDB;
 use primitives::{Bytes, H160, H256};
 
-use super::super::cache::ShardCache;
-use super::super::checkpoint::{CheckpointId, StateWithCheckpoint};
-use super::super::traits::{ShardState, ShardStateView};
-use super::super::{
+use crate::cache::ShardCache;
+use crate::checkpoint::{CheckpointId, StateWithCheckpoint};
+use crate::traits::{ShardState, ShardStateView};
+use crate::{
     Asset, AssetScheme, AssetSchemeAddress, CacheableItem, OwnedAsset, OwnedAssetAddress, StateDB, StateError,
     StateResult,
 };
@@ -626,8 +626,8 @@ impl<'db> ShardStateView for ReadOnlyShardLevelState<'db> {
 mod tests {
     use ctypes::transaction::AssetOutPoint;
 
-    use super::super::super::tests::helpers::{get_temp_state_db, get_test_client};
     use super::*;
+    use crate::tests::helpers::{get_temp_state_db, get_test_client};
 
     fn address() -> Address {
         Address::random()

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -52,10 +52,10 @@ use kvdb::DBTransaction;
 use primitives::{Bytes, H160, H256};
 use util_error::UtilError;
 
-use super::super::cache::{ShardCache, TopCache};
-use super::super::checkpoint::{CheckpointId, StateWithCheckpoint};
-use super::super::traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};
-use super::super::{
+use crate::cache::{ShardCache, TopCache};
+use crate::checkpoint::{CheckpointId, StateWithCheckpoint};
+use crate::traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};
+use crate::{
     Account, ActionData, Metadata, MetadataAddress, RegularAccount, RegularAccountAddress, Shard, ShardAddress,
     ShardLevelState, StateDB, StateError, StateResult,
 };
@@ -704,8 +704,8 @@ mod tests_state {
 
     use journaldb::{self, Algorithm};
 
-    use super::super::super::tests::helpers::{get_memory_db, get_temp_state, get_temp_state_db};
     use super::*;
+    use crate::tests::helpers::{get_memory_db, get_temp_state, get_temp_state_db};
 
     #[test]
     fn work_when_cloned() {
@@ -1051,9 +1051,9 @@ mod tests_parcel {
     };
     use primitives::H160;
 
-    use super::super::super::tests::helpers::{get_temp_state, get_test_client};
-    use super::super::super::{AssetScheme, AssetSchemeAddress, OwnedAsset, OwnedAssetAddress};
     use super::*;
+    use crate::tests::helpers::{get_temp_state, get_test_client};
+    use crate::{AssetScheme, AssetSchemeAddress, OwnedAsset, OwnedAssetAddress};
 
     fn address() -> (Address, Public) {
         let keypair = Random.generate().unwrap();

--- a/state/src/item/account.rs
+++ b/state/src/item/account.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use ckey::{self, Public};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 /// Single account in the system.
 // Don't forget to sync the field list with PodAccount.

--- a/state/src/item/action_data.rs
+++ b/state/src/item/action_data.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 use primitives::{Bytes, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp, NULL_RLP};
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug)]
 pub struct ActionData(Bytes);

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -18,7 +18,7 @@ use ctypes::ShardId;
 use primitives::{Bytes, H160, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, RlpEncodable, RlpDecodable)]
 #[serde(rename_all = "camelCase")]

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -22,8 +22,8 @@ use ctypes::ShardId;
 use primitives::H256;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::CacheableItem;
 use super::asset::Asset;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/state/src/item/metadata.rs
+++ b/state/src/item/metadata.rs
@@ -19,7 +19,7 @@ use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
 use ctypes::ShardId;
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug)]
 pub struct Metadata {

--- a/state/src/item/regular_account.rs
+++ b/state/src/item/regular_account.rs
@@ -18,7 +18,7 @@ use ckey::{public_to_address, Address, Public};
 use primitives::H256;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug)]
 pub struct RegularAccount {

--- a/state/src/item/shard.rs
+++ b/state/src/item/shard.rs
@@ -20,7 +20,7 @@ use ctypes::ShardId;
 use primitives::H256;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::CacheableItem;
+use crate::CacheableItem;
 
 #[derive(Clone, Debug)]
 pub struct Shard {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -52,20 +52,20 @@ mod traits;
 #[cfg(test)]
 pub mod tests;
 
-pub use action_handler::{ActionHandler, HitHandler};
-pub use checkpoint::{CheckpointId, StateWithCheckpoint};
-pub use db::StateDB;
-pub use error::Error as StateError;
-pub use impls::{ShardLevelState, TopLevelState};
-pub use item::account::Account;
-pub use item::action_data::ActionData;
-pub use item::asset::{Asset, OwnedAsset, OwnedAssetAddress};
-pub use item::asset_scheme::{AssetScheme, AssetSchemeAddress};
-pub use item::metadata::{Metadata, MetadataAddress};
-pub use item::regular_account::{RegularAccount, RegularAccountAddress};
-pub use item::shard::{Shard, ShardAddress};
-pub use traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};
+pub use crate::action_handler::{ActionHandler, HitHandler};
+pub use crate::checkpoint::{CheckpointId, StateWithCheckpoint};
+pub use crate::db::StateDB;
+pub use crate::error::Error as StateError;
+pub use crate::impls::{ShardLevelState, TopLevelState};
+pub use crate::item::account::Account;
+pub use crate::item::action_data::ActionData;
+pub use crate::item::asset::{Asset, OwnedAsset, OwnedAssetAddress};
+pub use crate::item::asset_scheme::{AssetScheme, AssetSchemeAddress};
+pub use crate::item::metadata::{Metadata, MetadataAddress};
+pub use crate::item::regular_account::{RegularAccount, RegularAccountAddress};
+pub use crate::item::shard::{Shard, ShardAddress};
+pub use crate::traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};
 
-use cache::CacheableItem;
+use crate::cache::CacheableItem;
 
 pub type StateResult<T> = Result<T, StateError>;

--- a/state/src/tests.rs
+++ b/state/src/tests.rs
@@ -23,8 +23,8 @@ pub mod helpers {
     use kvdb_memorydb;
     use primitives::H256;
 
-    use super::super::impls::TopLevelState;
-    use super::super::StateDB;
+    use crate::impls::TopLevelState;
+    use crate::StateDB;
 
     pub struct TestChainTimeInfoClient {}
 

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -22,7 +22,7 @@ use ctypes::ShardId;
 use cvm::ChainTimeInfo;
 use primitives::{Bytes, H256};
 
-use super::{
+use crate::{
     Account, ActionData, AssetScheme, AssetSchemeAddress, CacheableItem, Metadata, OwnedAsset, OwnedAssetAddress,
     RegularAccount, Shard, StateResult,
 };

--- a/stratum/src/lib.rs
+++ b/stratum/src/lib.rs
@@ -36,7 +36,7 @@ extern crate tokio_io;
 
 mod traits;
 
-pub use traits::{Error, JobDispatcher, PushWorkHandler, ServiceConfiguration};
+pub use crate::traits::{Error, JobDispatcher, PushWorkHandler, ServiceConfiguration};
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -47,9 +47,9 @@ mod block;
 mod parcel;
 mod snapshot;
 
-pub use self::block::BlockSyncExtension;
-pub use self::parcel::ParcelSyncExtension;
-pub use self::snapshot::SnapshotService;
+pub use crate::block::BlockSyncExtension;
+pub use crate::parcel::ParcelSyncExtension;
+pub use crate::snapshot::SnapshotService;
 
 #[cfg(test)]
 extern crate codechain_key as ckey;

--- a/types/src/invoice/block_invoices.rs
+++ b/types/src/invoice/block_invoices.rs
@@ -59,9 +59,9 @@ impl Encodable for BlockInvoices {
 mod tests {
     use rlp::rlp_encode_and_decode_test;
 
-    use super::super::super::parcel::Error;
-    use super::super::super::transaction::Error as TransactionError;
     use super::*;
+    use crate::parcel::Error;
+    use crate::transaction::Error as TransactionError;
 
     #[test]
     fn rlp_encode_and_decode_block_invoices() {

--- a/types/src/invoice/parcel_invoice.rs
+++ b/types/src/invoice/parcel_invoice.rs
@@ -18,8 +18,8 @@ use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
-use super::super::parcel::Error;
 use super::invoice_result::InvoiceResult;
+use crate::parcel::Error;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Invoice {

--- a/types/src/parcel/action.rs
+++ b/types/src/parcel/action.rs
@@ -20,8 +20,8 @@ use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::transaction::Transaction;
-use super::super::ShardId;
+use crate::transaction::Transaction;
+use crate::ShardId;
 
 const ASSET_TRANSACTION: u8 = 1;
 const PAYMENT: u8 = 2;

--- a/types/src/parcel/error.rs
+++ b/types/src/parcel/error.rs
@@ -20,9 +20,9 @@ use ckey::{Address, Error as KeyError, NetworkId};
 use primitives::H256;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::transaction::Error as TransactionError;
-use super::super::util::unexpected::Mismatch;
-use super::super::ShardId;
+use crate::transaction::Error as TransactionError;
+use crate::util::unexpected::Mismatch;
+use crate::ShardId;
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[serde(tag = "type", content = "content")]

--- a/types/src/transaction/error.rs
+++ b/types/src/transaction/error.rs
@@ -20,9 +20,9 @@ use ckey::Address;
 use primitives::{H160, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::util::unexpected::Mismatch;
-use super::super::ShardId;
 use super::Timelock;
+use crate::util::unexpected::Mismatch;
+use crate::ShardId;
 
 #[derive(Debug, PartialEq, Clone, Eq, Serialize)]
 #[serde(tag = "type", content = "content")]

--- a/types/src/transaction/transaction.rs
+++ b/types/src/transaction/transaction.rs
@@ -24,9 +24,9 @@ use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256, U128};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
-use super::super::util::tag::Tag;
-use super::super::ShardId;
 use super::error::Error;
+use crate::util::tag::Tag;
+use crate::ShardId;
 
 
 pub trait PartialHashing {

--- a/types/src/util/tag.rs
+++ b/types/src/util/tag.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::transaction::HashingError;
+use crate::transaction::HashingError;
 
 #[derive(Debug, PartialEq)]
 pub struct Tag {
@@ -60,8 +60,8 @@ impl Tag {
 }
 #[cfg(test)]
 mod tests {
-    use transaction::HashingError;
-    use util::tag::Tag;
+    use crate::transaction::HashingError;
+    use crate::util::tag::Tag;
     #[test]
     fn make_partial_signing_tag() {
         let bitvec = vec![

--- a/util/logger/src/logger.rs
+++ b/util/logger/src/logger.rs
@@ -18,10 +18,10 @@ use std::env;
 use std::thread;
 use time;
 
-use super::slogger;
-use super::structured_logger;
 use atty;
 use colored::Colorize;
+use crate::slogger;
+use crate::structured_logger;
 use env_logger::filter::{Builder as FilterBuilder, Filter};
 use log::{LevelFilter, Log, Metadata, Record};
 

--- a/util/merkle/src/lib.rs
+++ b/util/merkle/src/lib.rs
@@ -38,10 +38,10 @@ pub mod triedb;
 pub mod triedbmut;
 pub mod triehash;
 
-pub use self::node::Node;
-pub use skewed::skewed_merkle_root;
-pub use triedb::TrieDB;
-pub use triedbmut::TrieDBMut;
+pub use crate::node::Node;
+pub use crate::skewed::skewed_merkle_root;
+pub use crate::triedb::TrieDB;
+pub use crate::triedbmut::TrieDBMut;
 
 /// Trie Errors.
 ///

--- a/util/merkle/src/triedb.rs
+++ b/util/merkle/src/triedb.rs
@@ -18,9 +18,9 @@ use ccrypto::blake256;
 use hashdb::HashDB;
 use primitives::H256;
 
-use super::nibbleslice::NibbleSlice;
-use super::node::Node as RlpNode;
-use super::{Query, Trie, TrieError};
+use crate::nibbleslice::NibbleSlice;
+use crate::node::Node as RlpNode;
+use crate::{Query, Trie, TrieError};
 /// A `Trie` implementation using a generic `HashDB` backing database.
 ///
 /// Use it as a `Trie` trait object. You can use `db()` to get the backing database object.
@@ -55,7 +55,7 @@ pub struct TrieDB<'db> {
 impl<'db> TrieDB<'db> {
     /// Create a new trie with the backing database `db` and `root`
     /// Returns an error if `root` does not exist
-    pub fn new(db: &'db HashDB, root: &'db H256) -> super::Result<Self> {
+    pub fn new(db: &'db HashDB, root: &'db H256) -> crate::Result<Self> {
         if !db.contains(root) {
             Err(Box::new(TrieError::InvalidStateRoot(*root)))
         } else {
@@ -77,7 +77,7 @@ impl<'db> TrieDB<'db> {
         path: NibbleSlice,
         cur_node_hash: Option<H256>,
         query: Q,
-    ) -> super::Result<Option<Q::Item>> {
+    ) -> crate::Result<Option<Q::Item>> {
         match cur_node_hash {
             Some(hash) => {
                 let node_rlp = self.db.get(&hash).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(hash)))?;
@@ -114,7 +114,7 @@ impl<'db> Trie for TrieDB<'db> {
         self.root
     }
 
-    fn get_with<Q: Query>(&self, key: &[u8], query: Q) -> super::Result<Option<Q::Item>> {
+    fn get_with<Q: Query>(&self, key: &[u8], query: Q) -> crate::Result<Option<Q::Item>> {
         let path = blake256(key);
         let root = *self.root;
 
@@ -124,8 +124,8 @@ impl<'db> Trie for TrieDB<'db> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::*;
     use super::*;
+    use crate::*;
     use memorydb::*;
 
     #[test]

--- a/util/merkle/src/triedbmut.rs
+++ b/util/merkle/src/triedbmut.rs
@@ -20,7 +20,7 @@ use hashdb::DBValue;
 use hashdb::HashDB;
 use primitives::H256;
 
-use super::{Trie, TrieError, TrieMut};
+use crate::{Trie, TrieError, TrieMut};
 use nibbleslice::NibbleSlice;
 use node::Node as RlpNode;
 use triedb::TrieDB;
@@ -49,7 +49,7 @@ impl<'a> TrieDBMut<'a> {
 
     /// Create a new trie with the backing database `db` and `root.
     /// Returns an error if `root` does not exist.
-    pub fn from_existing(db: &'a mut HashDB, root: &'a mut H256) -> super::Result<Self> {
+    pub fn from_existing(db: &'a mut HashDB, root: &'a mut H256) -> crate::Result<Self> {
         if !db.contains(root) {
             return Err(Box::new(TrieError::InvalidStateRoot(*root)))
         }
@@ -67,7 +67,7 @@ impl<'a> TrieDBMut<'a> {
         insert_value: &[u8],
         cur_node_hash: Option<H256>,
         old_val: &mut Option<DBValue>,
-    ) -> super::Result<H256> {
+    ) -> crate::Result<H256> {
         match cur_node_hash {
             Some(hash) => {
                 let node_rlp = self.db.get(&hash).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(hash)))?;
@@ -177,7 +177,7 @@ impl<'a> TrieDBMut<'a> {
         path: NibbleSlice,
         cur_node_hash: Option<H256>,
         old_val: &mut Option<DBValue>,
-    ) -> super::Result<Option<H256>> {
+    ) -> crate::Result<Option<H256>> {
         match cur_node_hash {
             Some(hash) => {
                 let node_rlp = self.db.get(&hash).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(hash)))?;
@@ -306,13 +306,13 @@ impl<'a> TrieMut for TrieDBMut<'a> {
         *self.root == BLAKE_NULL_RLP
     }
 
-    fn get(&self, key: &[u8]) -> super::Result<Option<DBValue>> {
+    fn get(&self, key: &[u8]) -> crate::Result<Option<DBValue>> {
         let t = TrieDB::new(self.db, self.root)?;
 
         t.get(key)
     }
 
-    fn insert(&mut self, key: &[u8], value: &[u8]) -> super::Result<Option<DBValue>> {
+    fn insert(&mut self, key: &[u8], value: &[u8]) -> crate::Result<Option<DBValue>> {
         let path = blake256(key);
         let mut old_val = None;
         let cur_hash = *self.root;
@@ -321,7 +321,7 @@ impl<'a> TrieMut for TrieDBMut<'a> {
         Ok(old_val)
     }
 
-    fn remove(&mut self, key: &[u8]) -> super::Result<Option<DBValue>> {
+    fn remove(&mut self, key: &[u8]) -> crate::Result<Option<DBValue>> {
         let path = blake256(key);
         let mut old_val = None;
         let cur_hash = *self.root;
@@ -338,10 +338,10 @@ impl<'a> TrieMut for TrieDBMut<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::triehash::trie_root;
-    use super::super::TrieMut;
     use super::*;
     use ccrypto::BLAKE_NULL_RLP;
+    use crate::triehash::trie_root;
+    use crate::TrieMut;
     use memorydb::*;
     use primitives::bytes::ToPretty;
     use standardmap::*;

--- a/util/primitives/src/lib.rs
+++ b/util/primitives/src/lib.rs
@@ -19,7 +19,7 @@ extern crate ethereum_types;
 
 mod hash;
 
-pub use self::hash::{H1024, H128, H160, H256, H264, H32, H512, H520, H64};
+pub use crate::hash::{H1024, H128, H160, H256, H264, H32, H512, H520, H64};
 pub use ebytes::Bytes;
 pub use ethereum_types::{clean_0x, U128, U256, U512};
 

--- a/util/random/src/lib.rs
+++ b/util/random/src/lib.rs
@@ -16,7 +16,7 @@
 
 extern crate rand;
 
-pub use self::random::new;
+pub use crate::random::new;
 pub use rand::Rng;
 
 #[cfg(not(test))]

--- a/util/timer/src/lib.rs
+++ b/util/timer/src/lib.rs
@@ -18,4 +18,6 @@ extern crate parking_lot;
 
 mod timer;
 
-pub use timer::{ScheduleError as TimerScheduleError, TimeoutHandler, TimerApi, TimerLoop, TimerName, TimerToken};
+pub use crate::timer::{
+    ScheduleError as TimerScheduleError, TimeoutHandler, TimerApi, TimerLoop, TimerName, TimerToken,
+};

--- a/vm/src/decoder.rs
+++ b/vm/src/decoder.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use instruction::Instruction;
-use opcode;
+use crate::instruction::Instruction;
+use crate::opcode;
 
 #[derive(Debug, PartialEq)]
 pub enum DecoderError {

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -24,7 +24,7 @@ use ctypes::util::tag::Tag;
 use primitives::{H160, H256};
 
 
-use instruction::{has_expensive_opcodes, is_valid_unlock_script, Instruction};
+use crate::instruction::{has_expensive_opcodes, is_valid_unlock_script, Instruction};
 
 const DEFAULT_MAX_MEMORY: usize = 1024;
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -32,5 +32,5 @@ mod opcode;
 #[cfg(test)]
 mod tests;
 
-pub use decoder::{decode, DecoderError};
-pub use executor::{execute, ChainTimeInfo, Config as VMConfig, RuntimeError, ScriptResult};
+pub use crate::decoder::{decode, DecoderError};
+pub use crate::executor::{execute, ChainTimeInfo, Config as VMConfig, RuntimeError, ScriptResult};

--- a/vm/src/tests/decoder.rs
+++ b/vm/src/tests/decoder.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use decoder::{decode, DecoderError};
-use instruction::Instruction;
-use opcode;
+use crate::decoder::{decode, DecoderError};
+use crate::instruction::Instruction;
+use crate::opcode;
 
 macro_rules! test_no_argument_opcode {
     ($opcode:ident, $instruction:ident) => {

--- a/vm/src/tests/executor_tests/chk_multi_sig.rs
+++ b/vm/src/tests/executor_tests/chk_multi_sig.rs
@@ -22,8 +22,8 @@ use rlp::Encodable;
 
 use secp256k1::key::{SecretKey, MINUS_ONE_KEY, ONE_KEY};
 
-use executor::{execute, Config, RuntimeError, ScriptResult};
-use instruction::Instruction;
+use crate::executor::{execute, Config, RuntimeError, ScriptResult};
+use crate::instruction::Instruction;
 
 use super::executor::get_test_client;
 

--- a/vm/src/tests/executor_tests/chk_sig.rs
+++ b/vm/src/tests/executor_tests/chk_sig.rs
@@ -22,8 +22,8 @@ use rlp::Encodable;
 
 use secp256k1::key::{SecretKey, MINUS_ONE_KEY, ONE_KEY};
 
-use executor::{execute, Config, ScriptResult};
-use instruction::Instruction;
+use crate::executor::{execute, Config, ScriptResult};
+use crate::instruction::Instruction;
 
 use super::executor::get_test_client;
 

--- a/vm/src/tests/executor_tests/executor.rs
+++ b/vm/src/tests/executor_tests/executor.rs
@@ -19,8 +19,8 @@ use ckey::NetworkId;
 use ctypes::transaction::{AssetOutPoint, AssetTransferInput, Transaction};
 use primitives::{H160, H256};
 
-use executor::{execute, ChainTimeInfo, Config, RuntimeError, ScriptResult};
-use instruction::Instruction;
+use crate::executor::{execute, ChainTimeInfo, Config, RuntimeError, ScriptResult};
+use crate::instruction::Instruction;
 
 #[cfg(test)]
 pub struct TestClient {


### PR DESCRIPTION
In [rust 1.30](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html), a new keyword `crate` was introduced for module path specification.
It significantly improves readability for deeply nested files, by replacing `super::super::...` to `crate::...`.
This patch applies this new keyword to all existing code except for some parity-originated crates.