### PR TITLE
Query to the consensus engine which block a node mine on

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -594,7 +594,7 @@ impl PrepareOpenBlock for Client {
     fn prepare_open_block(&self, author: Address, extra_data: Bytes) -> OpenBlock {
         let engine = &*self.engine;
         let chain = self.block_chain();
-        let h = engine.get_latest_block_hash(chain.best_block_hash());
+        let h = engine.get_block_hash_to_mine_on(chain.best_block_hash());
         let latest_header = &chain.block_header(&h).expect("h is best block hash: so its header must exist: qed");
 
         let is_epoch_begin = chain.epoch_transition(latest_header.number(), h).is_some();

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -271,7 +271,10 @@ pub trait ConsensusEngine<M: Machine>: Sync + Send {
         header.hash()
     }
 
-    fn get_latest_block_hash(&self, best_block_hash: H256) -> H256 {
+    /// Some consensus(like Tendermint) could not mine on the client's best block,
+    /// because the client's best block could be different from the consensus engine's.
+    /// So ask to the consensus engine which block to mine on.
+    fn get_block_hash_to_mine_on(&self, best_block_hash: H256) -> H256 {
         best_block_hash
     }
 }

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -777,6 +777,15 @@ impl ConsensusEngine<CodeChainMachine> for Tendermint {
     fn register_chain_notify(&self, client: &Client) {
         client.add_notify(Arc::downgrade(&self.chain_notify) as Weak<ChainNotify>);
     }
+
+    fn get_block_hash_to_mine_on(&self, _best_block_hash: H256) -> H256 {
+        let c = self.client.read().as_ref().and_then(|weak| weak.upgrade()).expect("Client should be exist");
+
+        let prev_height = self.height() - 1;
+        c.block_header(&BlockId::Number(prev_height as BlockNumber))
+            .expect("Previous height's block should be imported")
+            .hash()
+    }
 }
 
 struct TendermintChainNotify {


### PR DESCRIPTION
Since CodeChain saves the highest block hash in the DB, the client does
not need to ask it to the engine.

This PR depends on #891 