### PR TITLE
Split `is_proposal` function's content to `is_proposal` and `on_verified_proposal`

### DIFF
--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -115,6 +115,7 @@ impl Importer {
                 }
                 if let Ok(closed_block) = self.check_and_close_block(&block, client) {
                     if self.engine.is_proposal(&block.header) {
+                        self.engine.on_verified_proposal(&header);
                         self.block_queue.mark_as_good(&[header.hash()]);
                     } else {
                         imported_blocks.push(header.hash());

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -212,6 +212,10 @@ pub trait ConsensusEngine<M: Machine>: Sync + Send {
         false
     }
 
+    /// Called when proposal block is verified.
+    /// Consensus many hold the verified proposal block until it should be imported.
+    fn on_verified_proposal(&self, _header: &Header) {}
+
     /// Broadcast a block proposal.
     fn broadcast_proposal_block(&self, _block: SealedBlock) {}
 

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -745,6 +745,10 @@ impl ConsensusEngine<CodeChainMachine> for Tendermint {
         if signatures_len != 1 {
             return false
         }
+        true
+    }
+
+    fn on_verified_proposal(&self, header: &Header) {
         let proposal = ConsensusMessage::new_proposal(header)
             .expect("block went through full verification; this Engine verifies new_proposal creation; qed");
         let proposer = proposal.verify().expect("block went through full verification; this Engine tries verify; qed");
@@ -754,7 +758,6 @@ impl ConsensusEngine<CodeChainMachine> for Tendermint {
             *self.proposal_parent.write() = *header.parent_hash();
         }
         self.votes.vote(proposal, proposer);
-        true
     }
 
     fn broadcast_proposal_block(&self, block: SealedBlock) {


### PR DESCRIPTION
`is_proposal` seems like checking whether the header is a proposal or
not. But indeed it changed engine's state if given header is a proposal.
By splitting the `is_proposal` into `is_proposal` and `on_verified_proposal`,
`is_proposal` only checks given header is a proposal or not.