### PR TITLE
Change signer public to signer index on Tendermint messages

### DIFF
--- a/core/src/consensus/simple_poa/mod.rs
+++ b/core/src/consensus/simple_poa/mod.rs
@@ -74,7 +74,7 @@ fn verify_external(header: &Header, validators: &ValidatorSet) -> Result<(), Err
     let signer = public_to_address(&recover(&sig, &header.bare_hash())?);
 
     if *header.author() != signer {
-        return Err(EngineError::NotAuthorized(*header.author()).into())
+        return Err(EngineError::BlockNotAuthorized(*header.author()).into())
     }
 
     if validators.contains_address(header.parent_hash(), &signer) {

--- a/core/src/consensus/tendermint/types.rs
+++ b/core/src/consensus/tendermint/types.rs
@@ -82,6 +82,14 @@ impl BitSet {
         BitSet([0; BITSET_SIZE])
     }
 
+    pub fn new_with_indices(indices: &[usize]) -> Self {
+        let mut bitset = BitSet::new();
+        for index in indices {
+            bitset.set(*index);
+        }
+        bitset
+    }
+
     pub fn all_set() -> Self {
         let mut bit_set = BitSet::new();
         for i in 0..bit_set.0.len() {
@@ -110,6 +118,13 @@ impl BitSet {
         let bit_index = index % 8;
 
         self.0[array_index] |= 1u8 << bit_index;
+    }
+
+    pub fn reset(&mut self, index: usize) {
+        let array_index = index / 8;
+        let bit_index = index % 8;
+
+        self.0[array_index] &= 0b1111_1111 ^ (1 << bit_index);
     }
 }
 

--- a/core/src/consensus/validator_set/mod.rs
+++ b/core/src/consensus/validator_set/mod.rs
@@ -49,10 +49,11 @@ pub trait ValidatorSet: Send + Sync {
     /// Draws a validator address from nonce modulo number of validators.
     fn get_address(&self, parent: &H256, nonce: usize) -> Address;
 
+    /// Draws a validator from nonce modulo number of validators.
+    fn get_index(&self, parent: &H256, public: &Public) -> Option<usize>;
+
     /// Returns the current number of validators.
     fn count(&self, parent: &H256) -> usize;
-
-    fn get_index(&self, parent: &H256, address: &Address) -> Option<usize>;
 
     /// Signalling that a new epoch has begun.
     ///

--- a/core/src/consensus/validator_set/validator_list.rs
+++ b/core/src/consensus/validator_set/validator_list.rs
@@ -91,12 +91,12 @@ impl ValidatorSet for ValidatorList {
         public_to_address(&self.get(bh, nonce))
     }
 
-    fn count(&self, _bh: &H256) -> usize {
-        self.validators.len()
+    fn get_index(&self, _bh: &H256, public: &Public) -> Option<usize> {
+        self.validators.iter().position(|v| v == public)
     }
 
-    fn get_index(&self, _bh: &H256, address: &Address) -> Option<usize> {
-        self.validators.iter().position(|validator| &public_to_address(validator) == address)
+    fn count(&self, _bh: &H256) -> usize {
+        self.validators.len()
     }
 
     fn is_epoch_end(&self, first: bool, _chain_head: &Header) -> Option<Vec<u8>> {


### PR DESCRIPTION
`VoteCollector` now stores index(`usize`) instead of `Public`.
`EngineError::NotAuthorized` is split to two: `BlockNotAuthorized` and `MessageNotAuthorized`. Because messages only have the index of the signer while blocks has the author field.

I'm concerned about two points:
1. Is it good to put the indices of the signers of the precommits on the block? This will improve the speed of verification because it'll use `verify` instead of `recover`.
2. Is `validators` are thread-safe? (Search for `self.validators` and `t.validators`.)