### PR TITLE
Move height increase logic in tendermint

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -98,7 +98,7 @@ pub trait EngineInfo: Send + Sync {
 }
 
 /// Client facilities used by internally sealing Engines.
-pub trait EngineClient: Sync + Send + ChainInfo + ImportBlock {
+pub trait EngineClient: Sync + Send + ChainInfo + ImportBlock + BlockInfo {
     /// Make a new block and seal it.
     fn update_sealing(&self);
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -51,6 +51,7 @@ use crate::error::Error;
 use crate::header::Header;
 use crate::parcel::{SignedParcel, UnverifiedParcel};
 use crate::scheme::CommonParams;
+use Client;
 
 /// Seal type.
 #[derive(Debug, PartialEq, Eq)]
@@ -235,6 +236,8 @@ pub trait ConsensusEngine<M: Machine>: Sync + Send {
     }
 
     fn recommended_confirmation(&self) -> u32;
+
+    fn register_chain_notify(&self, _: &Client) {}
 }
 
 /// Results of a query of whether an epoch change occurred at the given block.


### PR DESCRIPTION
When new block is imported, tendermint increase its block height a
`is_proposal` function. Change the code to use ChainNotify instead.