### PR TITLE
Change the field order in ConsensusMessage

### DIFF
--- a/core/src/consensus/tendermint/message.rs
+++ b/core/src/consensus/tendermint/message.rs
@@ -219,9 +219,9 @@ pub struct VoteOn {
 /// Message transmitted between consensus participants.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Default, RlpDecodable, RlpEncodable)]
 pub struct ConsensusMessage {
+    pub on: VoteOn,
     pub signature: SchnorrSignature,
     pub signer_index: usize,
-    pub on: VoteOn,
 }
 
 impl ConsensusMessage {


### PR DESCRIPTION
Since the `on` field is more useful when debugging the Tendermint,
change the field order to make debug log better.