### PR TITLE
Add metric logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,7 @@ version = "0.1.0"
 dependencies = [
  "bech32 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "codechain-crypto 0.1.0",
+ "codechain-logger 0.1.0",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "never 0.1.0 (git+https://github.com/CodeChain-io/rust-never.git)",
@@ -574,6 +575,7 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "codechain-crypto 0.1.0",
  "codechain-key 0.1.0",
+ "codechain-logger 0.1.0",
  "codechain-types 0.1.0",
  "primitives 0.2.0 (git+https://github.com/CodeChain-io/rust-codechain-primitives.git)",
  "rlp 0.2.1",

--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -227,6 +227,7 @@ pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
             .subsec_nanos() as usize,
     );
     clogger::init(&LoggerConfig::new(instance_id)).expect("Logger must be successfully initialized");
+    clogger::metric_logger.start_thread();
 
     let pf = load_password_file(&config.operating.password_path)?;
     let keys_path = match config.operating.keys_path {

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -1145,6 +1145,7 @@ impl TendermintExtension {
         let message = TendermintMessage::ConsensusMessage(message).rlp_bytes().into_vec();
         if let Some(api) = self.api.lock().as_ref() {
             for token in tokens {
+                ::clogger::metric_logger.increase("tendermint::send_message");
                 api.send(&token, &message);
             }
         }

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -943,6 +943,7 @@ impl MemPool {
             None => vec![],
         };
         for k in all_seqs_from_sender {
+            ::clogger::metric_logger.increase("mem_pool::update_future::all_seqs_from_sender");
             let order = self
                 .future
                 .drop(signer_public, k)

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -235,6 +235,7 @@ impl Miner {
         let results = parcels
             .into_iter()
             .map(|parcel| {
+                ::clogger::metric_logger.increase("miner::add_parcels_to_pool");
                 let hash = parcel.hash();
                 if client.parcel_block(&ParcelId::Hash(hash)).is_some() {
                     cdebug!(MINER, "Rejected parcel {:?}: already in the blockchain", hash);
@@ -424,6 +425,8 @@ impl Miner {
         let mut parcel_count: usize = 0;
         let parcel_total = parcels.len();
         for parcel in parcels {
+            ::clogger::metric_logger.increase("miner::prepare_block::parcel::push");
+
             let hash = parcel.hash();
             let start = Instant::now();
             // Check whether parcel type is allowed for sender
@@ -472,6 +475,7 @@ impl Miner {
         {
             let mut queue = self.mem_pool.write();
             for hash in invalid_parcels {
+                ::clogger::metric_logger.increase("miner::prepare_block::parcel::remove_invalid");
                 queue.remove(
                     &hash,
                     &fetch_seq,

--- a/core/src/parcel.rs
+++ b/core/src/parcel.rs
@@ -116,6 +116,7 @@ impl UnverifiedParcel {
 
     /// Recovers the public key of the signature.
     pub fn recover_public(&self) -> Result<Public, ckey::Error> {
+        ::clogger::metric_logger.increase("parcel::recover_public");
         Ok(recover(&self.signature(), &self.unsigned.hash())?)
     }
 
@@ -239,6 +240,7 @@ impl From<SignedParcel> for UnverifiedParcel {
 impl SignedParcel {
     /// Try to verify parcel and recover public.
     pub fn try_new(parcel: UnverifiedParcel) -> Result<Self, ckey::Error> {
+        ::clogger::metric_logger.increase("parcel::recover_public::from_signed_parcel");
         let public = parcel.recover_public()?;
         Ok(SignedParcel {
             parcel,
@@ -285,6 +287,7 @@ impl LocalizedParcel {
         if let Some(public) = self.cached_signer_public {
             return public
         }
+        ::clogger::metric_logger.increase("parcel::recover_public::from_localized_parcel");
         let public = self.recover_public()
             .expect("LocalizedParcel is always constructed from parcel from blockchain; Blockchain only stores verified parcels; qed");
         self.cached_signer_public = Some(public);

--- a/key/Cargo.toml
+++ b/key/Cargo.toml
@@ -20,3 +20,4 @@ secp256k1 = { path = "../util/secp256k1" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+codechain-logger = { path = "../util/logger" }

--- a/key/src/ecdsa.rs
+++ b/key/src/ecdsa.rs
@@ -227,6 +227,7 @@ impl Decodable for ECDSASignature {
 }
 
 pub fn sign_ecdsa(private: &Private, message: &Message) -> Result<ECDSASignature, Error> {
+    ::clogger::metric_logger.increase("ckey::ecdsa::sign");
     let context = &SECP256K1;
     let sec = key::SecretKey::from_slice(context, &private)?;
     let s = context.sign_recoverable(&SecpMessage::from_slice(&message[..])?, &sec)?;
@@ -240,6 +241,7 @@ pub fn sign_ecdsa(private: &Private, message: &Message) -> Result<ECDSASignature
 }
 
 pub fn verify_ecdsa(public: &Public, signature: &ECDSASignature, message: &Message) -> Result<bool, Error> {
+    ::clogger::metric_logger.increase("ckey::ecdsa::verify");
     let context = &SECP256K1;
     let rsig = RecoverableSignature::from_compact(
         context,
@@ -269,6 +271,7 @@ pub fn verify_ecdsa_address(address: &Address, signature: &ECDSASignature, messa
 }
 
 pub fn recover_ecdsa(signature: &ECDSASignature, message: &Message) -> Result<Public, Error> {
+    ::clogger::metric_logger.increase("ckey::ecdsa::recover");
     let context = &SECP256K1;
     let rsig = RecoverableSignature::from_compact(
         context,

--- a/key/src/lib.rs
+++ b/key/src/lib.rs
@@ -33,6 +33,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
+extern crate codechain_logger as clogger;
+
 mod address;
 mod ecdsa;
 mod error;

--- a/key/src/schnorr.rs
+++ b/key/src/schnorr.rs
@@ -181,6 +181,7 @@ impl Decodable for SchnorrSignature {
 }
 
 pub fn sign_schnorr(private: &Private, message: &Message) -> Result<SchnorrSignature, Error> {
+    ::clogger::metric_logger.increase("ckey::schnorr::sign");
     let context = &SECP256K1;
     let sec = key::SecretKey::from_slice(context, &private)?;
     let s = context.sign_schnorr(&SecpMessage::from_slice(&message[..])?, &sec)?;
@@ -191,6 +192,8 @@ pub fn sign_schnorr(private: &Private, message: &Message) -> Result<SchnorrSigna
 }
 
 pub fn verify_schnorr(public: &Public, signature: &SchnorrSignature, message: &Message) -> Result<bool, Error> {
+    ::clogger::metric_logger.increase("ckey::schnorr::verify");
+
     let context = &SECP256K1;
     let pdata: [u8; 65] = {
         let mut temp = [4u8; 65];
@@ -218,6 +221,7 @@ pub fn verify_schnorr_address(
 }
 
 pub fn recover_schnorr(signature: &SchnorrSignature, message: &Message) -> Result<Public, Error> {
+    ::clogger::metric_logger.increase("ckey::schnorr::recover");
     let context = &SECP256K1;
 
     let sig = schnorr::Signature::deserialize(&signature.0);

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -380,6 +380,7 @@ impl TopLevelState {
                 let approvers = approvals
                     .iter()
                     .map(|signature| {
+                        ::clogger::metric_logger.increase("state::top_level::recover");
                         let public = recover(&signature, &transaction_hash)?;
                         self.public_to_owner_address(&public)
                     })

--- a/util/logger/src/lib.rs
+++ b/util/logger/src/lib.rs
@@ -27,9 +27,11 @@ extern crate time;
 
 mod logger;
 mod macros;
+mod metric;
 mod structured_logger;
 
 use log::SetLoggerError;
+use metric::Metric;
 
 pub use logger::Config as LoggerConfig;
 use logger::Logger;
@@ -48,4 +50,8 @@ use lazy_static::lazy_static;
 
 lazy_static! {
     pub static ref slogger: StructuredLogger = StructuredLogger::create();
+}
+
+lazy_static! {
+    pub static ref metric_logger: Metric = Metric::new();
 }

--- a/util/logger/src/metric.rs
+++ b/util/logger/src/metric.rs
@@ -1,0 +1,122 @@
+// Copyright 2018 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+
+use parking_lot::RwLock;
+use time;
+
+pub type MetricKey = &'static str;
+
+pub struct MetricEntry {
+    pub value: u64,
+    pub prev: u64,
+}
+
+impl MetricEntry {
+    fn new_with(initial: u64) -> Self {
+        MetricEntry {
+            value: initial,
+            prev: 0,
+        }
+    }
+
+    fn changed(&self) -> u64 {
+        self.value - self.prev
+    }
+
+    fn inc(&mut self) {
+        self.value += 1;
+    }
+
+    fn reset_prev(&mut self) {
+        self.prev = self.value;
+    }
+}
+
+pub struct Metric {
+    inner: Arc<RwLock<MetricInner>>,
+}
+
+pub struct MetricInner {
+    table: BTreeMap<MetricKey, MetricEntry>,
+    prev_print_time: Instant,
+}
+
+impl Default for Metric {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Metric {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(MetricInner {
+                table: BTreeMap::new(),
+                prev_print_time: Instant::now(),
+            })),
+        }
+    }
+
+    pub fn start_thread(&self) {
+        let inner = Arc::clone(&self.inner);
+        thread::Builder::new()
+            .name("Metric logger".to_string())
+            .spawn(move || loop {
+                thread::sleep(::std::time::Duration::new(1, 0));
+                inner.write().print();
+            })
+            .unwrap();
+    }
+
+    pub fn increase(&self, key: &'static str) {
+        let mut guard = self.inner.write();
+        guard.increase(key);
+    }
+
+    pub fn print(&self) {
+        let mut guard = self.inner.write();
+        guard.print();
+    }
+}
+
+impl MetricInner {
+    pub fn increase(&mut self, key: &'static str) {
+        self.table.entry(key).or_insert_with(|| MetricEntry::new_with(1)).inc();
+    }
+
+    pub fn print(&mut self) {
+        let timestamp = time::strftime("%Y-%m-%d %H:%M:%S %Z", &time::now()).unwrap();
+        println!("Metric at : {}", timestamp);
+        let elapsed_secs = (Instant::now() - self.prev_print_time).as_secs() as f64;
+        for (k, v) in self.table.iter_mut() {
+            println!(
+                "Metric {}: cur {} changed {} speed {}",
+                k,
+                v.value,
+                v.changed(),
+                (v.changed() as f64) / elapsed_secs
+            );
+            v.reset_prev();
+        }
+
+        self.prev_print_time = Instant::now();
+    }
+}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -10,6 +10,8 @@ byteorder = "1.2.7"
 codechain-crypto = { path = "../crypto" }
 codechain-key = { path = "../key" }
 codechain-types = { path = "../types" }
+codechain-logger = { path = "../util/logger" }
+
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git" }
 rlp = { path = "../util/rlp" }
 

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -248,6 +248,7 @@ where
                 let tag = Tag::try_new(stack.pop()?.as_ref().to_vec())?;
                 let tx_hash = tx.hash_partially(tag, cur, burn)?;
                 let signature = Signature::from(stack.pop()?.assert_len(SIGNATURE_LENGTH)?.as_ref());
+                ::clogger::metric_logger.increase("vm::checksig");
                 let result = match verify(&pubkey, &signature, &tx_hash) {
                     Ok(true) => 1,
                     _ => 0,

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate byteorder;
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_key as ckey;
+extern crate codechain_logger as clogger;
 extern crate codechain_types as ctypes;
 extern crate primitives;
 


### PR DESCRIPTION
The metric logger prints logs/sec at every second.

I think that we should turn on/off using some environment variable.

The sample result.
```
Metric at : 2018-12-28 21:50:10
Metric ckey::ecdsa::recover: cur 36385 changed 0 speed 0
Metric ckey::ecdsa::sign: cur 6 changed 0 speed 0
Metric ckey::schnorr::sign: cur 109 changed 0 speed 0
Metric ckey::schnorr::verify: cur 106 changed 0 speed 0
Metric mem_pool::update_future::all_seqs_from_sender: cur 73562040 changed 1406636 speed
1406636
Metric miner::add_parcels_to_pool: cur 10001 changed 0 speed 0
Metric miner::local_parcel::mark_invalid: cur 2738 changed 191 speed 191
Metric miner::prepare_block::parcel::push: cur 40001 changed 0 speed 0
Metric miner::prepare_block::parcel::remove_invalid: cur 2738 changed 191 speed 191
Metric parcel::recover_public: cur 36385 changed 0 speed 0
Metric parcel::recover_public::from_signed_parcel: cur 36385 changed 0 speed 0
Metric tendermint::on_message: cur 1460 changed 0 speed 0
Metric tendermint::request_messages: cur 239 changed 0 speed 0
Metric tendermint::send_message: cur 493 changed 0 speed 0
Metric tendermint::send_proposal_block: cur 104 changed 0 speed 0
Metric tendermint::send_state: cur 636 changed 0 speed 0
```