### PR TITLE
Remove commented-reviews-by option in the mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
       - status-success=continuous-integration/travis-ci/pr
       - status-success=clahub
       - base=master


### PR DESCRIPTION
If all reviewers approved, we do not need to count comments.