### PR TITLE
Use the RLP length instead of HeapSizeOf trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,6 @@ dependencies = [
  "codechain-vm 0.1.0",
  "cuckoo 0.1.0 (git+https://github.com/CodeChain-io/rust-cuckoo.git?rev=280cab9c)",
  "hashdb 0.1.1",
- "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.0-a.0 (git+https://github.com/paritytech/hyper)",
  "journaldb 0.1.0",
  "kvdb 0.1.0",
@@ -334,7 +333,6 @@ version = "0.1.0"
 dependencies = [
  "bech32 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "codechain-crypto 0.1.0",
- "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "never 0.1.0 (git+https://github.com/CodeChain-io/rust-never.git)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -560,7 +558,6 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "codechain-crypto 0.1.0",
  "codechain-key 0.1.0",
- "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.2.0 (git+https://github.com/CodeChain-io/rust-codechain-primitives.git)",
  "rlp 0.2.1",
  "rlp_derive 0.1.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,6 @@ codechain-stratum = { path = "../stratum" }
 codechain-vm = { path = "../vm" }
 cuckoo = { git = "https://github.com/CodeChain-io/rust-cuckoo.git", rev = "280cab9c" }
 hashdb = { path = "../util/hashdb" }
-heapsize = "0.4"
 hyper = { git = "https://github.com/paritytech/hyper", default-features = false }
 journaldb = { path = "../util/journaldb" }
 linked-hash-map = "0.5"

--- a/core/src/consensus/validator_set/validator_list.rs
+++ b/core/src/consensus/validator_set/validator_list.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use heapsize::HeapSizeOf;
 use std::collections::HashSet;
 
 use ckey::{public_to_address, Address, Public};
@@ -59,12 +58,6 @@ impl From<Vec<Public>> for ValidatorList {
             validators,
             addresses,
         }
-    }
-}
-
-impl HeapSizeOf for ValidatorList {
-    fn heap_size_of_children(&self) -> usize {
-        self.validators.heap_size_of_children()
     }
 }
 

--- a/core/src/encoded.rs
+++ b/core/src/encoded.rs
@@ -26,7 +26,6 @@
 use ccrypto::blake256;
 use ckey::Address;
 use ctypes::BlockNumber;
-use heapsize::HeapSizeOf;
 use primitives::{H256, U256};
 use rlp::Rlp;
 
@@ -38,12 +37,6 @@ use crate::views;
 /// Owning header view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Header(Vec<u8>);
-
-impl HeapSizeOf for Header {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
-    }
-}
 
 impl Header {
     /// Create a new owning header view.
@@ -138,12 +131,6 @@ impl Header {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Body(Vec<u8>);
 
-impl HeapSizeOf for Body {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
-    }
-}
-
 impl Body {
     /// Create a new owning block body view. The raw bytes passed in must be an rlp-encoded block
     /// body.
@@ -200,12 +187,6 @@ impl Body {
 /// Owning block view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block(Vec<u8>);
-
-impl HeapSizeOf for Block {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
-    }
-}
 
 impl Block {
     /// Create a new owning block view. The raw bytes passed in must be an rlp-encoded block.

--- a/core/src/header.rs
+++ b/core/src/header.rs
@@ -21,7 +21,6 @@ use time::get_time;
 use ccrypto::{blake256, BLAKE_NULL_RLP};
 use ckey::Address;
 use ctypes::BlockNumber;
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H256, U256};
 use rlp::*;
 
@@ -271,12 +270,6 @@ impl Header {
     /// Get the Blake hash of this header, optionally `with_seal`.
     pub fn rlp_blake(&self, with_seal: &Seal) -> H256 {
         blake256(&self.rlp(with_seal))
-    }
-}
-
-impl HeapSizeOf for Header {
-    fn heap_size_of_children(&self) -> usize {
-        self.extra_data.heap_size_of_children() + self.seal.heap_size_of_children()
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,7 +31,6 @@ extern crate codechain_types as ctypes;
 extern crate codechain_vm as cvm;
 extern crate cuckoo;
 extern crate hashdb;
-extern crate heapsize;
 extern crate journaldb;
 extern crate kvdb;
 extern crate kvdb_memorydb;

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -20,7 +20,6 @@ use ccrypto::blake256;
 use ckey::{self, recover, sign, Private, Public, Signature};
 use ctypes::transaction::{ParcelError, Transaction};
 use ctypes::BlockNumber;
-use heapsize::HeapSizeOf;
 use primitives::H256;
 use rlp::{self, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
@@ -150,12 +149,6 @@ impl UnverifiedTransaction {
 pub struct SignedTransaction {
     tx: UnverifiedTransaction,
     signer_public: Public,
-}
-
-impl HeapSizeOf for SignedTransaction {
-    fn heap_size_of_children(&self) -> usize {
-        self.tx.unsigned.heap_size_of_children()
-    }
 }
 
 impl rlp::Encodable for SignedTransaction {

--- a/core/src/verification/verification.rs
+++ b/core/src/verification/verification.rs
@@ -19,7 +19,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use cmerkle::skewed_merkle_root;
 use ctypes::util::unexpected::{Mismatch, OutOfBounds};
 use ctypes::BlockNumber;
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H256};
 use rlp::UntrustedRlp;
 
@@ -39,14 +38,6 @@ pub struct PreverifiedBlock {
     pub transactions: Vec<SignedTransaction>,
     /// Block bytes
     pub bytes: Bytes,
-}
-
-impl HeapSizeOf for PreverifiedBlock {
-    fn heap_size_of_children(&self) -> usize {
-        self.header.heap_size_of_children()
-            + self.transactions.heap_size_of_children()
-            + self.bytes.heap_size_of_children()
-    }
 }
 
 /// Phase 1 quick block verification. Only does checks that are cheap. Operates on a single block

--- a/key/Cargo.toml
+++ b/key/Cargo.toml
@@ -14,7 +14,6 @@ never = { git = "https://github.com/CodeChain-io/rust-never.git" }
 parking_lot = "0.6.0"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git" }
 rand_xorshift = "0.1.0"
-heapsize = "0.4"
 rlp = { path = "../util/rlp" }
 secp256k1 = { path = "../util/secp256k1" }
 serde = "1.0"

--- a/key/src/address.rs
+++ b/key/src/address.rs
@@ -20,7 +20,6 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
-use heapsize::HeapSizeOf;
 use primitives::{remove_0x_prefix, H160};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
@@ -133,12 +132,6 @@ impl From<Address> for [u8; 20] {
 impl AsRef<[u8]> for Address {
     fn as_ref(&self) -> &[u8] {
         &self.0.as_ref()
-    }
-}
-
-impl HeapSizeOf for Address {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
     }
 }
 

--- a/key/src/lib.rs
+++ b/key/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Kodebox, Inc.
+// Copyright 2018-2019 Kodebox, Inc.
 // This file is part of CodeChain.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,7 +18,6 @@ extern crate codechain_crypto as crypto;
 #[macro_use]
 extern crate lazy_static;
 extern crate bech32;
-extern crate heapsize;
 extern crate never;
 extern crate parking_lot;
 extern crate primitives;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["CodeChain Team <codechain@kodebox.io>"]
 byteorder = "1.2.7"
 codechain-crypto = { path = "../crypto" }
 codechain-key = { path = "../key" }
-heapsize = "0.4"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git" }
 rlp = { path = "../util/rlp" }
 rlp_derive = { path = "../util/rlp_derive" }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -17,7 +17,6 @@
 extern crate byteorder;
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_key as ckey;
-extern crate heapsize;
 extern crate primitives;
 extern crate rlp;
 #[macro_use]

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -18,7 +18,6 @@ use std::collections::{HashMap, HashSet};
 
 use ccrypto::Blake;
 use ckey::{Address, NetworkId, Public, Signature};
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
@@ -423,89 +422,6 @@ impl From<Action> for Option<ShardTransaction> {
                 burn,
             }),
             _ => None,
-        }
-    }
-}
-
-impl HeapSizeOf for Action {
-    fn heap_size_of_children(&self) -> usize {
-        match self {
-            Action::MintAsset {
-                metadata,
-                output,
-                approvals,
-                allowed_script_hashes,
-                ..
-            } => {
-                metadata.heap_size_of_children()
-                    + output.heap_size_of_children()
-                    + approvals.heap_size_of_children()
-                    + allowed_script_hashes.heap_size_of_children()
-            }
-            Action::TransferAsset {
-                burns,
-                inputs,
-                outputs,
-                orders,
-                metadata,
-                approvals,
-                ..
-            } => {
-                burns.heap_size_of_children()
-                    + inputs.heap_size_of_children()
-                    + outputs.heap_size_of_children()
-                    + orders.heap_size_of_children()
-                    + metadata.heap_size_of_children()
-                    + approvals.heap_size_of_children()
-            }
-            Action::ChangeAssetScheme {
-                metadata,
-                approvals,
-                allowed_script_hashes,
-                ..
-            } => {
-                metadata.heap_size_of_children()
-                    + approvals.heap_size_of_children()
-                    + allowed_script_hashes.heap_size_of_children()
-            }
-            Action::ComposeAsset {
-                metadata,
-                inputs,
-                output,
-                approvals,
-                allowed_script_hashes,
-                ..
-            } => {
-                metadata.heap_size_of_children()
-                    + inputs.heap_size_of_children()
-                    + output.heap_size_of_children()
-                    + approvals.heap_size_of_children()
-                    + allowed_script_hashes.heap_size_of_children()
-            }
-            Action::DecomposeAsset {
-                input,
-                outputs,
-                approvals,
-                ..
-            } => input.heap_size_of_children() + outputs.heap_size_of_children() + approvals.heap_size_of_children(),
-            Action::UnwrapCCC {
-                burn,
-                approvals,
-                ..
-            } => burn.heap_size_of_children() + approvals.heap_size_of_children(),
-            Action::SetShardOwners {
-                owners,
-                ..
-            } => owners.heap_size_of_children(),
-            Action::SetShardUsers {
-                users,
-                ..
-            } => users.heap_size_of_children(),
-            Action::WrapCCC {
-                parameters,
-                ..
-            } => parameters.heap_size_of_children(),
-            _ => 0,
         }
     }
 }

--- a/types/src/transaction/input.rs
+++ b/types/src/transaction/input.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Kodebox, Inc.
+// Copyright 2018-2019 Kodebox, Inc.
 // This file is part of CodeChain.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use heapsize::HeapSizeOf;
 use primitives::Bytes;
 
 use super::{AssetOutPoint, Timelock};
@@ -26,12 +25,6 @@ pub struct AssetTransferInput {
     pub timelock: Option<Timelock>,
     pub lock_script: Bytes,
     pub unlock_script: Bytes,
-}
-
-impl HeapSizeOf for AssetTransferInput {
-    fn heap_size_of_children(&self) -> usize {
-        self.lock_script.heap_size_of_children() + self.unlock_script.heap_size_of_children()
-    }
 }
 
 impl AssetTransferInput {

--- a/types/src/transaction/order.rs
+++ b/types/src/transaction/order.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256};
 
 use super::error::Error;
@@ -138,22 +137,6 @@ impl Order {
             lock_script_hash_fee: self.lock_script_hash_fee,
             parameters_fee: self.parameters_fee.clone(),
         }
-    }
-}
-
-impl HeapSizeOf for Order {
-    fn heap_size_of_children(&self) -> usize {
-        self.origin_outputs.heap_size_of_children()
-            + self.parameters_from.heap_size_of_children()
-            + self.parameters_fee.heap_size_of_children()
-    }
-}
-
-impl HeapSizeOf for OrderOnTransfer {
-    fn heap_size_of_children(&self) -> usize {
-        self.order.heap_size_of_children()
-            + self.input_indices.heap_size_of_children()
-            + self.output_indices.heap_size_of_children()
     }
 }
 

--- a/types/src/transaction/output.rs
+++ b/types/src/transaction/output.rs
@@ -17,7 +17,6 @@
 use std::io::Cursor;
 
 use byteorder::{BigEndian, ReadBytesExt};
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256};
 
 use crate::ShardId;
@@ -28,12 +27,6 @@ pub struct AssetTransferOutput {
     pub parameters: Vec<Bytes>,
     pub asset_type: H256,
     pub quantity: u64,
-}
-
-impl HeapSizeOf for AssetTransferOutput {
-    fn heap_size_of_children(&self) -> usize {
-        self.parameters.heap_size_of_children()
-    }
 }
 
 impl AssetTransferOutput {

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -16,13 +16,11 @@
 
 use ccrypto::{blake128, blake256, blake256_with_key};
 use ckey::{Address, NetworkId};
-use heapsize::HeapSizeOf;
 use primitives::{Bytes, H160, H256};
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 
 use super::{
-    AssetMintOutput, AssetOutPoint, AssetTransferInput, AssetTransferOutput, HashingError, Order, OrderOnTransfer,
-    PartialHashing,
+    AssetMintOutput, AssetTransferInput, AssetTransferOutput, HashingError, Order, OrderOnTransfer, PartialHashing,
 };
 use crate::util::tag::Tag;
 use crate::ShardId;
@@ -258,81 +256,6 @@ impl ShardTransaction {
                 shard_id,
                 ..
             } => &id == shard_id,
-        }
-    }
-}
-
-impl HeapSizeOf for AssetOutPoint {
-    fn heap_size_of_children(&self) -> usize {
-        0
-    }
-}
-
-impl HeapSizeOf for AssetMintOutput {
-    fn heap_size_of_children(&self) -> usize {
-        self.parameters.heap_size_of_children() + self.supply.heap_size_of_children()
-    }
-}
-
-impl HeapSizeOf for ShardTransaction {
-    fn heap_size_of_children(&self) -> usize {
-        match self {
-            ShardTransaction::MintAsset {
-                metadata,
-                approver,
-                output,
-                allowed_script_hashes,
-                ..
-            } => {
-                metadata.heap_size_of_children()
-                    + approver.heap_size_of_children()
-                    + output.heap_size_of_children()
-                    + allowed_script_hashes.heap_size_of_children()
-            }
-            ShardTransaction::TransferAsset {
-                burns,
-                inputs,
-                outputs,
-                orders,
-                ..
-            } => {
-                burns.heap_size_of_children()
-                    + inputs.heap_size_of_children()
-                    + outputs.heap_size_of_children()
-                    + orders.heap_size_of_children()
-            }
-            ShardTransaction::ChangeAssetScheme {
-                metadata,
-                allowed_script_hashes,
-                ..
-            } => metadata.heap_size_of_children() + allowed_script_hashes.heap_size_of_children(),
-            ShardTransaction::ComposeAsset {
-                metadata,
-                approver,
-                inputs,
-                output,
-                allowed_script_hashes,
-                ..
-            } => {
-                metadata.heap_size_of_children()
-                    + approver.heap_size_of_children()
-                    + inputs.heap_size_of_children()
-                    + output.heap_size_of_children()
-                    + allowed_script_hashes.heap_size_of_children()
-            }
-            ShardTransaction::DecomposeAsset {
-                input,
-                outputs,
-                ..
-            } => input.heap_size_of_children() + outputs.heap_size_of_children(),
-            ShardTransaction::UnwrapCCC {
-                burn,
-                ..
-            } => burn.heap_size_of_children(),
-            ShardTransaction::WrapCCC {
-                output,
-                ..
-            } => output.heap_size_of_children(),
         }
     }
 }
@@ -751,6 +674,7 @@ mod tests {
 
     use rlp::rlp_encode_and_decode_test;
 
+    use super::super::AssetOutPoint;
     use super::*;
 
     #[test]

--- a/types/src/transaction/transaction.rs
+++ b/types/src/transaction/transaction.rs
@@ -16,7 +16,6 @@
 
 use ccrypto::blake256;
 use ckey::NetworkId;
-use heapsize::HeapSizeOf;
 use primitives::H256;
 use rlp::RlpStream;
 
@@ -33,12 +32,6 @@ pub struct Transaction {
     pub network_id: NetworkId,
 
     pub action: Action,
-}
-
-impl HeapSizeOf for Transaction {
-    fn heap_size_of_children(&self) -> usize {
-        self.action.heap_size_of_children()
-    }
 }
 
 impl Transaction {


### PR DESCRIPTION
Now the mempool and the verification queue use the RLP length as the memory usage of items.
Also, removed HeapSizeOf from codechain-core/key/types, because it is not used anymore.