### PR TITLE
Introduce orders

### DIFF
--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -1502,6 +1502,7 @@ pub mod test {
             burns: vec![],
             inputs: vec![],
             outputs: vec![],
+            orders: vec![],
         };
         let parcel = Parcel {
             seq: 0,

--- a/core/src/parcel.rs
+++ b/core/src/parcel.rs
@@ -351,12 +351,14 @@ mod tests {
         let burns = vec![];
         let inputs = vec![];
         let outputs = vec![];
+        let orders = vec![];
         let network_id = "tc".into();
         rlp_encode_and_decode_test!(Transaction::AssetTransfer {
             network_id,
             burns,
             inputs,
             outputs,
+            orders,
         });
     }
 

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -135,6 +135,7 @@ When `Transaction` is included in any response, there will be an additional fiel
  - burns: `AssetTransferInput[]`
  - inputs: `AssetTransferInput[]`
  - outputs: `AssetTransferOutput[]`
+ - orders: `OrderOnTransfer[]`
 
 ### AssetComposeData
 
@@ -187,6 +188,26 @@ When `Transaction` is included in any response, there will be an additional fiel
  - parameters: `number[][]`
  - assetType: `H256`
  - amount: `U64`
+
+### Order
+
+ - assetTypeFrom: `H256`
+ - assetTypeTo: `H256`
+ - assetTypeFee: `H256`
+ - assetAmountFrom: `U64`
+ - assetAmountTo: `U64`
+ - assetAmountFee: `U64`
+ - originOutputs: `AssetOutPoint[]`
+ - expiration: `number`
+ - lockScriptHash: `H160`
+ - parameters: `number[][]`
+
+### OrderOnTransfer
+
+ - order: `Order`
+ - spentAmount: `U64`
+ - inputIndices: `number[]`
+ - outputIndices: `number[]`
 
 ## Signature
 `H520` for ECDSA signature | `H512` for Schnorr signature

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -827,6 +827,7 @@ mod tests {
                 asset_type,
                 amount: 30,
             }],
+            orders: vec![],
         };
 
         assert_eq!(
@@ -913,6 +914,7 @@ mod tests {
                     amount: 15,
                 },
             ],
+            orders: vec![],
         };
         let transfer_hash = transfer.hash();
 
@@ -992,6 +994,7 @@ mod tests {
             }],
             inputs: vec![],
             outputs: vec![],
+            orders: vec![],
         };
 
         assert_eq!(
@@ -1083,6 +1086,7 @@ mod tests {
                     amount: 15,
                 },
             ],
+            orders: vec![],
         };
         let transfer_hash = transfer.hash();
 
@@ -1118,6 +1122,7 @@ mod tests {
             }],
             inputs: vec![],
             outputs: vec![],
+            orders: vec![],
         };
 
         assert_eq!(
@@ -1191,6 +1196,7 @@ mod tests {
                 asset_type,
                 amount: 20,
             }],
+            orders: vec![],
         };
 
         assert_eq!(
@@ -1297,6 +1303,7 @@ mod tests {
                 asset_type: asset_type2,
                 amount: 30,
             }],
+            orders: vec![],
         };
 
         assert_eq!(
@@ -1985,6 +1992,7 @@ mod tests {
                     amount: 15,
                 },
             ],
+            orders: vec![],
         };
         let transfer_hash = transfer.hash();
 
@@ -2095,6 +2103,7 @@ mod tests {
                 asset_type,
                 amount: 30,
             }],
+            orders: vec![],
         };
 
         let sender = address();
@@ -2146,6 +2155,7 @@ mod tests {
                     amount: 15,
                 },
             ],
+            orders: vec![],
         };
         let successful_transfer_hash = successful_transfer.hash();
 

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -1358,6 +1358,7 @@ mod tests_parcel {
                 asset_type,
                 amount: 30,
             }],
+            orders: vec![],
         };
         let mint_parcel = Parcel {
             fee: 11,
@@ -1438,6 +1439,7 @@ mod tests_parcel {
                 asset_type,
                 amount: 30,
             }],
+            orders: Vec::new(),
         };
         let mint_parcel = Parcel {
             fee: 11,
@@ -1747,6 +1749,7 @@ mod tests_parcel {
                     amount: 15,
                 },
             ],
+            orders: Vec::new(),
         };
         let transfer_hash = transfer.hash();
 
@@ -2119,6 +2122,7 @@ mod tests_parcel {
                     amount: 15,
                 },
             ],
+            orders: Vec::new(),
         };
         let transfer_tx_hash = transfer_tx.hash();
 
@@ -2359,6 +2363,7 @@ mod tests_parcel {
                     amount: 15,
                 },
             ],
+            orders: Vec::new(),
         };
 
         let parcel = Parcel {

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -1602,7 +1602,10 @@ mod tests_parcel {
 
         let asset_address = OwnedAssetAddress::new(transaction_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_scheme_address.into(), lock_script_hash, parameters, amount))), asset);
+        assert_eq!(
+            Ok(Some(OwnedAsset::new(asset_scheme_address.into(), lock_script_hash, parameters, amount, None))),
+            asset
+        );
     }
 
     #[test]
@@ -1657,7 +1660,7 @@ mod tests_parcel {
         let asset_address = OwnedAssetAddress::new(transaction_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
         assert_eq!(
-            Ok(Some(OwnedAsset::new(asset_scheme_address.into(), lock_script_hash, parameters, ::std::u64::MAX))),
+            Ok(Some(OwnedAsset::new(asset_scheme_address.into(), lock_script_hash, parameters, ::std::u64::MAX, None))),
             asset
         );
     }
@@ -1712,7 +1715,7 @@ mod tests_parcel {
         let asset_address = OwnedAssetAddress::new(mint_hash, 0, shard_id);
 
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], 30))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], 30, None))), asset);
 
         let random_lock_script_hash = H160::random();
         let transfer = Transaction::AssetTransfer {
@@ -1778,15 +1781,15 @@ mod tests_parcel {
 
         let asset0_address = OwnedAssetAddress::new(transfer_hash, 0, shard_id);
         let asset0 = state.asset(shard_id, &asset0_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![vec![1]], 10))), asset0);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![vec![1]], 10, None))), asset0);
 
         let asset1_address = OwnedAssetAddress::new(transfer_hash, 1, shard_id);
         let asset1 = state.asset(shard_id, &asset1_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], 5))), asset1);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], 5, None))), asset1);
 
         let asset2_address = OwnedAssetAddress::new(transfer_hash, 2, shard_id);
         let asset2 = state.asset(shard_id, &asset2_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, random_lock_script_hash, vec![], 15))), asset2);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, random_lock_script_hash, vec![], 15, None))), asset2);
     }
 
     #[test]
@@ -1887,7 +1890,7 @@ mod tests_parcel {
         let asset_type = asset_scheme_address.into();
         let asset_address = OwnedAssetAddress::new(parcel_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount, None))), asset);
 
         let unwrap_ccc_tx = Transaction::AssetUnwrapCCC {
             network_id,
@@ -1961,7 +1964,7 @@ mod tests_parcel {
         let asset_type = asset_scheme_address.into();
         let asset_address = OwnedAssetAddress::new(parcel_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount, None))), asset);
 
         let failed_lock_script = vec![0x02];
         let unwrap_ccc_tx = Transaction::AssetUnwrapCCC {
@@ -2001,7 +2004,7 @@ mod tests_parcel {
 
         let asset_address = OwnedAssetAddress::new(parcel_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount, None))), asset);
     }
 
     #[test]
@@ -2084,7 +2087,7 @@ mod tests_parcel {
         let asset_type = asset_scheme_address.into();
         let asset_address = OwnedAssetAddress::new(parcel_hash, 0, shard_id);
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![], amount, None))), asset);
 
         let lock_script_hash_burn = H160::from("ca5d3fa0a6887285ef6aa85cb12960a2b6706e00");
         let random_lock_script_hash = H160::random();
@@ -2147,15 +2150,15 @@ mod tests_parcel {
 
         let asset0_address = OwnedAssetAddress::new(transfer_tx_hash, 0, shard_id);
         let asset0 = state.asset(shard_id, &asset0_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![vec![1]], 10))), asset0);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, vec![vec![1]], 10, None))), asset0);
 
         let asset1_address = OwnedAssetAddress::new(transfer_tx_hash, 1, shard_id);
         let asset1 = state.asset(shard_id, &asset1_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash_burn, vec![], 5))), asset1);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash_burn, vec![], 5, None))), asset1);
 
         let asset2_address = OwnedAssetAddress::new(transfer_tx_hash, 2, shard_id);
         let asset2 = state.asset(shard_id, &asset2_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, random_lock_script_hash, vec![], 15))), asset2);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, random_lock_script_hash, vec![], 15, None))), asset2);
 
         let unwrap_ccc_tx = Transaction::AssetUnwrapCCC {
             network_id,
@@ -2669,7 +2672,7 @@ mod tests_parcel {
 
         let asset_type = asset_scheme_address.into();
         let asset = state.asset(shard_id, &asset_address);
-        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, parameters, amount))), asset);
+        assert_eq!(Ok(Some(OwnedAsset::new(asset_type, lock_script_hash, parameters, amount, None))), asset);
     }
 
     #[test]

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#approval-lib",
+    "codechain-sdk": "https://github.com/jhs7jhs/codechain-sdk-js.git#order-lib",
     "codechain-test-helper": "https://github.com/CodeChain-io/codechain-test-helper-js.git#ca7035acba6213ea65ef2795df8821499d7d29ca",
     "lodash": "^4.17.11",
     "mocha": "^5.2.0",

--- a/test/src/helper/error.ts
+++ b/test/src/helper/error.ts
@@ -120,6 +120,51 @@ export const ERROR = {
         code: -32099,
         data: stringContaining("InvalidTransaction(DuplicatedPreviousOutput"),
         message: anything
+    },
+    ORDER_IS_NOT_EMPTY: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("OrderIsNotEmpty")
+    },
+    INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InconsistentTransactionInOutWithOrders")
+    },
+    INVALID_ORIGIN_OUTPUTS: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOriginOutputs")
+    },
+    INVALID_ORDER_ASSET_AMOUNTS: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOrderAssetAmounts")
+    },
+    INVALID_ORDER_ASSET_TYPES: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOrderAssetTypes")
+    },
+    INVALID_ORDER_LOCK_SCRIPT_HASH: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOrderLockScriptHash")
+    },
+    INVALID_ORDER_PARAMETERS: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOrderParameters")
+    },
+    INVALID_OUTPUT_WITH_ORDER: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("InvalidOutputWithOrder")
+    },
+    ORDER_EXPIRED: {
+        code: -32099,
+        message: anything,
+        data: stringContaining("OrderExpired")
     }
 };
 

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -17,6 +17,8 @@
 import { ChildProcess, spawn } from "child_process";
 import { SDK } from "codechain-sdk";
 import {
+    AssetComposeTransaction,
+    AssetDecomposeTransaction,
     AssetTransferAddress,
     AssetTransferInput,
     AssetTransferTransaction,
@@ -468,8 +470,11 @@ export default class CodeChain {
         return { asset };
     }
 
-    public async signTransferInput(
-        tx: AssetTransferTransaction,
+    public async signTransactionInput(
+        tx:
+            | AssetTransferTransaction
+            | AssetComposeTransaction
+            | AssetDecomposeTransaction,
         index: number
     ) {
         const keyStore = await this.sdk.key.createLocalKeyStore(
@@ -478,7 +483,7 @@ export default class CodeChain {
         await this.sdk.key.signTransactionInput(tx, index, { keyStore });
     }
 
-    public async signTransferBurn(
+    public async signTransactionBurn(
         tx: AssetTransferTransaction | AssetUnwrapCCCTransaction,
         index: number
     ) {

--- a/test/src/integration/chain.test.ts
+++ b/test/src/integration/chain.test.ts
@@ -345,7 +345,7 @@ describe("chain", function() {
             recipient,
             amount: "0xa"
         });
-        await node.signTransferInput(tx, 0);
+        await node.signTransactionInput(tx, 0);
         const invoices = await node.sendTransaction(tx);
         expect(invoices!.length).to.equal(1);
         expect(invoices![0].success).to.be.true;

--- a/test/src/integration/mempool.test.ts
+++ b/test/src/integration/mempool.test.ts
@@ -238,7 +238,7 @@ describe("Timelock", function() {
             assetType: asset.assetType,
             recipient: await node.createP2PKHAddress()
         });
-        await node.signTransferInput(tx, 0);
+        await node.signTransactionInput(tx, 0);
         await node.sendTransaction(tx, { awaitInvoice: false });
         return tx.hash();
     }
@@ -322,7 +322,7 @@ describe("Timelock", function() {
             assetType: asset.assetType,
             recipient: await node.createP2PKHAddress()
         });
-        await node.signTransferInput(tx, 0);
+        await node.signTransactionInput(tx, 0);
         try {
             await node.sendTransaction(tx, { awaitInvoice: false });
             expect.fail();
@@ -391,7 +391,7 @@ describe("Timelock", function() {
             assetType: asset.assetType,
             recipient: await node.createP2PKHAddress()
         });
-        await node.signTransferInput(tx, 0);
+        await node.signTransactionInput(tx, 0);
         const { fee } = options;
         await node.sendTransaction(tx, { awaitInvoice: false, fee });
         return tx.hash();
@@ -464,7 +464,7 @@ describe("Timelock", function() {
                     recipient
                 }))
             );
-            await node.signTransferInput(transferTx, 0);
+            await node.signTransactionInput(transferTx, 0);
             await node.sendTransaction(transferTx);
             return transferTx.getTransferredAssets();
         }
@@ -488,8 +488,8 @@ describe("Timelock", function() {
                 })
             ]);
             tx.addOutputs({ amount: 2, recipient, assetType });
-            await node.signTransferInput(tx, 0);
-            await node.signTransferInput(tx, 1);
+            await node.signTransactionInput(tx, 0);
+            await node.signTransactionInput(tx, 1);
             await node.sendTransaction(tx, { awaitInvoice: false });
 
             expect(await node.getBestBlockNumber()).to.equal(3);
@@ -524,8 +524,8 @@ describe("Timelock", function() {
                 })
             ]);
             tx.addOutputs({ amount: 2, recipient, assetType });
-            await node.signTransferInput(tx, 0);
-            await node.signTransferInput(tx, 1);
+            await node.signTransactionInput(tx, 0);
+            await node.signTransactionInput(tx, 1);
             await node.sendTransaction(tx, { awaitInvoice: false });
 
             expect(await node.getBestBlockNumber()).to.equal(3);
@@ -560,8 +560,8 @@ describe("Timelock", function() {
                 })
             ]);
             tx.addOutputs({ amount: 2, recipient, assetType });
-            await node.signTransferInput(tx, 0);
-            await node.signTransferInput(tx, 1);
+            await node.signTransactionInput(tx, 0);
+            await node.signTransactionInput(tx, 1);
             await node.sendTransaction(tx, { awaitInvoice: false });
 
             expect(await node.getBestBlockNumber()).to.equal(3);
@@ -591,8 +591,8 @@ describe("Timelock", function() {
                 })
             ]);
             tx.addOutputs({ amount: 2, recipient, assetType });
-            await node.signTransferInput(tx, 0);
-            await node.signTransferInput(tx, 1);
+            await node.signTransactionInput(tx, 0);
+            await node.signTransactionInput(tx, 1);
             await node.sendTransaction(tx, { awaitInvoice: false });
 
             expect(await node.getBestBlockNumber()).to.equal(3);

--- a/test/src/integration/sync.test.ts
+++ b/test/src/integration/sync.test.ts
@@ -217,7 +217,7 @@ describe("sync", function() {
                         }
                     );
 
-                    await nodeA.signTransferInput(tx1, 0);
+                    await nodeA.signTransactionInput(tx1, 0);
                     const invoices1 = await nodeA.sendTransaction(tx1);
                     expect(invoices1!.length).to.equal(1);
                     expect(invoices1![0].success).to.be.true;
@@ -230,7 +230,7 @@ describe("sync", function() {
                         amount: 100
                     });
 
-                    await nodeA.signTransferInput(tx2, 0);
+                    await nodeA.signTransactionInput(tx2, 0);
                     const invoicesA = await nodeA.sendTransaction(tx2);
                     expect(invoicesA!.length).to.equal(1);
                     expect(invoicesA![0].success).to.be.false;

--- a/test/src/integration/transactions.test.ts
+++ b/test/src/integration/transactions.test.ts
@@ -110,7 +110,7 @@ describe("transactions", function() {
                         amount
                     }))
                 );
-                await node.signTransferInput(tx, 0);
+                await node.signTransactionInput(tx, 0);
                 const invoices = await node.sendTransaction(tx);
                 expect(invoices!.length).to.equal(1);
                 expect(invoices![0].success).to.be.true;
@@ -129,7 +129,7 @@ describe("transactions", function() {
                         amount
                     }))
                 );
-                await node.signTransferInput(tx, 0);
+                await node.signTransactionInput(tx, 0);
                 try {
                     await node.sendTransaction(tx);
                     expect.fail();
@@ -153,7 +153,7 @@ describe("transactions", function() {
                     amount
                 }))
             );
-            await node.signTransferInput(tx, 0);
+            await node.signTransactionInput(tx, 0);
             try {
                 await node.sendTransaction(tx);
                 expect.fail();
@@ -174,7 +174,7 @@ describe("transactions", function() {
                 recipient,
                 amount
             });
-            await node.signTransferInput(tx, 0);
+            await node.signTransactionInput(tx, 0);
             try {
                 await node.sendTransaction(tx);
                 expect.fail();
@@ -194,7 +194,7 @@ describe("transactions", function() {
                 recipient,
                 amount: amount * 2
             });
-            await node.signTransferInput(tx, 0);
+            await node.signTransactionInput(tx, 0);
             try {
                 await node.sendTransaction(tx);
                 expect.fail();
@@ -250,8 +250,8 @@ describe("transactions", function() {
                         }))
                     ])
                 );
-                await node.signTransferInput(tx, 0);
-                await node.signTransferInput(tx, 1);
+                await node.signTransactionInput(tx, 0);
+                await node.signTransactionInput(tx, 1);
                 const invoices = await node.sendTransaction(tx);
                 expect(invoices!.length).to.equal(1);
                 expect(invoices![0].success).to.be.true;
@@ -268,7 +268,7 @@ describe("transactions", function() {
             recipient: await node.createP2PKHBurnAddress(),
             amount: 1
         });
-        await node.signTransferInput(tx1, 0);
+        await node.signTransactionInput(tx1, 0);
         const invoices1 = await node.sendTransaction(tx1);
         expect(invoices1!.length).to.equal(1);
         expect(invoices1![0].success).to.be.true;
@@ -276,7 +276,7 @@ describe("transactions", function() {
         const transferredAsset = tx1.getTransferredAsset(0);
         const tx2 = node.sdk.core.createAssetTransferTransaction();
         tx2.addBurns(transferredAsset);
-        await node.signTransferBurn(tx2, 0);
+        await node.signTransactionBurn(tx2, 0);
         const invoices2 = await node.sendTransaction(tx2);
         expect(invoices2!.length).to.equal(1);
         expect(invoices2![0].success).to.be.true;
@@ -293,7 +293,7 @@ describe("transactions", function() {
             recipient: await node.createP2PKHBurnAddress(),
             amount: 1
         });
-        await node.signTransferInput(tx1, 0);
+        await node.signTransactionInput(tx1, 0);
         const invoices = await node.sendTransaction(tx1);
         expect(invoices!.length).to.equal(1);
         expect(invoices![0].success).to.be.true;
@@ -316,7 +316,7 @@ describe("transactions", function() {
                 }
             })
         );
-        await node.signTransferBurn(tx2, 0);
+        await node.signTransactionBurn(tx2, 0);
         try {
             await node.sendTransaction(tx2);
             expect.fail();
@@ -334,7 +334,7 @@ describe("transactions", function() {
             recipient: await node.createP2PKHBurnAddress(),
             amount: 1
         });
-        await node.signTransferInput(tx1, 0);
+        await node.signTransactionInput(tx1, 0);
         const invoices1 = await node.sendTransaction(tx1);
         expect(invoices1!.length).to.equal(1);
         expect(invoices1![0].success).to.be.true;
@@ -403,7 +403,7 @@ describe("transactions", function() {
                 amount: 10000,
                 recipient: await node.createP2PKHAddress()
             });
-            await node.signTransferInput(transferTx, 0);
+            await node.signTransactionInput(transferTx, 0);
         });
 
         it("approver sends a parcel", async function() {
@@ -969,7 +969,7 @@ describe("transactions", function() {
                 const tx = node.sdk.core.createAssetUnwrapCCCTransaction({
                     burn: wrapParcel.getAsset()
                 });
-                await node.signTransferBurn(tx, 0);
+                await node.signTransactionBurn(tx, 0);
                 const invoices = await node.sendTransaction(tx);
                 expect(invoices!.length).to.equal(1);
                 expect(invoices![0].success).to.be.true;
@@ -1017,7 +1017,7 @@ describe("transactions", function() {
                     recipient: recipientBurn,
                     amount
                 });
-                await node.signTransferInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 0);
                 const invoices1 = await node.sendTransaction(transferTx);
                 expect(invoices1!.length).to.equal(1);
                 expect(invoices1![0].success).to.be.true;
@@ -1030,7 +1030,7 @@ describe("transactions", function() {
                 const unwrapTx = node.sdk.core.createAssetUnwrapCCCTransaction({
                     burn: asset2!
                 });
-                await node.signTransferBurn(unwrapTx, 0);
+                await node.signTransactionBurn(unwrapTx, 0);
                 const invoices2 = await node.sendTransaction(unwrapTx);
                 expect(invoices2!.length).to.equal(1);
                 expect(invoices2![0].success).to.be.true;
@@ -1061,7 +1061,7 @@ describe("transactions", function() {
                 const tx = node.sdk.core.createAssetUnwrapCCCTransaction({
                     burn: mintTx.getMintedAsset()
                 });
-                await node.signTransferBurn(tx, 0);
+                await node.signTransactionBurn(tx, 0);
                 try {
                     await node.sendTransaction(tx);
                     expect.fail();

--- a/test/src/integration/transactionsWithOrders.test.ts
+++ b/test/src/integration/transactionsWithOrders.test.ts
@@ -1,0 +1,1747 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import * as _ from "lodash";
+import {
+    Asset,
+    H256,
+    AssetTransferAddress,
+    AssetOutPoint,
+    Order,
+    U64,
+    H160
+} from "codechain-sdk/lib/core/classes";
+
+import CodeChain from "../helper/spawn";
+import { ERROR, errorMatcher } from "../helper/error";
+import { faucetAddress, faucetSecret } from "../helper/constants";
+
+import "mocha";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe("transactions", function() {
+    let node: CodeChain;
+
+    before(async function() {
+        node = new CodeChain();
+        await node.start();
+    });
+
+    describe("AssetTransfer with orders", function() {
+        describe("Mint one asset", function() {
+            let aliceAddress: AssetTransferAddress;
+
+            let gold: Asset;
+
+            beforeEach(async function() {
+                aliceAddress = await node.createP2PKHAddress();
+                gold = (await node.mintAsset({
+                    amount: 10000,
+                    recipient: aliceAddress
+                })).asset;
+            });
+
+            it("Wrong order - originOutputs are wrong (asset type from/to is same)", async function() {
+                const splitTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(gold)
+                    .addOutputs(
+                        _.times(2, () => ({
+                            recipient: aliceAddress,
+                            amount: 5000,
+                            assetType: gold.assetType
+                        }))
+                    );
+                await node.signTransactionInput(splitTx, 0);
+
+                const splitInvoices = await node.sendTransaction(splitTx);
+                expect(splitInvoices!.length).to.equal(1);
+                expect(splitInvoices![0].success).to.be.true;
+
+                const splitGolds = splitTx.getTransferredAssets();
+                const splitGoldInputs = splitGolds.map(gold =>
+                    gold.createTransferInput()
+                );
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: new H256(
+                        "0000000000000000000000000000000000000000000000000000000000000000"
+                    ), // Fake asset type
+                    assetAmountFrom: 5000,
+                    assetAmountTo: 5000,
+                    expiration,
+                    originOutputs: [splitGoldInputs[0].prevOut],
+                    recipient: aliceAddress
+                });
+
+                (order.assetTypeTo as any) = gold.assetType;
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(splitGoldInputs)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 5000,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 5000,
+                            assetType: gold.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 5000,
+                        inputIndices: [0],
+                        outputIndices: [0]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORDER_ASSET_TYPES)
+                    );
+                }
+            });
+        });
+
+        describe("Mint two assets", function() {
+            let aliceAddress: AssetTransferAddress;
+            let bobAddress: AssetTransferAddress;
+
+            let gold: Asset;
+            let silver: Asset;
+
+            beforeEach(async function() {
+                aliceAddress = await node.createP2PKHAddress();
+                bobAddress = await node.createP2PKHAddress();
+                gold = (await node.mintAsset({
+                    amount: 10000,
+                    recipient: aliceAddress
+                })).asset;
+                silver = (await node.mintAsset({
+                    amount: 10000,
+                    recipient: bobAddress
+                })).asset;
+            });
+
+            it("Correct order, correct transfer", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            });
+
+            it("Correct order, correct transfer - Many originOutputs", async function() {
+                // Split minted gold asset to 10 assets
+                const splitTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(gold)
+                    .addOutputs(
+                        _.times(10, () => ({
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: gold.assetType
+                        }))
+                    );
+                await node.signTransactionInput(splitTx, 0);
+
+                const splitInvoices = await node.sendTransaction(splitTx);
+                expect(splitInvoices!.length).to.equal(1);
+                expect(splitInvoices![0].success).to.be.true;
+
+                const splitGolds = splitTx.getTransferredAssets();
+                const splitGoldInputs = splitGolds.map(gold =>
+                    gold.createTransferInput()
+                );
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: splitGoldInputs.map(input => input.prevOut),
+                    recipient: aliceAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(splitGoldInputs)
+                    .addInputs(silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: _.range(10),
+                        outputIndices: [0, 1]
+                    });
+                await Promise.all(
+                    _.range(transferTx.inputs.length).map(i =>
+                        node.signTransactionInput(transferTx, i)
+                    )
+                );
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            }).timeout(10_000);
+
+            it("Correct order, correct transfer - Output(to) is empty", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 10000,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 10000,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 10000,
+                        inputIndices: [0],
+                        outputIndices: [0]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            });
+
+            it("Correct two orders, correct transfer - Ratio is same", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const aliceOrder = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+
+                const bobOrder = node.sdk.core.createOrder({
+                    assetTypeFrom: silver.assetType,
+                    assetTypeTo: gold.assetType,
+                    assetAmountFrom: 1000,
+                    assetAmountTo: 100,
+                    expiration,
+                    originOutputs: [silverInput.prevOut],
+                    recipient: bobAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order: aliceOrder,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    })
+                    .addOrder({
+                        order: bobOrder,
+                        spentAmount: 1000,
+                        inputIndices: [1],
+                        outputIndices: [2, 3]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            });
+
+            it("Correct two orders, correct transfer - Ratio is different", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const aliceOrder = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+
+                const bobOrder = node.sdk.core.createOrder({
+                    assetTypeFrom: silver.assetType,
+                    assetTypeTo: gold.assetType,
+                    assetAmountFrom: 1000,
+                    assetAmountTo: 50,
+                    expiration,
+                    originOutputs: [silverInput.prevOut],
+                    recipient: bobAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 50,
+                            assetType: gold.assetType
+                        },
+                        // Bob gets more gold than he wanted.
+                        // If there's a relayer, relayer may take it.
+                        {
+                            recipient: bobAddress,
+                            amount: 50,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order: aliceOrder,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    })
+                    .addOrder({
+                        order: bobOrder,
+                        spentAmount: 1000,
+                        inputIndices: [1],
+                        outputIndices: [2, 4]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            });
+
+            it("Correct order, wrong transfer - Output(from) is empty", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 10000,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 10000,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 10000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 0,
+                        inputIndices: [0],
+                        outputIndices: [0]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(
+                            ERROR.INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS
+                        )
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Ratio is wrong", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000 - 10,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000 + 10,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(
+                            ERROR.INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS
+                        )
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Lock script hash is wrong", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+
+                (transferTx.orders[0].order.lockScriptHash as any) = new H160(
+                    "0000000000000000000000000000000000000000"
+                );
+
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORDER_LOCK_SCRIPT_HASH)
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Parameters are wrong", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+
+                (transferTx.orders[0].order.parameters as any) = [];
+
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORDER_PARAMETERS)
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Too many outputs (from)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900 - 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1, 2]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(
+                            ERROR.INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS
+                        )
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Too many outputs (to)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000 - 100,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 100,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1, 2]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(
+                            ERROR.INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS
+                        )
+                    );
+                }
+            });
+
+            it("Correct order, wrong transfer - Too many outputs (both)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900 - 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000 - 100,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 100,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1, 2, 3]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(
+                            ERROR.INCONSISTENT_TRANSACTION_IN_OUT_WITH_ORDERS
+                        )
+                    );
+                }
+            });
+
+            it("Wrong order - originOutputs are wrong (empty)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                (order.originOutputs as any) = [];
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORIGIN_OUTPUTS)
+                    );
+                }
+            });
+
+            it("Wrong order - originOutputs are wrong (prevOut does not match)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [silverInput.prevOut],
+                    recipient: aliceAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORIGIN_OUTPUTS)
+                    );
+                }
+            });
+
+            it("Wrong order - originOutputs are wrong (few outputs)", async function() {
+                // Split minted gold asset to 10 assets
+                const splitTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(gold)
+                    .addOutputs(
+                        _.times(10, () => ({
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: gold.assetType
+                        }))
+                    );
+                await node.signTransactionInput(splitTx, 0);
+
+                const splitInvoices = await node.sendTransaction(splitTx);
+                expect(splitInvoices!.length).to.equal(1);
+                expect(splitInvoices![0].success).to.be.true;
+
+                const splitGolds = splitTx.getTransferredAssets();
+                const splitGoldInputs = splitGolds.map(gold =>
+                    gold.createTransferInput()
+                );
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: splitGoldInputs
+                        .slice(0, 9)
+                        .map(input => input.prevOut),
+                    recipient: aliceAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(splitGoldInputs)
+                    .addInputs(silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: _.range(10),
+                        outputIndices: [0, 1]
+                    });
+                await Promise.all(
+                    _.range(transferTx.inputs.length).map(i =>
+                        node.signTransactionInput(transferTx, i)
+                    )
+                );
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.false;
+            }).timeout(10_000);
+
+            it("Wrong order - originOutputs are wrong (many outputs)", async function() {
+                // Split minted gold asset to 10 assets
+                const splitTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(gold)
+                    .addOutputs(
+                        _.times(10, () => ({
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: gold.assetType
+                        }))
+                    );
+                await node.signTransactionInput(splitTx, 0);
+
+                const splitInvoices = await node.sendTransaction(splitTx);
+                expect(splitInvoices!.length).to.equal(1);
+                expect(splitInvoices![0].success).to.be.true;
+
+                const splitGolds = splitTx.getTransferredAssets();
+                const splitGoldInputs = splitGolds.map(gold =>
+                    gold.createTransferInput()
+                );
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: splitGoldInputs.map(input => input.prevOut),
+                    recipient: aliceAddress
+                });
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(splitGoldInputs.slice(0, 9))
+                    .addInputs(silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 8900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: _.range(9),
+                        outputIndices: [0, 1]
+                    });
+                await Promise.all(
+                    _.range(transferTx.inputs.length).map(i =>
+                        node.signTransactionInput(transferTx, i)
+                    )
+                );
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.false;
+            }).timeout(10_000);
+
+            it("Wrong order - Ratio is wrong (from is zero)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                (order.assetAmountFrom as any) = new U64(0);
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORDER_ASSET_AMOUNTS)
+                    );
+                }
+            });
+
+            it("Wrong order - Ratio is wrong (to is zero)", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                (order.assetAmountTo as any) = new U64(0);
+
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(
+                        errorMatcher(ERROR.INVALID_ORDER_ASSET_AMOUNTS)
+                    );
+                }
+            });
+
+            it("Wrong order - Expiration is old", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = 0;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 1000,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 100,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 100,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx, 0);
+                await node.signTransactionInput(transferTx, 1);
+
+                const parcel = node.sdk.core
+                    .createAssetTransactionParcel({
+                        transaction: transferTx
+                    })
+                    .sign({
+                        secret: faucetSecret,
+                        fee: 10,
+                        seq: await node.sdk.rpc.chain.getSeq(faucetAddress)
+                    });
+
+                try {
+                    await node.sdk.rpc.chain.sendSignedParcel(parcel);
+                    expect.fail();
+                } catch (e) {
+                    expect(e).to.satisfy(errorMatcher(ERROR.ORDER_EXPIRED));
+                }
+            });
+
+            it("Successful partial fills", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+
+                const transferTx1 = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9950,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 500,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 50,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9500,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 50,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx1, 0);
+                await node.signTransactionInput(transferTx1, 1);
+
+                const invoices1 = await node.sendTransaction(transferTx1);
+                expect(invoices1!.length).to.equal(1);
+                expect(invoices1![0].success).to.be.true;
+
+                const orderConsumed = order.consume(50);
+                const transferTx2 = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(
+                        transferTx1.getTransferredAsset(0),
+                        transferTx1.getTransferredAsset(3)
+                    )
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9900,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 500,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 50,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9000,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order: orderConsumed,
+                        spentAmount: 50,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx2, 0);
+                await node.signTransactionInput(transferTx2, 1);
+
+                const invoices2 = await node.sendTransaction(transferTx2);
+                expect(invoices2!.length).to.equal(1);
+                expect(invoices2![0].success).to.be.true;
+            }).timeout(10_000);
+
+            it("Successful partial cancel", async function() {
+                const goldInput = gold.createTransferInput();
+                const silverInput = silver.createTransferInput();
+
+                const expiration = Math.round(Date.now() / 1000) + 120;
+                const order = node.sdk.core.createOrder({
+                    assetTypeFrom: gold.assetType,
+                    assetTypeTo: silver.assetType,
+                    assetAmountFrom: 100,
+                    assetAmountTo: 1000,
+                    expiration,
+                    originOutputs: [goldInput.prevOut],
+                    recipient: aliceAddress
+                });
+                const transferTx1 = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(goldInput, silverInput)
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9950,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: aliceAddress,
+                            amount: 500,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 50,
+                            assetType: gold.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9500,
+                            assetType: silver.assetType
+                        }
+                    )
+                    .addOrder({
+                        order,
+                        spentAmount: 50,
+                        inputIndices: [0],
+                        outputIndices: [0, 1]
+                    });
+                await node.signTransactionInput(transferTx1, 0);
+                await node.signTransactionInput(transferTx1, 1);
+
+                const invoices1 = await node.sendTransaction(transferTx1);
+                expect(invoices1!.length).to.equal(1);
+                expect(invoices1![0].success).to.be.true;
+
+                const transferTx2 = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(
+                        transferTx1.getTransferredAsset(0),
+                        transferTx1.getTransferredAsset(3)
+                    )
+                    .addOutputs(
+                        {
+                            recipient: aliceAddress,
+                            amount: 9500,
+                            assetType: silver.assetType
+                        },
+                        {
+                            recipient: bobAddress,
+                            amount: 9950,
+                            assetType: gold.assetType
+                        }
+                    );
+                await node.signTransactionInput(transferTx2, 0);
+                await node.signTransactionInput(transferTx2, 1);
+
+                const invoices2 = await node.sendTransaction(transferTx2);
+                expect(invoices2!.length).to.equal(1);
+                expect(invoices2![0].success).to.be.true;
+            });
+        }).timeout(10_000);
+
+        describe("Mint five assets", function() {
+            let addresses: AssetTransferAddress[];
+            let assets: Asset[];
+
+            beforeEach(async function() {
+                addresses = [];
+                assets = [];
+                for (let i = 0; i < 5; i++) {
+                    const address = await node.createP2PKHAddress();
+                    const { asset } = await node.mintAsset({
+                        amount: 10000,
+                        recipient: address
+                    });
+                    addresses.push(address);
+                    assets.push(asset);
+                }
+            });
+
+            it("Multiple orders", async function() {
+                const inputs = assets.map(asset => asset.createTransferInput());
+
+                let transferTx = node.sdk.core
+                    .createAssetTransferTransaction()
+                    .addInputs(inputs)
+                    .addOutputs([
+                        ..._.range(5).map(i => ({
+                            recipient: addresses[i],
+                            amount: 50,
+                            assetType: assets[(i + 1) % 5].assetType
+                        })),
+                        ..._.range(5).map(i => ({
+                            recipient: addresses[i],
+                            amount: 9950,
+                            assetType: assets[i].assetType
+                        }))
+                    ]);
+
+                for (let i = 0; i < 5; i++) {
+                    const order = node.sdk.core.createOrder({
+                        assetTypeFrom: assets[i].assetType,
+                        assetTypeTo: assets[(i + 1) % 5].assetType,
+                        assetAmountFrom: 100,
+                        assetAmountTo: 100,
+                        expiration: U64.MAX_VALUE,
+                        originOutputs: [inputs[i].prevOut],
+                        recipient: addresses[i]
+                    });
+                    transferTx.addOrder({
+                        order,
+                        spentAmount: 50,
+                        inputIndices: [i],
+                        outputIndices: [i, i + 5]
+                    });
+                }
+
+                await Promise.all(
+                    _.range(transferTx.inputs.length).map(i =>
+                        node.signTransactionInput(transferTx, i)
+                    )
+                );
+
+                const invoices = await node.sendTransaction(transferTx);
+                expect(invoices!.length).to.equal(1);
+                expect(invoices![0].success).to.be.true;
+            }).timeout(10_000);
+        });
+    });
+
+    afterEach(function() {
+        if (this.currentTest!.state === "failed") {
+            node.testFailed(this.currentTest!.fullTitle());
+        }
+    });
+
+    after(async function() {
+        await node.clean();
+    });
+});

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -876,13 +876,13 @@ codechain-primitives@^0.4.2, codechain-primitives@^0.4.3:
     request-promise "^4.2.2"
     rlp "^2.0.0"
 
-"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#approval-lib":
+"codechain-sdk@https://github.com/jhs7jhs/codechain-sdk-js.git#order-lib":
   version "0.5.1"
-  resolved "https://github.com/sgkim126/codechain-sdk-js.git#1faa8f506f1e2737e667b23d64bc559aac737e60"
+  resolved "https://github.com/jhs7jhs/codechain-sdk-js.git#7cb0a1d783b07fecea06c2d3aa891975540c5095"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.5.4"
-    codechain-primitives "^0.4.2"
+    codechain-primitives "^0.4.3"
     jayson "^2.0.6"
     lodash "^4.17.10"
     node-fetch "^2.1.2"

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -21,5 +21,5 @@ mod transaction;
 pub use self::error::Error;
 pub use self::transaction::{
     AssetMintOutput, AssetOutPoint, AssetTransferInput, AssetTransferOutput, AssetWrapCCCOutput, HashingError,
-    InnerTransaction, PartialHashing, Timelock, Transaction,
+    InnerTransaction, Order, OrderOnTransfer, PartialHashing, Timelock, Transaction,
 };

--- a/vm/src/tests/executor_tests/chk_multi_sig.rs
+++ b/vm/src/tests/executor_tests/chk_multi_sig.rs
@@ -35,6 +35,7 @@ fn valid_multi_sig_0_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -75,6 +76,7 @@ fn valid_multi_sig_1_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -97,6 +99,7 @@ fn valid_multi_sig_1_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -126,6 +129,7 @@ fn valid_multi_sig_2_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -148,6 +152,7 @@ fn valid_multi_sig_2_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -179,6 +184,7 @@ fn invalid_multi_sig_1_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -201,6 +207,7 @@ fn invalid_multi_sig_1_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -231,6 +238,7 @@ fn invalid_multi_sig_2_of_2() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -253,6 +261,7 @@ fn invalid_multi_sig_2_of_2() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -284,6 +293,7 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -306,6 +316,7 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -316,6 +327,7 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -347,6 +359,7 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -369,6 +382,7 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -400,6 +414,7 @@ fn invalid_multi_sig_with_less_sig_than_m() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -422,6 +437,7 @@ fn invalid_multi_sig_with_less_sig_than_m() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -451,6 +467,7 @@ fn invalid_multi_sig_with_more_sig_than_m() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -473,6 +490,7 @@ fn invalid_multi_sig_with_more_sig_than_m() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -504,6 +522,7 @@ fn invalid_multi_sig_with_too_many_arg() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -524,6 +543,7 @@ fn invalid_multi_sig_with_too_many_arg() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),

--- a/vm/src/tests/executor_tests/chk_sig.rs
+++ b/vm/src/tests/executor_tests/chk_sig.rs
@@ -35,6 +35,7 @@ fn valid_pay_to_public_key() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -55,6 +56,7 @@ fn valid_pay_to_public_key() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -77,6 +79,7 @@ fn invalid_pay_to_public_key() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -97,6 +100,7 @@ fn invalid_pay_to_public_key() {
             burns: Vec::new(),
             inputs: Vec::new(),
             outputs: Vec::new(),
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -161,6 +165,7 @@ fn sign_all_input_all_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -172,6 +177,7 @@ fn sign_all_input_all_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone(), input1],
             outputs: vec![output0, output1],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -235,6 +241,7 @@ fn sign_single_input_all_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -246,6 +253,7 @@ fn sign_single_input_all_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0, output1],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b10 as u8]),
@@ -308,6 +316,7 @@ fn sign_all_input_partial_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -319,6 +328,7 @@ fn sign_all_input_partial_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone(), input1],
             outputs: vec![output0],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b1, 0b00000101 as u8]),
@@ -381,6 +391,7 @@ fn sign_single_input_partial_output() {
         burns: Vec::new(),
         inputs: vec![input0.clone(), input1.clone()],
         outputs: vec![output0.clone(), output1.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -392,6 +403,7 @@ fn sign_single_input_partial_output() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b1, 0b00000100 as u8]),
@@ -434,6 +446,7 @@ fn distinguish_sign_single_input_with_sign_all() {
         burns: Vec::new(),
         inputs: vec![input0.clone()],
         outputs: vec![output0.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -445,6 +458,7 @@ fn distinguish_sign_single_input_with_sign_all() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),
@@ -488,6 +502,7 @@ fn distinguish_sign_single_output_with_sign_all() {
         burns: Vec::new(),
         inputs: vec![input0.clone()],
         outputs: vec![output0.clone()],
+        orders: Vec::new(),
     };
 
     // Execute sciprt in input0
@@ -499,6 +514,7 @@ fn distinguish_sign_single_output_with_sign_all() {
             burns: Vec::new(),
             inputs: vec![input0.clone()],
             outputs: vec![output0],
+            orders: Vec::new(),
         }
         .rlp_bytes(),
         &blake128(&[0b11 as u8]),

--- a/vm/src/tests/executor_tests/executor.rs
+++ b/vm/src/tests/executor_tests/executor.rs
@@ -83,6 +83,7 @@ fn simple_success() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -114,6 +115,7 @@ fn simple_failure() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -144,6 +146,7 @@ fn simple_burn() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -170,6 +173,7 @@ fn underflow() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -196,6 +200,7 @@ fn out_of_memory() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -234,6 +239,7 @@ fn invalid_unlock_script() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -260,6 +266,7 @@ fn conditional_burn() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -309,6 +316,7 @@ fn _blake256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -384,6 +392,7 @@ fn _ripemd160() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -467,6 +476,7 @@ fn _sha256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -550,6 +560,7 @@ fn _keccak256() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
@@ -632,6 +643,7 @@ fn dummy_tx() -> Transaction {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     }
 }
 
@@ -875,6 +887,7 @@ fn copy_stack_underflow() {
         burns: Vec::new(),
         inputs: Vec::new(),
         outputs: Vec::new(),
+        orders: Vec::new(),
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {


### PR DESCRIPTION
Basic idea is from the [0x Protocol](https://0xproject.com/), but this one is based on the UTXO model.

## Order

### Order (value)
```rust
pub struct Order {
    // Main order informations
    pub asset_type_from: H256,
    pub asset_type_to: H256,
    pub asset_type_fee: H256,
    pub asset_amount_from: u64,
    pub asset_amount_to: u64,
    pub asset_amount_fee: u64,
    /// previous outputs that order is started
    pub origin_outputs: Vec<AssetOutPoint>,
    /// expiration time by second
    pub expiration: u64,
    pub lock_script_hash: H160,
    pub parameters: Vec<Bytes>,
}
```

### OrderOnTransfer
```rust
pub struct OrderOnTransfer {
    pub order: Order,
    /// Spent amount of asset_type_from
    pub spent_amount: u64,
    /// Incides of transfer inputs which are moved as order
    pub input_indices: Vec<usize>,
    /// Incides of transfer outputs which are moved as order
    pub output_indices: Vec<usize>,
}
```

## Changed structs by Order
```rust
pub enum Transaction {
    ...
    AssetTransfer {
        network_id: NetworkId,
        burns: Vec<AssetTransferInput>,
        inputs: Vec<AssetTransferInput>,
        outputs: Vec<AssetTransferOutput>,
        orders: Vec<OrderOnInOut>,
    },
    ...
}
```
```rust
pub struct OwnedAsset {
    #[serde(flatten)]
    asset: Asset,
    lock_script_hash: H160,
    parameters: Vec<Bytes>,
    order_hash: Option<H256>,
}
```

## New Transaction Errors
```rust
pub enum Error {
    ...
    /// Order of OwnedAsset and AssetTransferInput is different
    OrderChanged {
        prev_out_order_hash: H256,
        transfer_order_hash: H256,
    },
    /// origin_outputs of order is not satisfied.
    InvalidOriginOutputs(H256),
    /// The input/output indices of the order on transfer is not valid.
    InvalidOrderInOutIndices,
    /// the input and output of tx is not consistent with its orders
    InconsistentTransactionInOutWithOrders,
    /// asset_type_from and asset_type_to is equal
    InvalidOrderAssetTypes {
        from: H256,
        to: H256,
        fee: H256,
    },
    /// invalid asset_amount_from, asset_amount_to because of ratio
    InvalidOrderAssetAmounts {
        from: u64,
        to: u64,
        fee: u64,
    },
    /// the lock script hash of the order is different from the output
    InvalidOrderLockScriptHash(H160),
    /// the parameters of the order is different from the output
    InvalidOrderParameters(Vec<Bytes>),
    OrderExpired {
        expiration: u64,
        timestamp: u64,
    },
}
```

The 1st ~ 3rd commits are for definition.
The 4th commit is for verification logic on orders.
The 5th ~ 6th commits are unit test cases implementation.
The 7th commit is temporal JSON RPC document for orders. The document does not explain about `Order` or `OrderOnInOut` because the design still can be changed.
The last commit is integration test cases implementation with the SDK.
