### PR TITLE
Add is_pending_queue_empty function in Client

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -302,7 +302,7 @@ impl TimeoutHandler for Client {
             }
             RESEAL_MIN_TIMER_TOKEN => {
                 // Checking self.ready_transactions() for efficiency
-                if !self.engine().engine_type().ignore_reseal_min_period() && !self.ready_transactions().is_empty() {
+                if !self.engine().engine_type().ignore_reseal_min_period() && !self.is_pending_queue_empty() {
                     self.update_sealing(BlockId::Latest, false);
                 }
             }
@@ -643,6 +643,10 @@ impl BlockChainClient for Client {
 
     fn ready_transactions(&self) -> Vec<SignedTransaction> {
         self.importer.miner.ready_transactions()
+    }
+
+    fn is_pending_queue_empty(&self) -> bool {
+        self.importer.miner.status().transactions_in_pending_queue == 0
     }
 
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber> {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -228,6 +228,9 @@ pub trait BlockChainClient:
     /// List all transactions that are allowed into the next block.
     fn ready_transactions(&self) -> Vec<SignedTransaction>;
 
+    /// Check there are transactions which are allowed into the next block.
+    fn is_pending_queue_empty(&self) -> bool;
+
     /// Look up the block number for the given block ID.
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber>;
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -483,6 +483,10 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.ready_transactions()
     }
 
+    fn is_pending_queue_empty(&self) -> bool {
+        self.miner.status().transactions_in_pending_queue == 0
+    }
+
     fn block_number(&self, _id: &BlockId) -> Option<BlockNumber> {
         unimplemented!()
     }


### PR DESCRIPTION
Do not use `ready_transactions()` to check whether the pending queue is empty or not. It is really not efficient.