### PR TITLE
Make IoService handle only one Handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,6 @@ version = "1.9.0"
 dependencies = [
  "codechain-logger 0.1.0",
  "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "limited-table 0.1.0 (git+https://github.com/CodeChain-io/rust-limited-table.git)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/io/Cargo.toml
+++ b/util/io/Cargo.toml
@@ -7,7 +7,6 @@ version = "1.9.0"
 authors = ["Parity Technologies <admin@parity.io>", "CodeChain Team <codechain@kodebox.io>"]
 
 [dependencies]
-limited-table = { git = "https://github.com/CodeChain-io/rust-limited-table.git" }
 codechain-logger = { path = "../logger" }
 mio = "0.6.16"
 crossbeam = "0.5.0"

--- a/util/io/src/lib.rs
+++ b/util/io/src/lib.rs
@@ -62,7 +62,6 @@
 
 #[macro_use]
 extern crate codechain_logger as clogger;
-extern crate limited_table;
 extern crate mio;
 #[macro_use]
 extern crate log;

--- a/util/io/src/worker.rs
+++ b/util/io/src/worker.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use crossbeam::deque;
-use service::{HandlerId, IoChannel, IoContext};
+use service::{IoChannel, IoContext};
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::Arc;
@@ -44,7 +44,6 @@ pub enum WorkType<Message> {
 pub struct Work<Message> {
     pub work_type: WorkType<Message>,
     pub token: usize,
-    pub handler_id: HandlerId,
     pub handler: Arc<IoHandler<Message>>,
 }
 
@@ -120,27 +119,27 @@ impl Worker {
         Message: Send + Sync + Clone + 'static, {
         match work.work_type {
             WorkType::Readable => {
-                if let Err(err) = work.handler.stream_readable(&IoContext::new(channel, work.handler_id), work.token) {
+                if let Err(err) = work.handler.stream_readable(&IoContext::new(channel), work.token) {
                     cwarn!(IO, "Error in stream_readable {:?}", err);
                 }
             }
             WorkType::Writable => {
-                if let Err(err) = work.handler.stream_writable(&IoContext::new(channel, work.handler_id), work.token) {
+                if let Err(err) = work.handler.stream_writable(&IoContext::new(channel), work.token) {
                     cwarn!(IO, "Error in stream_writable {:?}", err);
                 }
             }
             WorkType::Hup => {
-                if let Err(err) = work.handler.stream_hup(&IoContext::new(channel, work.handler_id), work.token) {
+                if let Err(err) = work.handler.stream_hup(&IoContext::new(channel), work.token) {
                     cwarn!(IO, "Error in stream_hup {:?}", err);
                 }
             }
             WorkType::Timeout => {
-                if let Err(err) = work.handler.timeout(&IoContext::new(channel, work.handler_id), work.token) {
+                if let Err(err) = work.handler.timeout(&IoContext::new(channel), work.token) {
                     cwarn!(IO, "Error in timeout {:?}", err);
                 }
             }
             WorkType::Message(message) => {
-                if let Err(err) = work.handler.message(&IoContext::new(channel, work.handler_id), &message) {
+                if let Err(err) = work.handler.message(&IoContext::new(channel), &message) {
                     cwarn!(IO, "Error in message {:?}", err);
                 }
             }


### PR DESCRIPTION
Current implementation allows multiple Handler be registered. But
CodeChain needs only one handler. So this patch removes multiple handler
feature.