### PR TITLE
Fix integration tests

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -25,8 +25,8 @@
     "tslint": "^5.10.0"
   },
   "dependencies": {
-    "codechain-sdk": "https://github.com/jhs7jhs/codechain-sdk-js.git#wrapped_ccc",
-    "codechain-test-helper": "https://github.com/CodeChain-io/codechain-test-helper-js.git#a4a9c26635a52395dfd17733eef66b18a144fd00",
+    "codechain-sdk": "https://github.com/jhs7jhs/codechain-sdk-js.git#build",
+    "codechain-test-helper": "https://github.com/CodeChain-io/codechain-test-helper-js.git#b07f735267a383769b0f9364cc267c4b5bbd286b",
     "jest": "^23.1.0",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",

--- a/test/src/helper/random.ts
+++ b/test/src/helper/random.ts
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { prng } from "seedrandom";
-
 export function makeRandomPassphrase() {
     let text = "";
     const possible =

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -23,7 +23,7 @@ import {
     H256,
     Invoice,
     Parcel,
-    U256,
+    U64,
     AssetTransferInput,
     PlatformAddress,
     AssetTransferAddress,
@@ -311,7 +311,7 @@ export default class CodeChain {
 
     public async payment(
         recipient: string | PlatformAddress,
-        amount: U256 | string | number
+        amount: U64 | string | number
     ) {
         const parcel = this.sdk.core
             .createPaymentParcel({
@@ -338,8 +338,8 @@ export default class CodeChain {
         parcel: Parcel,
         params: {
             account: string | PlatformAddress;
-            fee?: number | string | U256;
-            seq?: number | string | U256;
+            fee?: number | string | U64;
+            seq?: number;
         }
     ) {
         const keyStore = await this.sdk.key.createLocalKeyStore(
@@ -359,7 +359,7 @@ export default class CodeChain {
     public async sendTransaction(
         tx: Transaction,
         options?: {
-            seq?: U256 | number;
+            seq?: number;
             fee?: number;
             awaitInvoice?: boolean;
             secret?: string;
@@ -392,7 +392,7 @@ export default class CodeChain {
         amount: number;
         recipient?: string | AssetTransferAddress;
         secret?: string;
-        seq?: U256 | number;
+        seq?: number;
         metadata?: string;
         awaitMint?: boolean;
     }) {
@@ -450,7 +450,7 @@ export default class CodeChain {
     public async setRegularKey(
         key: any,
         options?: {
-            seq?: U256 | number;
+            seq?: number;
             awaitInvoice?: boolean;
             secret?: any;
         }
@@ -479,7 +479,7 @@ export default class CodeChain {
     }
 
     public async sendSignedParcel(options?: {
-        seq?: U256 | number;
+        seq?: number;
         awaitInvoice?: boolean;
         recipient?: PlatformAddress | string;
         amount?: number;

--- a/test/src/integration/chain.test.ts
+++ b/test/src/integration/chain.test.ts
@@ -17,7 +17,7 @@
 import {
     H256,
     H512,
-    U256,
+    U64,
     AssetMintTransaction,
     AssetScheme
 } from "codechain-sdk/lib/core/classes";
@@ -29,6 +29,7 @@ import {
 } from "../helper/constants";
 
 import CodeChain from "../helper/spawn";
+import { doesNotReject } from "assert";
 
 describe("chain", () => {
     const invalidHash = new H256("0".repeat(64));
@@ -82,19 +83,19 @@ describe("chain", () => {
 
     test("getSeq", async () => {
         await node.sdk.rpc.chain.getSeq(faucetAddress);
-        expect(await node.sdk.rpc.chain.getSeq(invalidAddress)).toEqual(
-            new U256(0)
-        );
+        expect(await node.sdk.rpc.chain.getSeq(invalidAddress)).toEqual(0);
         const bestBlockNumber = await node.sdk.rpc.chain.getBestBlockNumber();
         await node.sdk.rpc.chain.getSeq(faucetAddress, 0);
         await node.sdk.rpc.chain.getSeq(faucetAddress, bestBlockNumber);
-        await node.sdk.rpc.chain.getSeq(faucetAddress, bestBlockNumber + 1);
+        await expect(
+            node.sdk.rpc.chain.getSeq(faucetAddress, bestBlockNumber + 1)
+        ).rejects.toThrow("chain_getSeq returns undefined");
     });
 
     test("getBalance", async () => {
         await node.sdk.rpc.chain.getBalance(faucetAddress);
         expect(await node.sdk.rpc.chain.getBalance(invalidAddress)).toEqual(
-            new U256(0)
+            new U64(0)
         );
         const bestBlockNumber = await node.sdk.rpc.chain.getBestBlockNumber();
         await node.sdk.rpc.chain.getBalance(faucetAddress, 0);

--- a/test/src/integration/mempool.test.ts
+++ b/test/src/integration/mempool.test.ts
@@ -16,7 +16,7 @@
 
 import { wait } from "../helper/promise";
 import CodeChain from "../helper/spawn";
-import { Timelock, U256, Asset } from "codechain-sdk/lib/core/classes";
+import { Timelock, Asset } from "codechain-sdk/lib/core/classes";
 import { faucetAddress } from "../helper/constants";
 import { H256 } from "codechain-primitives/lib";
 
@@ -210,21 +210,16 @@ describe("Future queue", () => {
     });
 
     test("all pending parcel must be mined", async () => {
-        const seq =
-            (await node.sdk.rpc.chain.getSeq(faucetAddress)) || U256.ensure(0);
-        const seq1 = U256.plus(seq, 1);
-        const seq2 = U256.plus(seq, 2);
-        const seq3 = U256.plus(seq, 3);
-        const seq4 = U256.plus(seq, 4);
+        const seq = (await node.sdk.rpc.chain.getSeq(faucetAddress)) || 0;
 
-        await node.sendSignedParcel({ awaitInvoice: false, seq: seq3 });
+        await node.sendSignedParcel({ awaitInvoice: false, seq: seq + 3 });
         expect(await node.sdk.rpc.chain.getSeq(faucetAddress)).toEqual(seq);
-        await node.sendSignedParcel({ awaitInvoice: false, seq: seq2 });
+        await node.sendSignedParcel({ awaitInvoice: false, seq: seq + 2 });
         expect(await node.sdk.rpc.chain.getSeq(faucetAddress)).toEqual(seq);
-        await node.sendSignedParcel({ awaitInvoice: false, seq: seq1 });
+        await node.sendSignedParcel({ awaitInvoice: false, seq: seq + 1 });
         expect(await node.sdk.rpc.chain.getSeq(faucetAddress)).toEqual(seq);
         await node.sendSignedParcel({ awaitInvoice: false, seq: seq });
-        expect(await node.sdk.rpc.chain.getSeq(faucetAddress)).toEqual(seq4);
+        expect(await node.sdk.rpc.chain.getSeq(faucetAddress)).toEqual(seq + 4);
     });
 
     afterEach(async () => {

--- a/test/src/integration/onChainBlock.test.ts
+++ b/test/src/integration/onChainBlock.test.ts
@@ -377,8 +377,7 @@ describe("Test onChain block communication", async () => {
                 const bodyRequest = TH.getBlockBodyRequest();
 
                 expect(bodyRequest).toEqual(null);
-            },
-            30000
+            }
         );
     });
 });

--- a/test/src/integration/onChainBlock.test.ts
+++ b/test/src/integration/onChainBlock.test.ts
@@ -201,7 +201,6 @@ describe("Test onChain block communication", async () => {
 
     beforeAll(async () => {
         const node = new CodeChain({
-            logFlag: true,
             argv: ["--force-sealing"]
         });
         await node.start();
@@ -271,7 +270,7 @@ describe("Test onChain block communication", async () => {
     });
 
     beforeEach(async () => {
-        nodeA = new CodeChain({ logFlag: true });
+        nodeA = new CodeChain();
         await nodeA.start();
         TH = new TestHelper("0.0.0.0", nodeA.port);
         await TH.establish();

--- a/test/src/integration/onChainParcel.test.ts
+++ b/test/src/integration/onChainParcel.test.ts
@@ -22,7 +22,7 @@ describe("Test onChain parcel communication", () => {
     let nodeA: CodeChain;
 
     const VALID_FEE = 10;
-    const INVALID_FEE = 16069380442589902755419620923411626025222029937827928353013799;
+    const INVALID_FEE = 1606202993013799;
     const VALID_SEQ = 0;
     const INVALID_SEQ = 1;
     const VALID_NETWORKID = "tc";

--- a/test/src/integration/onChainParcel.test.ts
+++ b/test/src/integration/onChainParcel.test.ts
@@ -62,7 +62,7 @@ describe("Test onChain parcel communication", () => {
     ];
 
     beforeEach(async () => {
-        nodeA = new CodeChain({ logFlag: true });
+        nodeA = new CodeChain();
         await nodeA.start();
     });
 

--- a/test/src/integration/onChainParcel.test.ts
+++ b/test/src/integration/onChainParcel.test.ts
@@ -103,6 +103,8 @@ describe("Test onChain parcel communication", () => {
         test.each(testArray)(
             "%s",
             async (_testName, tfee, tseq, tnetworkId, tsig) => {
+                jest.setTimeout(20000);
+
                 const TH = new TestHelper("0.0.0.0", nodeA.port);
                 await TH.establish();
 
@@ -130,8 +132,7 @@ describe("Test onChain parcel communication", () => {
                 expect(parcels.length).toEqual(0);
 
                 await TH.end();
-            },
-            20000
+            }
         );
     });
 });

--- a/test/src/integration/reward.test.ts
+++ b/test/src/integration/reward.test.ts
@@ -17,7 +17,6 @@
 import CodeChain from "../helper/spawn";
 import { aliceAddress, aliceSecret, faucetAddress } from "../helper/constants";
 import { U64 } from "codechain-sdk/lib/core/classes";
-import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 
 describe("Reward = 50, 1 miner", () => {
     let node: CodeChain;

--- a/test/src/integration/reward.test.ts
+++ b/test/src/integration/reward.test.ts
@@ -16,7 +16,7 @@
 
 import CodeChain from "../helper/spawn";
 import { aliceAddress, aliceSecret, faucetAddress } from "../helper/constants";
-import { U256 } from "codechain-sdk/lib/core/U256";
+import { U64 } from "codechain-sdk/lib/core/classes";
 import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 
 describe("Reward = 50, 1 miner", () => {
@@ -34,14 +34,14 @@ describe("Reward = 50, 1 miner", () => {
         await node.sdk.rpc.devel.startSealing();
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50));
+        ).resolves.toEqual(new U64(50));
     });
 
     test("Mining a block with 1 parcel", async () => {
         await node.sendSignedParcel({ fee: 10 });
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50 + 10));
+        ).resolves.toEqual(new U64(50 + 10));
     });
 
     test("Mining a block with 3 parcels", async () => {
@@ -64,21 +64,21 @@ describe("Reward = 50, 1 miner", () => {
         await node.sdk.rpc.devel.startSealing();
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50 + 35));
+        ).resolves.toEqual(new U64(50 + 35));
     });
 
     test("Mining a block with a parcel that pays the author", async () => {
         await node.payment(aliceAddress, 100);
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50 + 10 + 100));
+        ).resolves.toEqual(new U64(50 + 10 + 100));
     });
 
     test("Mining a block with a parcel which author pays someone in", async () => {
         await node.sendSignedParcel({ fee: 10 }); // +60
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(60));
+        ).resolves.toEqual(new U64(60));
 
         const parcel = await node.sdk.core
             .createPaymentParcel({
@@ -89,7 +89,7 @@ describe("Reward = 50, 1 miner", () => {
         await node.sdk.rpc.chain.sendSignedParcel(parcel); // +60
         await expect(
             node.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(60));
+        ).resolves.toEqual(new U64(60));
     });
 
     afterEach(async () => {

--- a/test/src/integration/reward1.test.ts
+++ b/test/src/integration/reward1.test.ts
@@ -16,7 +16,6 @@
 
 import CodeChain from "../helper/spawn";
 import { faucetAddress } from "../helper/constants";
-import { U256 } from "codechain-sdk/lib/core/U256";
 
 describe("reward1", () => {
     let node: CodeChain;
@@ -77,13 +76,13 @@ describe("reward1", () => {
         await node.sendSignedParcel({
             amount: 10,
             fee: 456,
-            seq: U256.plus(seq, 1),
+            seq: seq + 1,
             awaitInvoice: false
         });
         await node.sendSignedParcel({
             amount: 10,
             fee: 321,
-            seq: U256.plus(seq, 2),
+            seq: seq + 2,
             awaitInvoice: false
         });
         await node.sdk.rpc.devel.startSealing();

--- a/test/src/integration/reward2.test.ts
+++ b/test/src/integration/reward2.test.ts
@@ -30,13 +30,11 @@ describeSkippedInTravis("reward2", () => {
     beforeEach(async () => {
         nodeA = new CodeChain({
             chain: `${__dirname}/../scheme/solo-block-reward-50.json`,
-            argv: ["--author", aliceAddress.toString(), "--force-sealing"],
-            logFlag: true
+            argv: ["--author", aliceAddress.toString(), "--force-sealing"]
         });
         nodeB = new CodeChain({
             chain: `${__dirname}/../scheme/solo-block-reward-50.json`,
-            argv: ["--author", bobAddress.toString(), "--force-sealing"],
-            logFlag: true
+            argv: ["--author", bobAddress.toString(), "--force-sealing"]
         });
 
         await Promise.all([nodeA.start(), nodeB.start()]);

--- a/test/src/integration/reward2.test.ts
+++ b/test/src/integration/reward2.test.ts
@@ -16,7 +16,7 @@
 
 import CodeChain from "../helper/spawn";
 import { aliceAddress, aliceSecret, bobAddress } from "../helper/constants";
-import { U256 } from "codechain-sdk/lib/core/U256";
+import { U64 } from "codechain-sdk/lib/core/classes";
 import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 
 const describeSkippedInTravis = process.env.TRAVIS ? describe.skip : describe;
@@ -46,37 +46,37 @@ describeSkippedInTravis("reward2", () => {
         await nodeA.sdk.rpc.devel.startSealing();
         await expect(
             nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50));
+        ).resolves.toEqual(new U64(50));
 
         await nodeB.connect(nodeA);
         await nodeB.waitBlockNumberSync(nodeA);
 
         await expect(
             nodeB.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50));
+        ).resolves.toEqual(new U64(50));
     });
 
     test("alice creates one block and bob creates two blocks in parallel. And then, sync", async () => {
         await nodeA.sdk.rpc.devel.startSealing();
         await expect(
             nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(50));
+        ).resolves.toEqual(new U64(50));
 
         await nodeB.sdk.rpc.devel.startSealing();
         await nodeB.sdk.rpc.devel.startSealing();
         await expect(
             nodeB.sdk.rpc.chain.getBalance(bobAddress)
-        ).resolves.toEqual(new U256(100));
+        ).resolves.toEqual(new U64(100));
 
         await nodeA.connect(nodeB);
         await nodeA.waitBlockNumberSync(nodeB);
 
         await expect(
             nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-        ).resolves.toEqual(new U256(0));
+        ).resolves.toEqual(new U64(0));
         await expect(
             nodeA.sdk.rpc.chain.getBalance(bobAddress)
-        ).resolves.toEqual(new U256(100));
+        ).resolves.toEqual(new U64(100));
     });
 
     test(
@@ -87,7 +87,7 @@ describeSkippedInTravis("reward2", () => {
                 await nodeA.sdk.rpc.devel.startSealing(); // +50 for alice
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(50));
+                ).resolves.toEqual(new U64(50));
             }
 
             // sync and disconnect
@@ -97,7 +97,7 @@ describeSkippedInTravis("reward2", () => {
 
                 await expect(
                     nodeB.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(50));
+                ).resolves.toEqual(new U64(50));
 
                 await nodeB.disconnect(nodeA);
             }
@@ -119,10 +119,10 @@ describeSkippedInTravis("reward2", () => {
                 ); // +45 for alice, +5 for bob in nodeA
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(255));
+                ).resolves.toEqual(new U64(255));
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(bobAddress)
-                ).resolves.toEqual(new U256(5));
+                ).resolves.toEqual(new U64(5));
             }
 
             // nodeB creates 3 blocks
@@ -143,10 +143,10 @@ describeSkippedInTravis("reward2", () => {
                 ); // -25 for alice. +75 for bob in nodeB
                 await expect(
                     nodeB.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(225));
+                ).resolves.toEqual(new U64(225));
                 await expect(
                     nodeB.sdk.rpc.chain.getBalance(bobAddress)
-                ).resolves.toEqual(new U256(495));
+                ).resolves.toEqual(new U64(495));
             }
 
             // sync. nodeA now sees nodeB's state
@@ -162,10 +162,10 @@ describeSkippedInTravis("reward2", () => {
 
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(225));
+                ).resolves.toEqual(new U64(225));
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(bobAddress)
-                ).resolves.toEqual(new U256(495));
+                ).resolves.toEqual(new U64(495));
             }
 
             // nodeA creates a block
@@ -173,7 +173,7 @@ describeSkippedInTravis("reward2", () => {
                 await nodeA.payment(aliceAddress, 1000); // +1060 for alice
                 await expect(
                     nodeA.sdk.rpc.chain.getBalance(aliceAddress)
-                ).resolves.toEqual(new U256(225 + 1060));
+                ).resolves.toEqual(new U64(225 + 1060));
             }
         },
         7000

--- a/test/src/integration/tendermint.test.ts
+++ b/test/src/integration/tendermint.test.ts
@@ -24,7 +24,6 @@ import {
     validator2Address,
     validator3Address
 } from "../helper/constants";
-import { U256 } from "codechain-sdk/lib/core/U256";
 import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 import { wait } from "../helper/promise";
 

--- a/test/src/integration/tendermint.test.ts
+++ b/test/src/integration/tendermint.test.ts
@@ -16,15 +16,11 @@
 
 import CodeChain from "../helper/spawn";
 import {
-    aliceAddress,
-    aliceSecret,
-    faucetAddress,
     validator0Address,
     validator1Address,
     validator2Address,
     validator3Address
 } from "../helper/constants";
-import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 import { wait } from "../helper/promise";
 
 const describeSkippedInTravis = process.env.TRAVIS ? describe.skip : describe;

--- a/test/src/integration/transactions.test.ts
+++ b/test/src/integration/transactions.test.ts
@@ -87,7 +87,7 @@ describe("transactions", () => {
                 const tx = node.sdk.core.createAssetTransferTransaction();
                 tx.addInputs(input);
                 tx.addOutputs(
-                    ...amounts.map(amount => ({
+                    amounts.map(amount => ({
                         assetType: input.assetType,
                         recipient,
                         amount
@@ -107,7 +107,7 @@ describe("transactions", () => {
                 const tx = node.sdk.core.createAssetTransferTransaction();
                 tx.addInputs(input);
                 tx.addOutputs(
-                    ...amounts.map(amount => ({
+                    amounts.map(amount => ({
                         assetType: input.assetType,
                         recipient,
                         amount
@@ -127,7 +127,7 @@ describe("transactions", () => {
             const tx = node.sdk.core.createAssetTransferTransaction();
             tx.addInputs(input);
             tx.addOutputs(
-                ...amounts.map(amount => ({
+                amounts.map(amount => ({
                     assetType: input.assetType,
                     recipient,
                     amount
@@ -178,9 +178,9 @@ describe("transactions", () => {
             async (input1Amounts, input2Amounts) => {
                 const recipient = await node.createP2PKHAddress();
                 const tx = node.sdk.core.createAssetTransferTransaction();
-                tx.addInputs(..._.shuffle([input1, input2]));
+                tx.addInputs(_.shuffle([input1, input2]));
                 tx.addOutputs(
-                    ..._.shuffle([
+                    _.shuffle([
                         ...input1Amounts.map(amount => ({
                             assetType: input1.assetType,
                             recipient,
@@ -594,7 +594,6 @@ describe("transactions", () => {
             expect(invoices![0].success).toBe(false);
 
             (tx.outputs[0].parameters as any) = address1Param;
-            (tx.seq as any) = 1;
             await node.sdk.key.signTransactionInput(tx, 0, {
                 signatureTag: {
                     input: "all",
@@ -617,7 +616,7 @@ describe("transactions", () => {
                         .createAssetTransferTransaction()
                         .addInputs(assets[0])
                         .addOutputs(
-                            ..._.times(length, () => ({
+                            _.times(length, () => ({
                                 assetType,
                                 amount: 1,
                                 recipient: address1

--- a/test/src/integration/transactions.test.ts
+++ b/test/src/integration/transactions.test.ts
@@ -19,7 +19,6 @@ import {
     Asset,
     AssetTransferTransaction,
     PlatformAddress,
-    U256,
     AssetTransferAddress,
     SignedParcel,
     AssetMintTransaction
@@ -692,7 +691,7 @@ describe("transactions", () => {
                 .sign({
                     secret: faucetSecret,
                     fee: 10,
-                    seq: U256.plus(seq, 1)
+                    seq: seq + 1
                 });
             await node.sdk.rpc.chain.sendSignedParcel(parcel1);
 
@@ -757,9 +756,7 @@ describe("transactions", () => {
             });
             await node.sdk.key.signTransactionInput(decomposeTx, 0);
 
-            const seq0 = await node.sdk.rpc.chain.getSeq(faucetAddress);
-            const seq1 = U256.plus(seq0, 1);
-            const seq2 = U256.plus(seq0, 2);
+            const seq = await node.sdk.rpc.chain.getSeq(faucetAddress);
 
             const parcel0 = node.sdk.core
                 .createAssetTransactionParcel({
@@ -768,7 +765,7 @@ describe("transactions", () => {
                 .sign({
                     secret: faucetSecret,
                     fee: 10,
-                    seq: seq0
+                    seq
                 });
             const parcel1 = node.sdk.core
                 .createAssetTransactionParcel({
@@ -777,7 +774,7 @@ describe("transactions", () => {
                 .sign({
                     secret: faucetSecret,
                     fee: 10,
-                    seq: seq1
+                    seq: seq + 1
                 });
             const parcel2 = node.sdk.core
                 .createAssetTransactionParcel({
@@ -786,7 +783,7 @@ describe("transactions", () => {
                 .sign({
                     secret: faucetSecret,
                     fee: 10,
-                    seq: seq2
+                    seq: seq + 2
                 });
 
             await node.sdk.rpc.chain.sendSignedParcel(parcel0);

--- a/test/src/integration/verification.test.ts
+++ b/test/src/integration/verification.test.ts
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { PlatformAddress } from "codechain-sdk/lib/core/classes";
-
 import CodeChain from "../helper/spawn";
 import { faucetAddress, faucetSecret } from "../helper/constants";
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -775,43 +775,6 @@ codechain-keystore@^0.5.4:
     lowdb-session-storage-adapter "^1.0.0"
     uuid "^3.3.2"
 
-codechain-keystore@~0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/codechain-keystore/-/codechain-keystore-0.2.3.tgz#7534f583771d16503aa8c02acd7a4d53d9ae20ea"
-  integrity sha512-+j9Xg+EbWmnGo8u5Itb+fGTMXOMQaxHpe8ux7MUTTNYu3lLYMlNwAopNjfrtBGp5xbb23ewqMkU56FBMRr9mvw==
-  dependencies:
-    codechain-primitives "^0.2.0"
-    config "^2.0.1"
-    lodash "^4.17.10"
-    lowdb "^1.0.0"
-    uuid "^3.3.2"
-
-codechain-primitives@^0.1.0-rc2:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.1.0.tgz#1324596a0d91c15736cc6ea96379d84bcb80f476"
-  integrity sha512-UpZ9aCfSdAuPcLJyqyMP6xRUl6kp1J18+pIN/TDmCOm4TdF14b8EKHuReKUYn9uWdgwENoa3T1IPxscQcx3wqQ==
-  dependencies:
-    bignumber.js "^7.2.1"
-    blakejs "^1.1.0"
-    buffer "^5.2.1"
-    elliptic "^6.4.1"
-    lodash "^4.17.11"
-    ripemd160 "^2.0.2"
-    rlp "^2.1.0"
-
-codechain-primitives@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.2.0.tgz#1e86b8adb1466606d478f95f25aa4eb5d6dc0e75"
-  integrity sha512-NFrBkJozIl0NNvVhCdhBem7DslUDOgO/KbeSCApkQuIlvUb6SQQsjEqvPad7SYFRIzxcKWRuDmTlTHMGoiLhzQ==
-  dependencies:
-    bignumber.js "^7.2.1"
-    blakejs "^1.1.0"
-    buffer "^5.2.1"
-    elliptic "^6.4.1"
-    lodash "^4.17.11"
-    ripemd160 "^2.0.2"
-    rlp "^2.1.0"
-
 codechain-primitives@^0.3.0:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.3.4.tgz#9ba6dfa53bcf6a083430eadaaba5e2130daea66e"
@@ -828,10 +791,10 @@ codechain-primitives@^0.3.0:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-codechain-primitives@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.4.1.tgz#06550ad15b91fc46cf2c6d80f93d16c37f244077"
-  integrity sha512-3ZAV9mkUKQmXFjW7j6wcE5mS9oubBj0C31PwitsVc7Lvgl0o8F7FQW9NSrYN8JLLYHwSIVM66L2paYYmE9/L8A==
+codechain-primitives@^0.4.2, codechain-primitives@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.4.3.tgz#e8dd9e1b52e0af7069e78f2c79e9affd417e2f44"
+  integrity sha512-z70qQt4YK5jwnrsMj0oG6C07KA2AqBDkrjf1YpT1FtjUDvE2SMHWvM3XlpA6fvOdF1fEtLPQpvpaDkPsYduvCA==
   dependencies:
     bignumber.js "^7.2.1"
     blakejs "^1.1.0"
@@ -844,46 +807,34 @@ codechain-primitives@^0.4.1:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-codechain-sdk@^0.2.0-alpha.2:
-  version "0.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/codechain-sdk/-/codechain-sdk-0.2.0-alpha.2.tgz#494f8db85693f662a5df453ff9d0d08f94af1210"
-  integrity sha512-cryYUuMCnOmz/WyR/q5REqnEhCKKZF4whYpzwIxXiY+ZYiVfJQ5sJsgH+kXYGhXXxR2s8db2ohp9XFy2+Wo0jA==
-  dependencies:
-    buffer "5.1.0"
-    codechain-keystore "~0.2.1"
-    codechain-primitives "^0.1.0-rc2"
-    jayson "^2.0.6"
-    lodash "^4.17.10"
-    node-fetch "^2.1.2"
-    request-promise "^4.2.2"
-    rlp "^2.0.0"
-
-"codechain-sdk@https://github.com/jhs7jhs/codechain-sdk-js.git#wrapped_ccc":
+"codechain-sdk@https://github.com/jhs7jhs/codechain-sdk-js.git#build":
   version "0.5.1"
-  resolved "https://github.com/jhs7jhs/codechain-sdk-js.git#6051731b869675491235cde84a5ab530487c2238"
+  resolved "https://github.com/jhs7jhs/codechain-sdk-js.git#55dae963a87b28c647e2d8e786ffdd959a661434"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.5.4"
-    codechain-primitives "^0.4.1"
+    codechain-primitives "^0.4.2"
     jayson "^2.0.6"
     lodash "^4.17.10"
     node-fetch "^2.1.2"
     request-promise "^4.2.2"
     rlp "^2.0.0"
 
-"codechain-test-helper@https://github.com/CodeChain-io/codechain-test-helper-js.git#a4a9c26635a52395dfd17733eef66b18a144fd00":
+"codechain-test-helper@https://github.com/CodeChain-io/codechain-test-helper-js.git#b07f735267a383769b0f9364cc267c4b5bbd286b":
   version "1.0.0"
-  resolved "https://github.com/CodeChain-io/codechain-test-helper-js.git#a4a9c26635a52395dfd17733eef66b18a144fd00"
+  resolved "https://github.com/CodeChain-io/codechain-test-helper-js.git#b07f735267a383769b0f9364cc267c4b5bbd286b"
   dependencies:
     "@types/crypto-js" "^3.1.43"
     blakejs "^1.1.0"
-    codechain-sdk "^0.2.0-alpha.2"
+    codechain-primitives "^0.4.3"
+    codechain-sdk "https://github.com/jhs7jhs/codechain-sdk-js.git#build"
     crypto "^1.0.1"
     dgram "^1.0.1"
     elliptic "^6.4.1"
+    jest "^23.1.0"
     net "^1.0.2"
     rlp "^2.1.0"
-    tslint "^5.11.0"
+    ts-jest "^22.4.6"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -4202,7 +4153,7 @@ tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@^5.10.0, tslint@^5.11.0:
+tslint@^5.10.0:
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   integrity sha1-mPMMAurjzecAYgHkwzywi0hYHu0=


### PR DESCRIPTION
1. Remove U256
2. Remove unused import statements
3. Remove `{logFlag: true}` from creating CodeChain instances. 
4. Remove timeout field from `test.each`, and moved it to `jest.setTimeout()`
5. Fixed integration tests on transactions