### PR TITLE
Import proposal block early

### DIFF
--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -113,14 +113,12 @@ impl Importer {
                 }
                 if let Ok(closed_block) = self.check_and_close_block(&block, client) {
                     if self.engine.is_proposal(&block.header) {
-                        self.engine.on_verified_proposal(encoded::Block::new(block.bytes));
-                        self.block_queue.mark_as_good(&[header.hash()]);
-                    } else {
-                        imported_blocks.push(header.hash());
-
-                        let route = self.commit_block(&closed_block, &header, &block.bytes, client);
-                        import_results.push(route);
+                        self.engine.on_verified_proposal(encoded::Block::new(block.bytes.clone()));
                     }
+
+                    imported_blocks.push(header.hash());
+                    let route = self.commit_block(&closed_block, &header, &block.bytes, client);
+                    import_results.push(route);
                 } else {
                     invalid_blocks.insert(header.hash());
                 }
@@ -397,12 +395,8 @@ impl Importer {
                 .expect("Parent of importing header must exist")
                 .decode();
             if self.check_header(&header, &parent_header) {
-                if self.engine.is_proposal(&header) {
-                    self.header_queue.mark_as_good(&[hash]);
-                } else {
-                    imported.push(hash);
-                    routes.push(self.commit_header(&header, client));
-                }
+                imported.push(hash);
+                routes.push(self.commit_header(&header, client));
             } else {
                 bad.insert(hash);
             }

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -51,7 +51,7 @@ use crate::consensus::EngineType;
 use crate::encoded;
 use crate::error::{BlockError, Error};
 use crate::header::Header;
-use crate::views::BlockView;
+use crate::views::{BlockView, HeaderView};
 use crate::BlockId;
 use ChainNotify;
 
@@ -785,6 +785,10 @@ impl ConsensusEngine<CodeChainMachine> for Tendermint {
         c.block_header(&BlockId::Number(prev_height as BlockNumber))
             .expect("Previous height's block should be imported")
             .hash()
+    }
+
+    fn get_best_block_from_highest_score_header(&self, header: &HeaderView) -> H256 {
+        header.parent_hash()
     }
 }
 

--- a/core/src/consensus/vote_collector.rs
+++ b/core/src/consensus/vote_collector.rs
@@ -187,4 +187,9 @@ impl<M: Message + Default + Encodable + Debug> VoteCollector<M> {
             .and_then(|c| c.block_votes.get(&message.block_hash()))
             .and_then(|origins| origins.get(&message.signature()).cloned())
     }
+
+    pub fn get_block_hashes(&self, round: &M::Round) -> Vec<H256> {
+        let guard = self.votes.read();
+        guard.get(round).map(|c| c.block_votes.keys().cloned().filter_map(|x| x).collect()).unwrap_or_else(Vec::new)
+    }
 }

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -549,7 +549,9 @@ impl Miner {
                         .seal(&*self.engine, seal.clone())
                         .map(|sealed| {
                             self.engine.proposal_generated(&sealed);
+                            let import_result = chain.import_sealed_block(&sealed);
                             self.engine.broadcast_proposal_block(sealed);
+                            import_result
                         })
                         .map_err(|e| {
                             cwarn!(MINER, "ERROR: seal failed when given internally generated seal: {}", e);


### PR DESCRIPTION
This PR depends on #891, #933 

If a node would import a proposal block early, the node could propagate the previous block shortly, because the previous block became the best block when the proposal block is imported.
