### PR TITLE
Fix the transaction type on RPC

### DIFF
--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -34,7 +34,7 @@ use jsonrpc_core::Result;
 
 use super::super::errors;
 use super::super::traits::Chain;
-use super::super::types::{Block, BlockNumberAndHash, Parcel, Transaction};
+use super::super::types::{Block, BlockNumberAndHash, Parcel, Transaction, TransactionWithHash};
 
 pub struct ChainClient<C, M>
 where
@@ -100,7 +100,7 @@ where
         Ok(self.client.parcel_invoice(&parcel_hash.into()))
     }
 
-    fn get_transaction(&self, transaction_hash: H256) -> Result<Option<Transaction>> {
+    fn get_transaction(&self, transaction_hash: H256) -> Result<Option<TransactionWithHash>> {
         Ok(self.client.transaction(&transaction_hash).map(Into::into))
     }
 

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -24,7 +24,7 @@ use primitives::H256;
 
 use jsonrpc_core::Result;
 
-use super::super::types::{Block, BlockNumberAndHash, Parcel, Transaction};
+use super::super::types::{Block, BlockNumberAndHash, Parcel, Transaction, TransactionWithHash};
 
 build_rpc_trait! {
     pub trait Chain {
@@ -42,7 +42,7 @@ build_rpc_trait! {
 
         /// Gets transaction with given hash.
         # [rpc(name = "chain_getTransaction")]
-        fn get_transaction(&self, H256) -> Result<Option<Transaction>>;
+        fn get_transaction(&self, H256) -> Result<Option<TransactionWithHash>>;
 
         /// Gets transaction invoice with given hash.
         # [rpc(name = "chain_getTransactionInvoices")]

--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -19,7 +19,7 @@ use ckey::{NetworkId, PlatformAddress};
 use ctypes::BlockNumber;
 use primitives::{H256, U256};
 
-use super::{Action, Parcel};
+use super::{ActionWithTxHash, Parcel};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -76,7 +76,7 @@ impl Block {
                         seq: unverified.seq,
                         fee: unverified.fee.into(),
                         network_id,
-                        action: Action::from_core(unverified.action.clone(), network_id),
+                        action: ActionWithTxHash::from_core(unverified.action.clone(), network_id),
                         hash: unverified.hash(),
                         sig,
                     }

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -18,16 +18,18 @@ mod action;
 mod block;
 mod parcel;
 mod transaction;
+mod transaction_with_hash;
 mod unsigned_parcel;
 mod work;
 
 use primitives::H256;
 
-pub use self::action::Action;
+pub use self::action::{Action, ActionWithTxHash};
 pub use self::block::Block;
 pub use self::block::BlockNumberAndHash;
 pub use self::parcel::Parcel;
 pub use self::transaction::Transaction;
+pub use self::transaction_with_hash::TransactionWithHash;
 pub use self::unsigned_parcel::UnsignedParcel;
 pub use self::work::Work;
 

--- a/rpc/src/v1/types/parcel.rs
+++ b/rpc/src/v1/types/parcel.rs
@@ -19,7 +19,7 @@ use cjson::uint::Uint;
 use ckey::{NetworkId, Signature};
 use primitives::H256;
 
-use super::Action;
+use super::ActionWithTxHash;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,7 +30,7 @@ pub struct Parcel {
     pub seq: u64,
     pub fee: Uint,
     pub network_id: NetworkId,
-    pub action: Action,
+    pub action: ActionWithTxHash,
     pub hash: H256,
     pub sig: Signature,
 }
@@ -45,7 +45,7 @@ impl From<LocalizedParcel> for Parcel {
             seq: p.seq,
             fee: p.fee.into(),
             network_id: p.network_id,
-            action: Action::from_core(p.action.clone(), p.network_id),
+            action: ActionWithTxHash::from_core(p.action.clone(), p.network_id),
             hash: p.hash(),
             sig,
         }
@@ -62,7 +62,7 @@ impl From<SignedParcel> for Parcel {
             seq: p.seq,
             fee: p.fee.into(),
             network_id: p.network_id,
-            action: Action::from_core(p.action.clone(), p.network_id),
+            action: ActionWithTxHash::from_core(p.action.clone(), p.network_id),
             hash: p.hash(),
             sig,
         }

--- a/rpc/src/v1/types/transaction_with_hash.rs
+++ b/rpc/src/v1/types/transaction_with_hash.rs
@@ -1,0 +1,134 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use ckey::{NetworkId, PlatformAddress};
+use ctypes::transaction::{AssetMintOutput, AssetTransferInput, AssetTransferOutput, Transaction as TransactionType};
+use ctypes::ShardId;
+use primitives::H256;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", tag = "type", content = "data")]
+pub enum TransactionWithHash {
+    #[serde(rename_all = "camelCase")]
+    AssetMint {
+        network_id: NetworkId,
+        shard_id: ShardId,
+        metadata: String,
+        registrar: Option<PlatformAddress>,
+
+        output: AssetMintOutput,
+        hash: H256,
+    },
+    #[serde(rename_all = "camelCase")]
+    AssetTransfer {
+        network_id: NetworkId,
+        burns: Vec<AssetTransferInput>,
+        inputs: Vec<AssetTransferInput>,
+        outputs: Vec<AssetTransferOutput>,
+        hash: H256,
+    },
+    #[serde(rename_all = "camelCase")]
+    AssetCompose {
+        network_id: NetworkId,
+        shard_id: ShardId,
+        metadata: String,
+        registrar: Option<PlatformAddress>,
+        inputs: Vec<AssetTransferInput>,
+        output: AssetMintOutput,
+        hash: H256,
+    },
+    #[serde(rename_all = "camelCase")]
+    AssetDecompose {
+        network_id: NetworkId,
+        input: AssetTransferInput,
+        outputs: Vec<AssetTransferOutput>,
+        hash: H256,
+    },
+    #[serde(rename_all = "camelCase")]
+    AssetUnwrapCCC {
+        network_id: NetworkId,
+        burn: AssetTransferInput,
+        hash: H256,
+    },
+}
+
+impl From<TransactionType> for TransactionWithHash {
+    fn from(from: TransactionType) -> Self {
+        let hash = from.hash();
+        match from {
+            TransactionType::AssetMint {
+                network_id,
+                shard_id,
+                metadata,
+                registrar,
+                output,
+            } => TransactionWithHash::AssetMint {
+                network_id,
+                shard_id,
+                metadata,
+                registrar: registrar.map(|registrar| PlatformAddress::new_v1(network_id, registrar)),
+                output,
+                hash,
+            },
+            TransactionType::AssetTransfer {
+                network_id,
+                burns,
+                inputs,
+                outputs,
+            } => TransactionWithHash::AssetTransfer {
+                network_id,
+                burns,
+                inputs,
+                outputs,
+                hash,
+            },
+            TransactionType::AssetCompose {
+                network_id,
+                shard_id,
+                metadata,
+                registrar,
+                inputs,
+                output,
+            } => TransactionWithHash::AssetCompose {
+                network_id,
+                shard_id,
+                metadata,
+                registrar: registrar.map(|registrar| PlatformAddress::new_v1(network_id, registrar)),
+                inputs,
+                output,
+                hash,
+            },
+            TransactionType::AssetDecompose {
+                network_id,
+                input,
+                outputs,
+            } => TransactionWithHash::AssetDecompose {
+                network_id,
+                input,
+                outputs,
+                hash,
+            },
+            TransactionType::AssetUnwrapCCC {
+                network_id,
+                burn,
+            } => TransactionWithHash::AssetUnwrapCCC {
+                network_id,
+                burn,
+                hash,
+            },
+        }
+    }
+}

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -117,6 +117,10 @@ A string that starts with "(NetworkID)c", and Bech32 string follows. For example
  - type: "assetMint" | "assetTransfer" | "assetCompose" | "assetDecompose" | "assetUnwrapCCC"
  - data: `AssetMintData` | `AssetTransferData` | `AssetComposeData` | `AssetDecomposeData` | `AssetUnwrapCCCData`
 
+### Transaction in Response
+
+When `Transaction` is included in any response, there will be an additional field `hash` in the data, which is the hash value of the given transaction. This decreases the time to calculate the transaction hash when it is needed from the response.
+
 ### AssetMintData
 
  - networkId: `NetworkID`

--- a/test/src/integration/chain.test.ts
+++ b/test/src/integration/chain.test.ts
@@ -388,8 +388,33 @@ describe("chain", function() {
         ).to.be.null;
     });
 
+    it("executeTransaction", async function() {
+        const scheme = node.sdk.core.createAssetScheme({
+            shardId: 0,
+            metadata: "",
+            amount: 10000
+        });
+        const tx = node.sdk.core.createAssetMintTransaction({
+            scheme,
+            recipient: await node.createP2PKHAddress()
+        });
+
+        const data = tx.toJSON();
+        data.data.output.lockScriptHash = `0x${
+            data.data.output.lockScriptHash
+        }`;
+
+        await node.sdk.rpc
+            .sendRpcRequest("chain_executeTransaction", [
+                data,
+                faucetAddress.value
+            ])
+            .then(result => {
+                expect(result).to.deep.equal({ success: true });
+            });
+    });
+
     // Not implemented
-    it("executeTransactions");
     it("getNumberOfShards");
     it("getShardRoot");
 


### PR DESCRIPTION
1. Removed `hash` field from the type. It is currently not used in the SDK, and not documented in the spec.
2. Added types to support `number`(by `usize`) and `U64`(by `Uint`).
3. Added simple test case for the transaction. Test cases will be added more after this PR.