### PR TITLE
Tendermint: do not lock on the height `h` if a block is committed in the height `h`

### DIFF
--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -415,6 +415,7 @@ impl Tendermint {
             None => true,
         };
         let lock_change = is_newer_than_lock
+            && vote_step.height == self.height.load(AtomicOrdering::SeqCst)
             && vote_step.step == Step::Prevote
             && message.block_hash.is_some()
             && self.has_enough_aligned_votes(message);


### PR DESCRIPTION
Previous this commit

In Tendermint consensus, if the node received a new "prevote" message on
height h after a node transit to "commit" state on height h, the node is
locked on the message's block.

After this commit

A node locks on the height `h` which is already committed.

This fixes https://github.com/CodeChain-io/codechain/issues/898