### PR TITLE
Add timeout token counter in Tendermint

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -207,7 +207,7 @@ pub trait ConsensusEngine<M: Machine>: Sync + Send {
     fn populate_from_parent(&self, _header: &mut M::Header, _parent: &M::Header) {}
 
     /// Trigger next step of the consensus engine.
-    fn step(&self) {}
+    fn step(&self, _token: usize) {}
 
     /// Stops any services that the may hold the Engine and makes it safe to drop.
     fn stop(&self) {}


### PR DESCRIPTION
There could be a race condition between `step()` and functions which call `to_step()` except `step()`. `to_step()` can be called twice.