### PR TITLE
Rename transactionHash to tracker

### DIFF
--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -483,8 +483,8 @@ impl BodyProvider for BlockChain {
         self.body_db.parcel_address(hash)
     }
 
-    fn transaction_address(&self, hash: &H256) -> Option<TransactionAddress> {
-        self.body_db.transaction_address(hash)
+    fn transaction_address(&self, tracker: &H256) -> Option<TransactionAddress> {
+        self.body_db.transaction_address(tracker)
     }
 
     fn block_body(&self, hash: &H256) -> Option<encoded::Body> {

--- a/core/src/blockchain/body_db.rs
+++ b/core/src/blockchain/body_db.rs
@@ -283,7 +283,7 @@ pub trait BodyProvider {
     /// Get the address of parcel with given hash.
     fn parcel_address(&self, hash: &H256) -> Option<ParcelAddress>;
 
-    fn transaction_address(&self, hash: &H256) -> Option<TransactionAddress>;
+    fn transaction_address(&self, tracker: &H256) -> Option<TransactionAddress>;
 
     /// Get the block body (uncles and parcels).
     fn block_body(&self, hash: &H256) -> Option<encoded::Body>;
@@ -300,8 +300,8 @@ impl BodyProvider for BodyDB {
         Some(result)
     }
 
-    fn transaction_address(&self, hash: &H256) -> Option<TransactionAddress> {
-        Some(self.db.read_with_cache(db::COL_EXTRA, &self.transaction_address_cache, hash)?)
+    fn transaction_address(&self, tracker: &H256) -> Option<TransactionAddress> {
+        Some(self.db.read_with_cache(db::COL_EXTRA, &self.transaction_address_cache, tracker)?)
     }
 
     /// Get block body data

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -188,8 +188,8 @@ impl Client {
         }
     }
 
-    fn transaction_address(&self, hash: &H256) -> Option<TransactionAddress> {
-        self.block_chain().transaction_address(hash)
+    fn transaction_address(&self, tracker: &H256) -> Option<TransactionAddress> {
+        self.block_chain().transaction_address(tracker)
     }
 
     fn parcel_address_of_successful_transaction(&self, hash: &H256) -> Option<ParcelAddress> {
@@ -613,14 +613,14 @@ impl BlockChainClient for Client {
         self.parcel_address(id).and_then(|address| chain.parcel_invoice(&address))
     }
 
-    fn transaction(&self, hash: &H256) -> Option<LocalizedTransaction> {
+    fn transaction(&self, tracker: &H256) -> Option<LocalizedTransaction> {
         let chain = self.block_chain();
-        let address = self.transaction_address(hash)?;
+        let address = self.transaction_address(tracker)?;
         address.into_iter().map(Into::into).map(|address| chain.parcel(&address)).next()?
     }
 
-    fn transaction_invoices(&self, hash: &H256) -> Vec<Invoice> {
-        self.transaction_address(hash)
+    fn transaction_invoices(&self, tracker: &H256) -> Vec<Invoice> {
+        self.transaction_address(tracker)
             .map(|address| {
                 address
                     .into_iter()

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -245,10 +245,10 @@ pub trait BlockChainClient:
     /// Get parcel invoice with given hash.
     fn parcel_invoice(&self, id: &TransactionId) -> Option<Invoice>;
 
-    /// Get the transaction with given hash.
-    fn transaction(&self, hash: &H256) -> Option<LocalizedTransaction>;
+    /// Get the transaction with given tracker.
+    fn transaction(&self, tracker: &H256) -> Option<LocalizedTransaction>;
 
-    fn transaction_invoices(&self, hash: &H256) -> Vec<Invoice>;
+    fn transaction_invoices(&self, tracker: &H256) -> Vec<Invoice>;
 }
 
 /// Result of import block operation.

--- a/core/src/codechain_machine.rs
+++ b/core/src/codechain_machine.rs
@@ -127,13 +127,12 @@ impl CodeChainMachine {
                         .into())
                     }
                     Timelock::BlockAge(value) => {
-                        let absolute =
-                            client.transaction_block_number(&input.prev_out.transaction_hash).ok_or_else(|| {
-                                Error::State(StateError::Transaction(TransactionError::Timelocked {
-                                    timelock,
-                                    remaining_time: u64::max_value(),
-                                }))
-                            })? + value;
+                        let absolute = client.transaction_block_number(&input.prev_out.tracker).ok_or_else(|| {
+                            Error::State(StateError::Transaction(TransactionError::Timelocked {
+                                timelock,
+                                remaining_time: u64::max_value(),
+                            }))
+                        })? + value;
                         if absolute > header.number() {
                             return Err(StateError::Transaction(TransactionError::Timelocked {
                                 timelock,
@@ -151,7 +150,7 @@ impl CodeChainMachine {
                     }
                     Timelock::TimeAge(value) => {
                         let absolute =
-                            client.transaction_block_timestamp(&input.prev_out.transaction_hash).ok_or_else(|| {
+                            client.transaction_block_timestamp(&input.prev_out.tracker).ok_or_else(|| {
                                 Error::State(StateError::Transaction(TransactionError::Timelocked {
                                     timelock,
                                     remaining_time: u64::max_value(),

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -308,7 +308,7 @@ impl Miner {
                         Timelock::Block(value) => (true, value),
                         Timelock::BlockAge(value) => (
                             true,
-                            client.transaction_block_number(&input.prev_out.transaction_hash).ok_or_else(|| {
+                            client.transaction_block_number(&input.prev_out.tracker).ok_or_else(|| {
                                 Error::State(StateError::Transaction(TransactionError::Timelocked {
                                     timelock,
                                     remaining_time: u64::max_value(),
@@ -318,7 +318,7 @@ impl Miner {
                         Timelock::Time(value) => (false, value),
                         Timelock::TimeAge(value) => (
                             false,
-                            client.transaction_block_timestamp(&input.prev_out.transaction_hash).ok_or_else(|| {
+                            client.transaction_block_timestamp(&input.prev_out.tracker).ok_or_else(|| {
                                 Error::State(StateError::Transaction(TransactionError::Timelocked {
                                     timelock,
                                     remaining_time: u64::max_value(),

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -110,21 +110,21 @@ where
         Ok(self.client.parcel_invoice(&transaction_hash.into()))
     }
 
-    fn get_transaction_with_payload_hash(&self, payload_hash: H256) -> Result<Option<Transaction>> {
-        Ok(self.client.transaction(&payload_hash).map(Into::into))
+    fn get_transaction_by_tracker(&self, tracker: H256) -> Result<Option<Transaction>> {
+        Ok(self.client.transaction(&tracker).map(Into::into))
     }
 
-    fn get_invoices_with_payload_hash(&self, payload_hash: H256) -> Result<Vec<Invoice>> {
-        Ok(self.client.transaction_invoices(&payload_hash))
+    fn get_invoices_by_tracker(&self, tracker: H256) -> Result<Vec<Invoice>> {
+        Ok(self.client.transaction_invoices(&tracker))
     }
 
-    fn get_asset_scheme_by_hash(
+    fn get_asset_scheme_by_tracker(
         &self,
-        transaction_hash: H256,
+        tracker: H256,
         shard_id: ShardId,
         block_number: Option<u64>,
     ) -> Result<Option<AssetScheme>> {
-        let address = AssetSchemeAddress::new(transaction_hash, shard_id);
+        let address = AssetSchemeAddress::new(tracker, shard_id);
         self.get_asset_scheme_by_type(address.into(), block_number)
     }
 

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -40,17 +40,17 @@ build_rpc_trait! {
         # [rpc(name = "chain_getInvoice")]
         fn get_invoice(&self, H256) -> Result<Option<Invoice>>;
 
-        /// Gets transaction with given payload hash.
-        # [rpc(name = "chain_getTransactionById")]
-        fn get_transaction_with_payload_hash(&self, H256) -> Result<Option<Transaction>>;
+        /// Gets transaction with given transaction tracker.
+        # [rpc(name = "chain_getTransactionByTracker")]
+        fn get_transaction_by_tracker(&self, H256) -> Result<Option<Transaction>>;
 
-        /// Gets transaction invoices with given payload hash.
-        # [rpc(name = "chain_getInvoicesById")]
-        fn get_invoices_with_payload_hash(&self, H256) -> Result<Vec<Invoice>>;
+        /// Gets transaction invoices with given transaction tracker.
+        # [rpc(name = "chain_getInvoicesByTracker")]
+        fn get_invoices_by_tracker(&self, H256) -> Result<Vec<Invoice>>;
 
-        /// Gets asset scheme with given payload hash.
-        # [rpc(name = "chain_getAssetSchemeByHash")]
-        fn get_asset_scheme_by_hash(&self, H256, ShardId, Option<u64>) -> Result<Option<AssetScheme>>;
+        /// Gets asset scheme with given transaction tracker.
+        # [rpc(name = "chain_getAssetSchemeByTracker")]
+        fn get_asset_scheme_by_tracker(&self, H256, ShardId, Option<u64>) -> Result<Option<AssetScheme>>;
 
         /// Gets asset scheme with given asset type.
         # [rpc(name = "chain_getAssetSchemeByType")]

--- a/rpc/src/v1/types/asset_input.rs
+++ b/rpc/src/v1/types/asset_input.rs
@@ -21,7 +21,7 @@ use primitives::{Bytes, H256};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetOutPoint {
-    pub transaction_id: H256,
+    pub tracker: H256,
     pub index: usize,
     pub asset_type: H256,
     pub amount: Uint,
@@ -30,7 +30,7 @@ pub struct AssetOutPoint {
 impl From<AssetOutPointType> for AssetOutPoint {
     fn from(from: AssetOutPointType) -> Self {
         AssetOutPoint {
-            transaction_id: from.transaction_hash,
+            tracker: from.tracker,
             index: from.index,
             asset_type: from.asset_type,
             amount: from.amount.into(),
@@ -41,7 +41,7 @@ impl From<AssetOutPointType> for AssetOutPoint {
 impl From<AssetOutPoint> for AssetOutPointType {
     fn from(from: AssetOutPoint) -> Self {
         AssetOutPointType {
-            transaction_hash: from.transaction_id,
+            tracker: from.tracker,
             index: from.index,
             asset_type: from.asset_type,
             amount: from.amount.into(),

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -276,9 +276,9 @@ When `Transaction` is included in any response, there will be an additional fiel
  * [chain_sendSignedTransaction](#chain_sendsignedtransaction)
  * [chain_getTransaction](#chain_gettransaction)
  * [chain_getInvoice](#chain_getinvoice)
- * [chain_getTransactionById](#chain_gettransactionbyid)
- * [chain_getInvoicesById](#chain_getinvoicesbyid)
- * [chain_getAssetSchemeByHash](#chain_getassetschemebyhash)
+ * [chain_getTransactionByTracker](#chain_gettransactionbytracker)
+ * [chain_getInvoicesByTracker](#chain_getinvoicesbytracker)
+ * [chain_getAssetSchemeByTracker](#chain_getassetschemebytracker)
  * [chain_getAssetSchemeByType](#chain_getassetschemebytype)
  * [chain_getAsset](#chain_getasset)
  * [chain_getText](#chain_gettext)
@@ -743,11 +743,11 @@ Errors: `Invalid Params`
 
 [Back to **List of methods**](#list-of-methods)
 
-## chain_getTransactionById
-Gets a transaction with the given transaction id.
+## chain_getTransactionByTracker
+Gets a transaction with the given tracker.
 
 ### Params
- 1. transaction id - `H256`
+ 1. tracker - `H256`
 
 ### Returns
 `null` | `Transaction`
@@ -758,7 +758,7 @@ Errors: `Invalid Params`
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getTransactionById", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "chain_getTransactionByTracker", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
     localhost:8080
 ```
 
@@ -788,11 +788,11 @@ Errors: `Invalid Params`
 
 [Back to **List of methods**](#list-of-methods)
 
-## chain_getInvoicesById
-Gets transaction invoices with the given transaction id.
+## chain_getInvoicesByTracker
+Gets transaction invoices with the given tracker.
 
 ### Params
- 1. transaction id - `H256`
+ 1. tracker - `H256`
 
 ### Returns
 `string[]` - Each string is either "Success" or "Failed".
@@ -803,7 +803,7 @@ Errors: `Invalid Params`
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getInvoicesById", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "chain_getInvoicesByTracker", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
     localhost:8080
 ```
 
@@ -818,11 +818,11 @@ Errors: `Invalid Params`
 
 [Back to **List of methods**](#list-of-methods)
 
-## chain_getAssetSchemeByHash
-Gets an asset scheme with the given asset type.
+## chain_getAssetSchemeByTracker
+Gets an asset scheme with the tracker of the mint transaction.
 
 ### Params
- 1. transaction id of AssetMintTransaction - `H256`
+ 1. tracker of AssetMintTransaction - `H256`
  2. shard id - `number`
  3. block number: `number` | `null`
 
@@ -835,7 +835,7 @@ Errors: `KVDB Error`, `Invalid Params`
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getAssetSchemeByHash", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc", 0, null], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "chain_getAssetSchemeByTracker", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc", 0, null], "id": null}' \
     localhost:8080
 ```
 

--- a/state/src/impls/test_helper.rs
+++ b/state/src/impls/test_helper.rs
@@ -113,7 +113,7 @@ macro_rules! asset_mint_output {
 macro_rules! asset_out_point {
     ($tracker:expr, $index:expr, $asset_type:expr, $amount:expr) => {
         $crate::ctypes::transaction::AssetOutPoint {
-            transaction_hash: $tracker,
+            tracker: $tracker,
             index: $index,
             asset_type: $asset_type,
             amount: $amount,

--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -25,12 +25,12 @@ macro_rules! define_address_constructor {
     };
     (SHARD, $name:ident, $prefix:expr) => {
         fn from_transaction_hash_with_shard_id(
-            transaction_hash: ::primitives::H256,
+            tracker: ::primitives::H256,
             index: u64,
             shard_id: ::ctypes::ShardId,
         ) -> Self {
             let mut hash: ::primitives::H256 =
-                ::ccrypto::Blake::blake_with_key(&transaction_hash, &::primitives::H128::from(index));
+                ::ccrypto::Blake::blake_with_key(&tracker, &::primitives::H128::from(index));
             hash[0..2].clone_from_slice(&[$prefix, 0]);
 
             let mut shard_id_bytes = Vec::<u8>::new();

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -163,10 +163,10 @@ pub struct AssetSchemeAddress(H256);
 impl_address!(SHARD, AssetSchemeAddress, PREFIX);
 
 impl AssetSchemeAddress {
-    pub fn new(transaction_hash: H256, shard_id: ShardId) -> Self {
+    pub fn new(tracker: H256, shard_id: ShardId) -> Self {
         let index = ::std::u64::MAX;
 
-        Self::from_transaction_hash_with_shard_id(transaction_hash, index, shard_id)
+        Self::from_transaction_hash_with_shard_id(tracker, index, shard_id)
     }
     pub fn new_with_zero_suffix(shard_id: ShardId) -> Self {
         let mut hash = H256::zero();

--- a/test/package.json
+++ b/test/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#rlp-lib",
+    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#rename-lib",
     "codechain-test-helper": "https://github.com/sgkim126/codechain-test-helper-js.git#refac-lib",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -430,7 +430,7 @@ export default class CodeChain {
         });
         await this.sdk.rpc.chain.sendSignedTransaction(signed);
         if (awaitInvoice) {
-            return this.sdk.rpc.chain.getInvoicesById(tx.id(), {
+            return this.sdk.rpc.chain.getInvoicesByTracker(tx.tracker(), {
                 timeout: 300 * 1000
             });
         }
@@ -468,7 +468,7 @@ export default class CodeChain {
         if (!awaitMint) {
             return { asset: tx.getMintedAsset() };
         }
-        const asset = await this.sdk.rpc.chain.getAsset(tx.id(), 0);
+        const asset = await this.sdk.rpc.chain.getAsset(tx.tracker(), 0);
         if (asset === null) {
             throw Error(`Failed to mint asset`);
         }

--- a/test/src/integration.long/sync2.test.ts
+++ b/test/src/integration.long/sync2.test.ts
@@ -255,14 +255,14 @@ describe("sync 2 nodes", function() {
                         expect(await nodeA.getBestBlockHash()).to.deep.equal(
                             await nodeB.getBestBlockHash()
                         );
-                        const invoicesA = await nodeA.sdk.rpc.chain.getInvoicesById(
-                            tx2.id()
+                        const invoicesA = await nodeA.sdk.rpc.chain.getInvoicesByTracker(
+                            tx2.tracker()
                         );
                         expect(invoicesA!.length).to.equal(1);
                         expect(invoicesA![0].success).to.be.false;
 
-                        const invoicesB = await nodeB.sdk.rpc.chain.getInvoicesById(
-                            tx2.id()
+                        const invoicesB = await nodeB.sdk.rpc.chain.getInvoicesByTracker(
+                            tx2.tracker()
                         );
                         expect(invoicesB!.length).to.equal(1);
                         expect(invoicesB![0].success).to.be.false;
@@ -285,14 +285,14 @@ describe("sync 2 nodes", function() {
                             await nodeB.getBestBlockHash()
                         );
 
-                        const invoicesA = await nodeA.sdk.rpc.chain.getInvoicesById(
-                            tx2.id()
+                        const invoicesA = await nodeA.sdk.rpc.chain.getInvoicesByTracker(
+                            tx2.tracker()
                         );
                         expect(invoicesA!.length).to.equal(1);
                         expect(invoicesA![0].success).to.be.true;
 
-                        const invoicesB = await nodeB.sdk.rpc.chain.getInvoicesById(
-                            tx2.id()
+                        const invoicesB = await nodeB.sdk.rpc.chain.getInvoicesByTracker(
+                            tx2.tracker()
                         );
                         expect(invoicesB!.length).to.equal(1);
                         expect(invoicesB![0].success).to.be.true;

--- a/test/src/integration.long/transactions.test.ts
+++ b/test/src/integration.long/transactions.test.ts
@@ -309,7 +309,7 @@ describe("transactions", function() {
         expect(invoices2!.length).to.equal(1);
         expect(invoices2![0].success).to.be.true;
 
-        expect(await node.sdk.rpc.chain.getAsset(tx2.id(), 0)).to.be.null;
+        expect(await node.sdk.rpc.chain.getAsset(tx2.tracker(), 0)).to.be.null;
     });
 
     it("Burn unsuccessful(ZeroAmount)", async function() {
@@ -336,7 +336,7 @@ describe("transactions", function() {
             node.sdk.core.createAssetTransferInput({
                 assetOutPoint: {
                     assetType,
-                    transactionId: tx1.id(),
+                    tracker: tx1.tracker(),
                     index: 0,
                     lockScriptHash,
                     parameters,
@@ -388,7 +388,8 @@ describe("transactions", function() {
             "ScriptShouldBeBurnt"
         );
 
-        expect(await node.sdk.rpc.chain.getAsset(tx1.id(), 0)).not.to.be.null;
+        expect(await node.sdk.rpc.chain.getAsset(tx1.tracker(), 0)).not.to.be
+            .null;
     });
 
     it("Cannot burn P2PKH asset", async function() {
@@ -555,7 +556,7 @@ describe("transactions", function() {
                 recipient
             });
             await node.sendAssetTransaction(tx);
-            const asset = await node.sdk.rpc.chain.getAsset(tx.id(), 0);
+            const asset = await node.sdk.rpc.chain.getAsset(tx.tracker(), 0);
             if (asset === null) {
                 throw Error(`Failed to mint an asset`);
             }
@@ -1151,7 +1152,7 @@ describe("transactions", function() {
                 expect(invoices1![0].success).to.be.true;
 
                 const asset2 = await node.sdk.rpc.chain.getAsset(
-                    transferTx.id(),
+                    transferTx.tracker(),
                     0
                 );
 

--- a/test/src/integration/mempool.test.ts
+++ b/test/src/integration/mempool.test.ts
@@ -93,7 +93,7 @@ describe("Timelock", function() {
     });
 
     async function checkTx(txhash: H256, shouldBeConfirmed: boolean) {
-        const invoices = await node.sdk.rpc.chain.getInvoicesById(txhash);
+        const invoices = await node.sdk.rpc.chain.getInvoicesByTracker(txhash);
         if (shouldBeConfirmed) {
             expect(invoices.length).to.equal(1);
             expect(invoices[0].error).to.be.undefined;
@@ -126,7 +126,7 @@ describe("Timelock", function() {
         await node.signTransactionInput(tx, 0);
         const { fee } = options;
         await node.sendAssetTransaction(tx, { awaitInvoice: false, fee });
-        return tx.id();
+        return tx.tracker();
     }
 
     describe("The current items should move to the future queue", async function() {

--- a/test/src/integration/verification.test.ts
+++ b/test/src/integration/verification.test.ts
@@ -212,7 +212,7 @@ describe("solo - 1 node", function() {
             });
             input = node.sdk.core.createAssetTransferInput({
                 assetOutPoint: {
-                    transactionId: "0x" + "0".repeat(64),
+                    tracker: "0x" + "0".repeat(64),
                     index: 0,
                     assetType: "0x" + "1".repeat(64),
                     amount: 12345
@@ -364,11 +364,11 @@ describe("solo - 1 node", function() {
             });
 
             ["0x1" + "0".repeat(64), "0x" + "f".repeat(65)].forEach(function(
-                transactionHash
+                tracker
             ) {
-                it(`transactionHash: ${transactionHash}`, async function() {
+                it(`tracker: ${tracker}`, async function() {
                     // Burn
-                    encoded[3][2][0][0][0] = transactionHash;
+                    encoded[3][2][0][0][0] = tracker;
                     try {
                         await node.sendSignedTransactionWithRlpBytes(
                             RLP.encode(encoded)
@@ -380,7 +380,7 @@ describe("solo - 1 node", function() {
                         );
                     }
                     // Input
-                    encoded[3][3][0][0][0] = transactionHash;
+                    encoded[3][3][0][0][0] = tracker;
                     try {
                         await node.sendSignedTransactionWithRlpBytes(
                             RLP.encode(encoded)
@@ -621,11 +621,11 @@ describe("solo - 1 node", function() {
             });
 
             ["0x1" + "0".repeat(64), "0x" + "f".repeat(65)].forEach(function(
-                transactionHash
+                tracker
             ) {
-                it(`transactionHash: ${transactionHash}`, async function() {
+                it(`tracker: ${tracker}`, async function() {
                     // Input
-                    encoded[3][2][0][0] = transactionHash;
+                    encoded[3][2][0][0] = tracker;
                     try {
                         await node.sendSignedTransactionWithRlpBytes(
                             RLP.encode(encoded)
@@ -730,10 +730,10 @@ describe("solo - 1 node", function() {
             });
 
             ["0x1" + "0".repeat(64), "0x" + "f".repeat(65)].forEach(function(
-                transactionHash
+                tracker
             ) {
-                it(`transactionHash: ${transactionHash}`, async function() {
-                    encoded[3][2][0][0] = transactionHash;
+                it(`tracker: ${tracker}`, async function() {
+                    encoded[3][2][0][0] = tracker;
                     try {
                         await node.sendSignedTransactionWithRlpBytes(
                             RLP.encode(encoded)

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -879,9 +879,9 @@ codechain-primitives@^0.4.4:
     request-promise "^4.2.2"
     rlp "^2.0.0"
 
-"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#rlp-lib":
+"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#rename-lib":
   version "0.5.1"
-  resolved "https://github.com/sgkim126/codechain-sdk-js.git#77cab2bdd28d439b1684bd1b49ca3a4cd3cfbba2"
+  resolved "https://github.com/sgkim126/codechain-sdk-js.git#0616c8121cbc8f91ada8453da9d0a1988bca721a"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -881,10 +881,10 @@ fn check_duplication_in_prev_out(
 ) -> Result<(), TransactionError> {
     let mut prev_out_set = HashSet::new();
     for input in inputs.iter().chain(burns) {
-        let prev_out = (input.prev_out.transaction_hash, input.prev_out.index);
+        let prev_out = (input.prev_out.tracker, input.prev_out.index);
         if !prev_out_set.insert(prev_out) {
             return Err(TransactionError::DuplicatedPreviousOutput {
-                transaction_hash: input.prev_out.transaction_hash,
+                transaction_hash: input.prev_out.tracker,
                 index: input.prev_out.index,
             })
         }
@@ -1122,7 +1122,7 @@ mod tests {
         let lock_script_hash = H160::random();
         let parameters = vec![vec![1]];
         let origin_output = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
             amount: 30,
@@ -1154,7 +1154,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1199,13 +1199,13 @@ mod tests {
         let parameters2 = vec![vec![2]];
 
         let origin_output_1 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
             amount: 40,
         };
         let origin_output_2 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_c,
             amount: 30,
@@ -1244,7 +1244,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1309,7 +1309,7 @@ mod tests {
 
         // Case 1: ratio is wrong
         let origin_output = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
             amount: 30,
@@ -1341,7 +1341,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1380,13 +1380,13 @@ mod tests {
 
         // Case 2: multiple outputs with same order and asset_type
         let origin_output_1 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
             amount: 40,
         };
         let origin_output_2 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_c,
             amount: 40,
@@ -1425,7 +1425,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1505,7 +1505,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1585,7 +1585,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
                         amount: 10,
@@ -1654,13 +1654,13 @@ mod tests {
         let lock_script_hash = H160::random();
         let parameters = vec![vec![1]];
         let origin_output_1 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
             amount: 30,
         };
         let origin_output_2 = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 0,
             asset_type: asset_type_b,
             amount: 10,
@@ -1757,7 +1757,7 @@ mod tests {
             network_id: NetworkId::default(),
             burn: AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::default(),
+                    tracker: Default::default(),
                     index: 0,
                     asset_type: H256::zero(),
                     amount: 0,
@@ -1775,7 +1775,7 @@ mod tests {
             network_id: NetworkId::default(),
             burn: AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::default(),
+                    tracker: Default::default(),
                     index: 0,
                     asset_type: invalid_asset_type,
                     amount: 1,

--- a/types/src/transaction/asset_out_point.rs
+++ b/types/src/transaction/asset_out_point.rs
@@ -23,7 +23,7 @@ use crate::ShardId;
 
 #[derive(Debug, Clone, Eq, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct AssetOutPoint {
-    pub transaction_hash: H256,
+    pub tracker: H256,
     pub index: usize,
     pub asset_type: H256,
     pub amount: u64,
@@ -46,7 +46,7 @@ mod tests {
         asset_type[2..4].clone_from_slice(&[0xBE, 0xEF]);
 
         let p = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 3,
             asset_type,
             amount: 34,

--- a/types/src/transaction/order.rs
+++ b/types/src/transaction/order.rs
@@ -172,7 +172,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -193,7 +193,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 0,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -214,7 +214,7 @@ mod tests {
             asset_amount_to: 0,
             asset_amount_fee: 0,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -242,7 +242,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: H256::random(),
                 amount: 10,
@@ -280,7 +280,7 @@ mod tests {
             asset_amount_to: 0,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -308,7 +308,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -336,7 +336,7 @@ mod tests {
             asset_amount_to: 0,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -364,7 +364,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 2,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
                 amount: 10,
@@ -394,7 +394,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type,
                 amount: 10,
@@ -423,7 +423,7 @@ mod tests {
             asset_amount_to: 2,
             asset_amount_fee: 3,
             origin_outputs: vec![AssetOutPoint {
-                transaction_hash: H256::random(),
+                tracker: H256::random(),
                 index: 0,
                 asset_type,
                 amount: 10,

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -737,7 +737,7 @@ mod tests {
         asset_type[2..4].clone_from_slice(&[0xBE, 0xEF]);
 
         let prev_out = AssetOutPoint {
-            transaction_hash: H256::random(),
+            tracker: H256::random(),
             index: 3,
             asset_type,
             amount: 34,
@@ -761,7 +761,7 @@ mod tests {
         assert!(is_input_and_output_consistent(
             &[AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::random(),
+                    tracker: H256::random(),
                     index: 0,
                     asset_type,
                     amount,
@@ -796,7 +796,7 @@ mod tests {
             &[
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type1,
                         amount: amount1,
@@ -807,7 +807,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type2,
                         amount: amount2,
@@ -851,7 +851,7 @@ mod tests {
             &[
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type1,
                         amount: amount1,
@@ -862,7 +862,7 @@ mod tests {
                 },
                 AssetTransferInput {
                     prev_out: AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type2,
                         amount: amount2,
@@ -917,7 +917,7 @@ mod tests {
         assert!(!is_input_and_output_consistent(
             &[AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::random(),
+                    tracker: H256::random(),
                     index: 0,
                     asset_type,
                     amount: input_amount,
@@ -939,7 +939,7 @@ mod tests {
         assert!(!is_input_and_output_consistent(
             &[AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::random(),
+                    tracker: H256::random(),
                     index: 0,
                     asset_type,
                     amount: input_amount,
@@ -966,7 +966,7 @@ mod tests {
         assert!(!is_input_and_output_consistent(
             &[AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::random(),
+                    tracker: H256::random(),
                     index: 0,
                     asset_type,
                     amount: input_amount,
@@ -991,7 +991,7 @@ mod tests {
             network_id: NetworkId::default(),
             input: AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::default(),
+                    tracker: Default::default(),
                     index: 0,
                     asset_type: H256::default(),
                     amount: 30,
@@ -1011,7 +1011,7 @@ mod tests {
             network_id: NetworkId::default(),
             burn: AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::default(),
+                    tracker: Default::default(),
                     index: 0,
                     asset_type: H256::zero(),
                     amount: 30,
@@ -1031,7 +1031,7 @@ mod tests {
             burns: vec![],
             inputs: vec![AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::random(),
+                    tracker: H256::random(),
                     index: 0,
                     asset_type: H256::random(),
                     amount: 30,
@@ -1055,7 +1055,7 @@ mod tests {
                     asset_amount_to: 10,
                     asset_amount_fee: 0,
                     origin_outputs: vec![AssetOutPoint {
-                        transaction_hash: H256::random(),
+                        tracker: H256::random(),
                         index: 0,
                         asset_type: H256::random(),
                         amount: 30,
@@ -1078,7 +1078,7 @@ mod tests {
     fn apply_long_filter() {
         let input = AssetTransferInput {
             prev_out: AssetOutPoint {
-                transaction_hash: H256::default(),
+                tracker: Default::default(),
                 index: 0,
                 asset_type: H256::default(),
                 amount: 0,
@@ -1090,7 +1090,7 @@ mod tests {
         let inputs: Vec<AssetTransferInput> = (0..100)
             .map(|_| AssetTransferInput {
                 prev_out: AssetOutPoint {
-                    transaction_hash: H256::default(),
+                    tracker: Default::default(),
                     index: 0,
                     asset_type: H256::default(),
                     amount: 0,

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -317,9 +317,7 @@ where
                     }
                     TIMELOCK_TYPE_BLOCK_AGE => {
                         stack.push(Item::from(
-                            client
-                                .transaction_block_age(&cur.prev_out.transaction_hash)
-                                .map_or(false, |age| age >= value),
+                            client.transaction_block_age(&cur.prev_out.tracker).map_or(false, |age| age >= value),
                         ))?;
                     }
                     TIMELOCK_TYPE_TIME => {
@@ -327,9 +325,7 @@ where
                     }
                     TIMELOCK_TYPE_TIME_AGE => {
                         stack.push(Item::from(
-                            client
-                                .transaction_time_age(&cur.prev_out.transaction_hash)
-                                .map_or(false, |age| age >= value),
+                            client.transaction_time_age(&cur.prev_out.tracker).map_or(false, |age| age >= value),
                         ))?;
                     }
                     _ => return Err(RuntimeError::InvalidTimelockType),

--- a/vm/src/tests/executor_tests/chk_multi_sig.rs
+++ b/vm/src/tests/executor_tests/chk_multi_sig.rs
@@ -39,7 +39,7 @@ fn valid_multi_sig_0_of_2() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -80,7 +80,7 @@ fn valid_multi_sig_1_of_2() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -133,7 +133,7 @@ fn valid_multi_sig_2_of_2() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -188,7 +188,7 @@ fn valid_multi_sig_2_of_3_110() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -246,7 +246,7 @@ fn valid_multi_sig_2_of_3_101() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -304,7 +304,7 @@ fn valid_multi_sig_2_of_3_011() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -362,7 +362,7 @@ fn invalid_multi_sig_1_of_2() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -416,7 +416,7 @@ fn invalid_multi_sig_2_of_2() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -471,7 +471,7 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -537,7 +537,7 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -592,7 +592,7 @@ fn invalid_multi_sig_with_less_sig_than_m() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -645,7 +645,7 @@ fn invalid_multi_sig_with_more_sig_than_m() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -700,7 +700,7 @@ fn invalid_multi_sig_with_too_many_arg() {
     };
     let outpoint = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,

--- a/vm/src/tests/executor_tests/chk_sig.rs
+++ b/vm/src/tests/executor_tests/chk_sig.rs
@@ -39,7 +39,7 @@ fn valid_pay_to_public_key() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -83,7 +83,7 @@ fn invalid_pay_to_public_key() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -122,7 +122,7 @@ fn sign_all_input_all_output() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,
@@ -135,7 +135,7 @@ fn sign_all_input_all_output() {
     };
     // Make input indexed 1
     let out1 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 1,
         asset_type: H256::default(),
         amount: 1,
@@ -198,7 +198,7 @@ fn sign_single_input_all_output() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,
@@ -211,7 +211,7 @@ fn sign_single_input_all_output() {
     };
     // Make input indexed 1
     let out1 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 1,
         asset_type: H256::default(),
         amount: 1,
@@ -273,7 +273,7 @@ fn sign_all_input_partial_output() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,
@@ -286,7 +286,7 @@ fn sign_all_input_partial_output() {
     };
     // Make input indexed 1
     let out1 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 1,
         asset_type: H256::default(),
         amount: 1,
@@ -348,7 +348,7 @@ fn sign_single_input_partial_output() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,
@@ -361,7 +361,7 @@ fn sign_single_input_partial_output() {
     };
     // Make input indexed 1
     let out1 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 1,
         asset_type: H256::default(),
         amount: 1,
@@ -423,7 +423,7 @@ fn distinguish_sign_single_input_with_sign_all() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,
@@ -479,7 +479,7 @@ fn distinguish_sign_single_output_with_sign_all() {
     let client = get_test_client();
     // Make input indexed 0
     let out0 = AssetOutPoint {
-        transaction_hash: H256::default(),
+        tracker: Default::default(),
         index: 0,
         asset_type: H256::default(),
         amount: 0,

--- a/vm/src/tests/executor_tests/executor.rs
+++ b/vm/src/tests/executor_tests/executor.rs
@@ -87,7 +87,7 @@ fn simple_success() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -119,7 +119,7 @@ fn simple_failure() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -150,7 +150,7 @@ fn simple_burn() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -177,7 +177,7 @@ fn underflow() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -204,7 +204,7 @@ fn out_of_memory() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -243,7 +243,7 @@ fn invalid_unlock_script() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -270,7 +270,7 @@ fn conditional_burn() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -320,7 +320,7 @@ fn _blake256() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -396,7 +396,7 @@ fn _ripemd160() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -480,7 +480,7 @@ fn _sha256() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -564,7 +564,7 @@ fn _keccak256() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -651,7 +651,7 @@ fn dummy_tx() -> ShardTransaction {
 fn dummy_input() -> AssetTransferInput {
     AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,
@@ -891,7 +891,7 @@ fn copy_stack_underflow() {
     };
     let input = AssetTransferInput {
         prev_out: AssetOutPoint {
-            transaction_hash: H256::default(),
+            tracker: Default::default(),
             index: 0,
             asset_type: H256::default(),
             amount: 0,


### PR DESCRIPTION
And it renames the below RPC APIs.
1. chain_getTransactionById -> chain_getTransactionByTracker
2. chain_getInvoicesById -> chain_getInvoicesByTracker
3. chain_getAssetSchemeByHash -> chain_getAssetSchemeByTracker