### PR TITLE
Add benchmark tests for key module

### DIFF
--- a/key/benches/ecdsa.rs
+++ b/key/benches/ecdsa.rs
@@ -1,0 +1,52 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate codechain_key as ckey;
+extern crate test;
+
+use ckey::{recover, sign, verify, Generator, Message, Random};
+use test::Bencher;
+
+#[bench]
+fn ecdsa_sign(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let _signature = sign(key_pair.private(), &message).unwrap();
+    })
+}
+
+#[bench]
+fn ecdsa_sign_and_verify(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let signature = sign(key_pair.private(), &message).unwrap();
+        assert_eq!(Ok(true), verify(key_pair.public(), &signature, &message));
+    })
+}
+
+#[bench]
+fn ecdsa_sign_and_recover(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let signature = sign(key_pair.private(), &message).unwrap();
+        assert_eq!(Ok(*key_pair.public()), recover(&signature, &message));
+    });
+}

--- a/key/benches/schnorr.rs
+++ b/key/benches/schnorr.rs
@@ -1,0 +1,52 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate codechain_key as ckey;
+extern crate test;
+
+use ckey::{recover_schnorr, sign_schnorr, verify_schnorr, Generator, Message, Random};
+use test::Bencher;
+
+#[bench]
+fn schnorr_sign(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let _signature = sign_schnorr(key_pair.private(), &message).unwrap();
+    });
+}
+
+#[bench]
+fn schnorr_sign_and_verify(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let signature = sign_schnorr(key_pair.private(), &message).unwrap();
+        assert_eq!(Ok(true), verify_schnorr(key_pair.public(), &signature, &message));
+    });
+}
+
+#[bench]
+fn schnorr_sign_and_recover(b: &mut Bencher) {
+    b.iter(|| {
+        let key_pair = Random.generate().unwrap();
+        let message = Message::random();
+        let signature = sign_schnorr(key_pair.private(), &message).unwrap();
+        assert_eq!(Ok(*key_pair.public()), recover_schnorr(&signature, &message));
+    });
+}


### PR DESCRIPTION
```
test bench::ecdsa::sign               ... bench:     128,742 ns/iter (+/- 3,340)
test bench::ecdsa::sign_and_recover   ... bench:     235,956 ns/iter (+/- 9,578)
test bench::ecdsa::sign_and_verify    ... bench:     221,750 ns/iter (+/- 5,645)
test bench::schnorr::sign             ... bench:      91,617 ns/iter (+/- 2,879)
test bench::schnorr::sign_and_recover ... bench:     200,221 ns/iter (+/- 6,225)
test bench::schnorr::sign_and_verify  ... bench:     161,003 ns/iter (+/- 5,153)
```
| signature        | sign       | sign + recover | sign + verify | recover | verify |
| ---                   | ---          | ---                    | ---                 | ---           | ---         |
| ecdsa             | 128,742 | 235,956          | 221,750        | 107,214 | 93,008 |
| schnorr           | 91,617   | 200,221          | 161,003        | 108,604 | 69,386 |
| ecdsa/schnorr | 1.405     | 1.178             | 1.377            | 0.987     | 1.340   |

Schnorr is faster than ECDSA about 30% for sign/verify but it's slower over 10% for recover.

It seems replacing ecdsa to schnorr and adding signer field for tendermint votes message can enhance the performance.