### PR TITLE
Add jobs to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ jobs:
       name: test-osx
       os: osx
       install:
-        - nvm install 8
-        - nvm use 8
-        - npm install -g yarn
         - rustup toolchain install nightly-2018-10-18
         - rustup component add rustfmt-preview --toolchain nightly-2018-10-18
         - rustup component add clippy-preview --toolchain nightly-2018-10-18
@@ -24,7 +21,18 @@ jobs:
         - cargo +nightly-2018-10-18 fmt -- --check || TEST_FAILED=true
         - test $TEST_FAILED || cargo +nightly-2018-10-18 clippy --all-targets --all-features -- -D warnings || TEST_FAILED=true
         - test $TEST_FAILED || RUST_BACKTRACE=1 cargo test --verbose --all || TEST_FAILED=true
-        - test $TEST_FAILED || cd test && yarn && yarn lint || TEST_FAILED=true
+        - "! test $TEST_FAILED"
+    - name: int-test-osx
+      os: osx
+      install:
+        - nvm install 8
+        - nvm use 8
+        - npm install -g yarn
+      before_script:
+        - cargo fetch --verbose
+      script:
+        - cd test && yarn && yarn lint || TEST_FAILED=true
+        - test $TEST_FAILED || cargo build || TEST_FAILED=true
         - test $TEST_FAILED || INT_TEST_FLAG=true && yarn start-short || TEST_FAILED=true
         - test $TEST_FAILED || yarn start-long || TEST_FAILED=true
         - "! test $TEST_FAILED"
@@ -34,9 +42,6 @@ jobs:
       os: linux
       sudo: required
       install:
-        - nvm install 8
-        - nvm use 8
-        - npm install -g yarn
         - rustup toolchain install nightly-2018-10-18
         - rustup component add rustfmt-preview --toolchain nightly-2018-10-18
         - rustup component add clippy-preview --toolchain nightly-2018-10-18
@@ -46,8 +51,21 @@ jobs:
         - cargo +nightly-2018-10-18 fmt -- --check || TEST_FAILED=true
         - test $TEST_FAILED || cargo +nightly-2018-10-18 clippy --all-targets --all-features -- -D warnings || TEST_FAILED=true
         - test $TEST_FAILED || RUST_BACKTRACE=1 cargo test --verbose --all || TEST_FAILED=true
-        - test $TEST_FAILED || cd test && yarn && yarn lint || TEST_FAILED=true
-        - test $TEST_FAILED || INT_TEST_FLAG=true && yarn start || TEST_FAILED=true
+        - "! test $TEST_FAILED"
+    - name: int-test-linux
+      os: linux
+      sudo: required
+      install:
+        - nvm install 8
+        - nvm use 8
+        - npm install -g yarn
+      before_script:
+        - cargo fetch --verbose
+      script:
+        - cd test && yarn && yarn lint || TEST_FAILED=true
+        - test $TEST_FAILED || cargo build || TEST_FAILED=true
+        - test $TEST_FAILED || INT_TEST_FLAG=true && yarn start-short || TEST_FAILED=true
+        - test $TEST_FAILED || yarn start-long || TEST_FAILED=true
         - "! test $TEST_FAILED"
       after_failure:
         - test $INT_TEST_FLAG && ./upload_logs.sh


### PR DESCRIPTION
Currently, clippy and unit test are stable but integration tests are
failed sporadically because of timeout.
This patch creates jobs for integration tests to make re-run the
integration tests fast.