### PR TITLE
Save Tendermint's state to the DB

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -450,6 +450,10 @@ impl EngineClient for Client {
     fn score_to_target(&self, score: &U256) -> U256 {
         self.engine.score_to_target(score)
     }
+
+    fn get_kvdb(&self) -> Arc<KeyValueDB> {
+        self.db.clone()
+    }
 }
 
 impl BlockInfo for Client {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -109,6 +109,8 @@ pub trait EngineClient: Sync + Send + ChainInfo + ImportBlock + BlockInfo {
 
     /// Convert PoW difficulty to target.
     fn score_to_target(&self, score: &U256) -> U256;
+
+    fn get_kvdb(&self) -> Arc<KeyValueDB>;
 }
 
 /// Provides `seq` and `latest_seq` methods

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -46,6 +46,7 @@ use ctypes::transaction::Transaction;
 use ctypes::BlockNumber;
 use cvm::ChainTimeInfo;
 use journaldb;
+use kvdb::KeyValueDB;
 use kvdb_memorydb;
 use parking_lot::RwLock;
 use primitives::{Bytes, H256, U256};
@@ -571,5 +572,10 @@ impl super::EngineClient for TestBlockChainClient {
 
     fn score_to_target(&self, _score: &U256) -> U256 {
         U256::zero()
+    }
+
+    fn get_kvdb(&self) -> Arc<KeyValueDB> {
+        let db = kvdb_memorydb::create(NUM_COLUMNS.unwrap_or(0));
+        Arc::new(db)
     }
 }

--- a/core/src/consensus/tendermint/backup.rs
+++ b/core/src/consensus/tendermint/backup.rs
@@ -1,0 +1,90 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use kvdb::{DBTransaction, KeyValueDB};
+use primitives::H256;
+
+use super::message::ConsensusMessage;
+use super::types::{Height, Step, View};
+use crate::db;
+
+const BACKUP_KEY: &[u8] = b"tendermint-backup";
+
+pub struct BackupView<'a> {
+    pub height: &'a Height,
+    pub view: &'a View,
+    pub step: &'a Step,
+    pub votes: &'a [ConsensusMessage],
+    pub last_confirmed_view: &'a (H256, View),
+}
+
+pub struct BackupData {
+    pub height: Height,
+    pub view: View,
+    pub step: Step,
+    pub votes: Vec<ConsensusMessage>,
+    pub proposal: Option<H256>,
+    pub last_confirmed_view: (H256, View),
+}
+
+pub fn backup(db: &KeyValueDB, backup_data: BackupView) {
+    let BackupView {
+        height,
+        view,
+        step,
+        votes,
+        last_confirmed_view,
+    } = backup_data;
+    let mut s = rlp::RlpStream::new();
+    s.begin_list(6);
+    s.append(height).append(view).append(step).append_list(votes);
+    s.append(&last_confirmed_view.0).append(&last_confirmed_view.1);
+
+    let mut batch = DBTransaction::new();
+    batch.put(db::COL_EXTRA, BACKUP_KEY, &s.drain().into_vec());
+    db.write(batch).expect("Low level database error. Some issue with disk?");
+}
+
+pub fn restore(db: &KeyValueDB) -> Option<BackupData> {
+    let value = db.get(db::COL_EXTRA, BACKUP_KEY).expect("Low level database error. Some issue with disk?");
+    let (height, view, step, votes, last_confirmed_view) = value.map(|bytes| {
+        let bytes = bytes.into_vec();
+        let rlp = rlp::Rlp::new(&bytes);
+        (rlp.val_at(0), rlp.val_at(1), rlp.val_at(2), rlp.at(3).as_list(), (rlp.val_at(4), rlp.val_at(5)))
+    })?;
+
+    let proposal = find_proposal(&votes, height, view);
+
+    Some(BackupData {
+        height,
+        view,
+        step,
+        votes,
+        proposal,
+        last_confirmed_view,
+    })
+}
+
+fn find_proposal(votes: &[ConsensusMessage], height: Height, view: View) -> Option<H256> {
+    votes
+        .iter()
+        .rev()
+        .find(|vote| {
+            vote.vote_step.step == Step::Propose && vote.vote_step.view == view && vote.vote_step.height == height
+        })
+        .map(|vote| vote.block_hash)
+        .unwrap_or(None)
+}

--- a/core/src/consensus/vote_collector.rs
+++ b/core/src/consensus/vote_collector.rs
@@ -194,4 +194,8 @@ impl<M: Message + Default + Encodable + Debug> VoteCollector<M> {
         let guard = self.votes.read();
         guard.get(round).map(|c| c.block_votes.keys().cloned().filter_map(|x| x).collect()).unwrap_or_else(Vec::new)
     }
+
+    pub fn get_all(&self) -> Vec<M> {
+        self.votes.read().iter().flat_map(|(_round, collector)| collector.messages.iter()).cloned().collect()
+    }
 }


### PR DESCRIPTION
Tendermint should save votes to the persistent DB not to send
DoubleVote. Save backup data when step is changed or the node sends a
vote.