### PR TITLE
Change the definition of the asset type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ name = "codechain-rpc"
 version = "0.1.0"
 dependencies = [
  "codechain-core 0.1.0",
+ "codechain-crypto 0.1.0",
  "codechain-json 0.1.0",
  "codechain-key 0.1.0",
  "codechain-keystore 0.1.0",

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -356,9 +356,14 @@ impl AssetClient for Client {
         }
     }
 
-    fn get_asset(&self, transaction_hash: H256, index: usize, id: BlockId) -> TrieResult<Option<OwnedAsset>> {
+    fn get_asset(
+        &self,
+        transaction_hash: H256,
+        index: usize,
+        shard_id: ShardId,
+        id: BlockId,
+    ) -> TrieResult<Option<OwnedAsset>> {
         if let Some(state) = Client::state_at(&self, id) {
-            let shard_id = 0; // FIXME
             let address = OwnedAssetAddress::new(transaction_hash, index, shard_id);
             Ok(state.asset(shard_id, &address)?)
         } else {

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -23,8 +23,8 @@ use ckey::{Address, PlatformAddress, Public};
 use cmerkle::Result as TrieResult;
 use cnetwork::NodeId;
 use cstate::{
-    ActionHandler, AssetScheme, AssetSchemeAddress, FindActionHandler, OwnedAsset, OwnedAssetAddress, StateDB, Text,
-    TopLevelState, TopStateView,
+    ActionHandler, AssetScheme, FindActionHandler, OwnedAsset, OwnedAssetAddress, StateDB, Text, TopLevelState,
+    TopStateView,
 };
 use ctimer::{TimeoutHandler, TimerApi, TimerScheduleError, TimerToken};
 use ctypes::invoice::Invoice;
@@ -35,7 +35,7 @@ use hashdb::AsHashDB;
 use journaldb;
 use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
-use primitives::{Bytes, H256, U256};
+use primitives::{Bytes, H160, H256, U256};
 use rlp::UntrustedRlp;
 
 use super::importer::Importer;
@@ -348,9 +348,8 @@ impl DatabaseClient for Client {
 }
 
 impl AssetClient for Client {
-    fn get_asset_scheme(&self, asset_type: AssetSchemeAddress, id: BlockId) -> TrieResult<Option<AssetScheme>> {
+    fn get_asset_scheme(&self, asset_type: H160, shard_id: ShardId, id: BlockId) -> TrieResult<Option<AssetScheme>> {
         if let Some(state) = Client::state_at(&self, id) {
-            let shard_id = asset_type.shard_id();
             Ok(state.asset_scheme(shard_id, &asset_type)?)
         } else {
             Ok(None)

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -34,13 +34,13 @@ use std::sync::Arc;
 use ckey::{Address, PlatformAddress, Public};
 use cmerkle::Result as TrieResult;
 use cnetwork::NodeId;
-use cstate::{AssetScheme, AssetSchemeAddress, FindActionHandler, OwnedAsset, Text, TopLevelState, TopStateView};
+use cstate::{AssetScheme, FindActionHandler, OwnedAsset, Text, TopLevelState, TopStateView};
 use ctypes::invoice::Invoice;
 use ctypes::transaction::{AssetTransferInput, PartialHashing, ShardTransaction};
 use ctypes::{BlockNumber, ShardId};
 use cvm::ChainTimeInfo;
 use kvdb::KeyValueDB;
-use primitives::{Bytes, H256, U256};
+use primitives::{Bytes, H160, H256, U256};
 
 use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
@@ -293,7 +293,7 @@ pub trait DatabaseClient {
 
 /// Provides methods to access asset
 pub trait AssetClient {
-    fn get_asset_scheme(&self, asset_type: AssetSchemeAddress, id: BlockId) -> TrieResult<Option<AssetScheme>>;
+    fn get_asset_scheme(&self, asset_type: H160, shard_id: ShardId, id: BlockId) -> TrieResult<Option<AssetScheme>>;
 
     fn get_asset(&self, transaction_hash: H256, index: usize, id: BlockId) -> TrieResult<Option<OwnedAsset>>;
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -295,7 +295,13 @@ pub trait DatabaseClient {
 pub trait AssetClient {
     fn get_asset_scheme(&self, asset_type: H160, shard_id: ShardId, id: BlockId) -> TrieResult<Option<AssetScheme>>;
 
-    fn get_asset(&self, transaction_hash: H256, index: usize, id: BlockId) -> TrieResult<Option<OwnedAsset>>;
+    fn get_asset(
+        &self,
+        transaction_hash: H256,
+        index: usize,
+        shard_id: ShardId,
+        id: BlockId,
+    ) -> TrieResult<Option<OwnedAsset>>;
 
     fn is_asset_spent(
         &self,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["CodeChain Team <codechain@kodebox.io>"]
 
 [dependencies]
 codechain-core = { path = "../core" }
+codechain-crypto = { path = "../crypto" }
 codechain-json = { path = "../json" }
 codechain-key = { path = "../key" }
 codechain-keystore = { path = "../keystore" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 extern crate codechain_core as ccore;
+extern crate codechain_crypto as ccrypto;
 #[macro_use]
 extern crate codechain_logger as clogger;
 extern crate codechain_json as cjson;

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -20,14 +20,15 @@ use ccore::{
     AssetClient, BlockId, EngineInfo, ExecuteClient, MinerService, MiningBlockChainClient, RegularKey, RegularKeyOwner,
     Shard, SignedTransaction, TextClient, UnverifiedTransaction,
 };
+use ccrypto::Blake;
 use cjson::bytes::Bytes;
 use cjson::uint::Uint;
 use ckey::{public_to_address, NetworkId, PlatformAddress, Public};
-use cstate::{AssetSchemeAddress, FindActionHandler};
+use cstate::FindActionHandler;
 use ctypes::invoice::Invoice;
 use ctypes::transaction::{Action, ShardTransaction as ShardTransactionType};
 use ctypes::{BlockNumber, ShardId};
-use primitives::{Bytes as BytesArray, H256};
+use primitives::{Bytes as BytesArray, H160, H256};
 use rlp::{DecoderError, UntrustedRlp};
 
 use jsonrpc_core::Result;
@@ -124,23 +125,23 @@ where
         shard_id: ShardId,
         block_number: Option<u64>,
     ) -> Result<Option<AssetScheme>> {
-        let address = AssetSchemeAddress::new(tracker, shard_id);
-        self.get_asset_scheme_by_type(address.into(), block_number)
+        let asset_type = Blake::blake(tracker);
+        self.get_asset_scheme_by_type(asset_type, shard_id, block_number)
     }
 
-    fn get_asset_scheme_by_type(&self, asset_type: H256, block_number: Option<u64>) -> Result<Option<AssetScheme>> {
+    fn get_asset_scheme_by_type(
+        &self,
+        asset_type: H160,
+        shard_id: ShardId,
+        block_number: Option<u64>,
+    ) -> Result<Option<AssetScheme>> {
+        let network_id = self.client.common_params().network_id;
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        match AssetSchemeAddress::from_hash(asset_type) {
-            Some(address) => {
-                let network_id = self.client.common_params().network_id;
-                Ok(self
-                    .client
-                    .get_asset_scheme(address, block_id)
-                    .map_err(errors::transaction_state)?
-                    .map(|asset_scheme| AssetScheme::from_core(asset_scheme, network_id)))
-            }
-            None => Ok(None),
-        }
+        Ok(self
+            .client
+            .get_asset_scheme(asset_type, shard_id, block_id)
+            .map_err(errors::transaction_state)?
+            .map(|asset_scheme| AssetScheme::from_core(asset_scheme, network_id)))
     }
 
     fn get_text(&self, transaction_hash: H256, block_number: Option<u64>) -> Result<Option<Text>> {

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -153,9 +153,16 @@ where
             .map(|text| Text::from_core(text, self.client.common_params().network_id)))
     }
 
-    fn get_asset(&self, transaction_hash: H256, index: usize, block_number: Option<u64>) -> Result<Option<OwnedAsset>> {
+    fn get_asset(
+        &self,
+        transaction_hash: H256,
+        index: usize,
+        shard_id: ShardId,
+        block_number: Option<u64>,
+    ) -> Result<Option<OwnedAsset>> {
         let block_id = block_number.map(BlockId::Number).unwrap_or(BlockId::Latest);
-        let asset = self.client.get_asset(transaction_hash, index, block_id).map_err(errors::transaction_state)?;
+        let asset =
+            self.client.get_asset(transaction_hash, index, shard_id, block_id).map_err(errors::transaction_state)?;
         Ok(asset.map(From::from))
     }
 

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -19,7 +19,7 @@ use cjson::uint::Uint;
 use ckey::{NetworkId, PlatformAddress, Public};
 use ctypes::invoice::Invoice;
 use ctypes::{BlockNumber, ShardId};
-use primitives::{Bytes as BytesArray, H256};
+use primitives::{Bytes as BytesArray, H160, H256};
 
 use jsonrpc_core::Result;
 
@@ -53,7 +53,7 @@ build_rpc_trait! {
 
         /// Gets asset scheme with given asset type.
         # [rpc(name = "chain_getAssetSchemeByType")]
-        fn get_asset_scheme_by_type(&self, H256, Option<u64>) -> Result<Option<AssetScheme>>;
+        fn get_asset_scheme_by_type(&self, H160, ShardId, Option<u64>) -> Result<Option<AssetScheme>>;
 
         /// Gets text with given transaction hash.
         # [rpc(name = "chain_getText")]

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -61,7 +61,7 @@ build_rpc_trait! {
 
         /// Gets asset with given asset type.
         # [rpc(name = "chain_getAsset")]
-        fn get_asset(&self, H256, usize, Option<u64>) -> Result<Option<OwnedAsset>>;
+        fn get_asset(&self, H256, usize, ShardId, Option<u64>) -> Result<Option<OwnedAsset>>;
 
         /// Checks whether an asset is spent or not.
         # [rpc(name = "chain_isAssetSpent")]

--- a/rpc/src/v1/types/action.rs
+++ b/rpc/src/v1/types/action.rs
@@ -56,7 +56,8 @@ pub enum Action {
     #[serde(rename_all = "camelCase")]
     ChangeAssetScheme {
         network_id: NetworkId,
-        asset_type: H256,
+        shard_id: ShardId,
+        asset_type: H160,
         metadata: String,
         approver: Option<PlatformAddress>,
         administrator: Option<PlatformAddress>,
@@ -165,7 +166,8 @@ pub enum ActionWithTracker {
     #[serde(rename_all = "camelCase")]
     ChangeAssetScheme {
         network_id: NetworkId,
-        asset_type: H256,
+        shard_id: ShardId,
+        asset_type: H160,
         metadata: String,
         approver: Option<PlatformAddress>,
         administrator: Option<PlatformAddress>,
@@ -293,6 +295,7 @@ impl ActionWithTracker {
             },
             ActionType::ChangeAssetScheme {
                 network_id,
+                shard_id,
                 asset_type,
                 metadata,
                 approver,
@@ -301,6 +304,7 @@ impl ActionWithTracker {
                 approvals,
             } => ActionWithTracker::ChangeAssetScheme {
                 network_id,
+                shard_id,
                 asset_type,
                 metadata,
                 approver: approver.map(|approver| PlatformAddress::new_v1(network_id, approver)),
@@ -477,6 +481,7 @@ impl From<Action> for Result<ActionType, ConversionError> {
             }
             Action::ChangeAssetScheme {
                 network_id,
+                shard_id,
                 asset_type,
                 metadata,
                 approver,
@@ -495,6 +500,7 @@ impl From<Action> for Result<ActionType, ConversionError> {
                 };
                 ActionType::ChangeAssetScheme {
                     network_id,
+                    shard_id,
                     asset_type,
                     metadata,
                     approver,

--- a/rpc/src/v1/types/asset.rs
+++ b/rpc/src/v1/types/asset.rs
@@ -22,7 +22,7 @@ use rustc_serialize::hex::ToHex;
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
-    asset_type: H256,
+    asset_type: H160,
     quantity: Uint,
 }
 

--- a/rpc/src/v1/types/asset_input.rs
+++ b/rpc/src/v1/types/asset_input.rs
@@ -16,14 +16,16 @@
 
 use cjson::uint::Uint;
 use ctypes::transaction::{AssetOutPoint as AssetOutPointType, AssetTransferInput as AssetTransferInputType, Timelock};
-use primitives::{Bytes, H256};
+use ctypes::ShardId;
+use primitives::{Bytes, H160, H256};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetOutPoint {
     pub tracker: H256,
     pub index: usize,
-    pub asset_type: H256,
+    pub asset_type: H160,
+    pub shard_id: ShardId,
     pub quantity: Uint,
 }
 
@@ -33,6 +35,7 @@ impl From<AssetOutPointType> for AssetOutPoint {
             tracker: from.tracker,
             index: from.index,
             asset_type: from.asset_type,
+            shard_id: from.shard_id,
             quantity: from.quantity.into(),
         }
     }
@@ -44,6 +47,7 @@ impl From<AssetOutPoint> for AssetOutPointType {
             tracker: from.tracker,
             index: from.index,
             asset_type: from.asset_type,
+            shard_id: from.shard_id,
             quantity: from.quantity.into(),
         }
     }

--- a/rpc/src/v1/types/asset_output.rs
+++ b/rpc/src/v1/types/asset_output.rs
@@ -19,7 +19,8 @@ use std::iter::FromIterator;
 
 use cjson::uint::Uint;
 use ctypes::transaction::{AssetMintOutput as AssetMintOutputType, AssetTransferOutput as AssetTransferOutputType};
-use primitives::{H160, H256};
+use ctypes::ShardId;
+use primitives::H160;
 use rustc_serialize::hex::{FromHex, FromHexError, ToHex};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -27,7 +28,8 @@ use rustc_serialize::hex::{FromHex, FromHexError, ToHex};
 pub struct AssetTransferOutput {
     pub lock_script_hash: H160,
     pub parameters: Vec<String>,
-    pub asset_type: H256,
+    pub asset_type: H160,
+    pub shard_id: ShardId,
     pub quantity: Uint,
 }
 
@@ -37,6 +39,7 @@ impl From<AssetTransferOutputType> for AssetTransferOutput {
             lock_script_hash: from.lock_script_hash,
             parameters: from.parameters.iter().map(|bytes| bytes.to_hex()).collect(),
             asset_type: from.asset_type,
+            shard_id: from.shard_id,
             quantity: from.quantity.into(),
         }
     }
@@ -48,6 +51,7 @@ impl From<AssetTransferOutput> for Result<AssetTransferOutputType, FromHexError>
             lock_script_hash: from.lock_script_hash,
             parameters: Result::from_iter(from.parameters.iter().map(|hexstr| hexstr.from_hex()))?,
             asset_type: from.asset_type,
+            shard_id: from.shard_id,
             quantity: from.quantity.into(),
         })
     }

--- a/rpc/src/v1/types/order.rs
+++ b/rpc/src/v1/types/order.rs
@@ -16,7 +16,8 @@
 
 use cjson::uint::Uint;
 use ctypes::transaction::{Order as OrderType, OrderOnTransfer as OrderOnTransferType};
-use primitives::{H160, H256};
+use ctypes::ShardId;
+use primitives::H160;
 use rustc_serialize::hex::{FromHex, FromHexError, ToHex};
 
 use super::AssetOutPoint;
@@ -24,9 +25,12 @@ use super::AssetOutPoint;
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
-    pub asset_type_from: H256,
-    pub asset_type_to: H256,
-    pub asset_type_fee: H256,
+    pub asset_type_from: H160,
+    pub asset_type_to: H160,
+    pub asset_type_fee: H160,
+    pub shard_id_from: ShardId,
+    pub shard_id_to: ShardId,
+    pub shard_id_fee: ShardId,
     pub asset_quantity_from: Uint,
     pub asset_quantity_to: Uint,
     pub asset_quantity_fee: Uint,
@@ -44,6 +48,9 @@ impl From<OrderType> for Order {
             asset_type_from: from.asset_type_from,
             asset_type_to: from.asset_type_to,
             asset_type_fee: from.asset_type_fee,
+            shard_id_from: from.shard_id_from,
+            shard_id_to: from.shard_id_to,
+            shard_id_fee: from.shard_id_fee,
             asset_quantity_from: from.asset_quantity_from.into(),
             asset_quantity_to: from.asset_quantity_to.into(),
             asset_quantity_fee: from.asset_quantity_fee.into(),
@@ -66,6 +73,9 @@ impl From<Order> for Result<OrderType, FromHexError> {
             asset_type_from: from.asset_type_from,
             asset_type_to: from.asset_type_to,
             asset_type_fee: from.asset_type_fee,
+            shard_id_from: from.shard_id_from,
+            shard_id_to: from.shard_id_to,
+            shard_id_fee: from.shard_id_fee,
             asset_quantity_from: from.asset_quantity_from.into(),
             asset_quantity_to: from.asset_quantity_to.into(),
             asset_quantity_fee: from.asset_quantity_fee.into(),

--- a/spec/Asset-Exchange-Protocol.md
+++ b/spec/Asset-Exchange-Protocol.md
@@ -18,9 +18,12 @@ The format of `Order` is as shown below.
 
 |        Name        |    Data Type    |                                                Description                                                |
 |--------------------|-----------------|-----------------------------------------------------------------------------------------------------------|
-| assetTypeFrom      | H256            | The type of the asset offered by maker                                                                    |
-| assetTypeTo        | H256            | The type of the asset requested by maker                                                                  |
-| assetTypeFee       | H256            | The type of the asset offered by maker to give as fees                                                    |
+| assetTypeFrom      | H160            | The type of the asset offered by maker                                                                    |
+| assetTypeTo        | H160            | The type of the asset requested by maker                                                                  |
+| assetTypeFee       | H160            | The type of the asset offered by maker to give as fees                                                    |
+| shardIdFrom        | ShardId         | The shard ID of the asset offered by maker                                                                    |
+| shardIdTo          | ShardId         | The shard ID of the asset requested by maker                                                                  |
+| shardIdFee         | ShardId         | The shard ID of the asset offered by maker to give as fees                                                    |
 | assetAmountFrom    | U64             | Total amount of assets with the type assetTypeFrom                                                        |
 | assetAmountTo      | U64             | Total amount of assets with the type assetTypeTo                                                          |
 | assetAmountFee     | U64             | Total amount of assets with the type assetTypeFee                                                         |

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -163,7 +163,7 @@ A string that starts with "(NetworkID)c", and Bech32 string follows. For example
 ## Asset
 
  - amount: `U64`
- - assetType: `H256`
+ - assetType: `H160`
  - lockScriptHash: `H160`
  - parameters: `number[][]`
 
@@ -203,21 +203,26 @@ When `Transaction` is included in any response, there will be an additional fiel
 
  - transactionId: `H256`
  - index: `number`
- - assetType: `H256`
+ - assetType: `H160`
+ - shardId: `number`
  - amount: `U64`
 
 ### AssetTransferOutput
 
  - lockScriptHash: `H160`
  - parameters: `number[][]`
- - assetType: `H256`
+ - assetType: `H160`
+ - shardId: `number`
  - amount: `U64`
 
 ### Order
 
- - assetTypeFrom: `H256`
- - assetTypeTo: `H256`
- - assetTypeFee: `H256`
+ - assetTypeFrom: `H160`
+ - assetTypeTo: `H160`
+ - assetTypeFee: `H160`
+ - shardIdFrom: `number`
+ - shardIdTo: `number`
+ - shardIdFee: `number`
  - assetAmountFrom: `U64`
  - assetAmountTo: `U64`
  - assetAmountFee: `U64`
@@ -860,7 +865,8 @@ Gets an asset scheme with the given asset type.
 
 ### Params
  1. asset type - `H256`
- 2. block number: `number` | `null`
+ 2. shard id - `number`
+ 3. block number: `number` | `null`
 
 ### Returns
 `null` | `AssetScheme`
@@ -891,12 +897,13 @@ Errors: `KVDB Error`, `Invalid Params`
 [Back to **List of methods**](#list-of-methods)
 
 ## chain_getAsset
-Gets an asset with the given asset type.
+Gets an asset with the given transaction hash and the index.
 
 ### Params
  1. transaction id - `H256`
  2. index - `number`
- 3. block number: `number` | `null`
+ 3. shard id - `number`
+ 4. block number: `number` | `null`
 
 ### Returns
 `null` | `Asset`

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -890,11 +890,11 @@ mod tests {
         );
 
         let transaction_tracker = transaction.tracker();
+        let asset_type = Blake::blake(transaction_tracker);
         assert_eq!(Ok(Invoice::Success), state.apply(&transaction.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(transaction_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
             (asset: (transaction_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
     }
@@ -916,12 +916,12 @@ mod tests {
             approver: approver
         );
         let transaction_tracker = transaction.tracker();
+        let asset_type = Blake::blake(transaction_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&transaction.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(transaction_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, SHARD_ID) => { metadata: metadata, supply: ::std::u64::MAX, approver: approver }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: ::std::u64::MAX, approver: approver }),
             (asset: (transaction_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: ::std::u64::MAX })
         ]);
     }
@@ -944,6 +944,7 @@ mod tests {
         );
 
         let transaction_tracker = transaction.tracker();
+        let asset_type = Blake::blake(transaction_tracker);
         assert_eq!(
             Ok(Invoice::Success),
             state.apply(&transaction.clone().into(), &sender, &[sender], &[], &get_test_client())
@@ -954,9 +955,8 @@ mod tests {
             state.apply(&transaction.into(), &sender, &[sender], &[], &get_test_client())
         );
 
-        let asset_type = H256::from(AssetSchemeAddress::new(transaction_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, SHARD_ID) => { metadata: metadata, supply: ::std::u64::MAX, approver: approver }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: ::std::u64::MAX, approver: approver }),
             (asset: (transaction_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: ::std::u64::MAX })
         ]);
     }
@@ -975,12 +975,12 @@ mod tests {
         let mint =
             asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone(), approver: approver);
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -996,7 +996,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, approver: approver }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
             (asset: (transfer_tracker, 0, SHARD_ID))
         ]);
@@ -1014,13 +1014,12 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1038,7 +1037,7 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&transfer.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10, lock_script_hash: lock_script_hash }),
             (asset: (transfer_tracker, 1, SHARD_ID) => { asset_type: asset_type, quantity: 5, lock_script_hash: lock_script_hash }),
@@ -1065,13 +1064,13 @@ mod tests {
             allowed_script_hashes: allowed_script_hashes.clone()
         );
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1088,7 +1087,7 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&transfer.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10, lock_script_hash: lock_script_hash }),
             (asset: (transfer_tracker, 1, SHARD_ID) => { asset_type: asset_type, quantity: 5, lock_script_hash: lock_script_hash }),
@@ -1114,12 +1113,12 @@ mod tests {
             allowed_script_hashes: allowed_script_hashes.clone()
         );
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1135,7 +1134,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, allowed_script_hashes: allowed_script_hashes}),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
             (asset: (transfer_tracker, 0, SHARD_ID))
         ]);
@@ -1153,13 +1152,12 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1172,7 +1170,7 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&burn.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (burn_tracker, 0, SHARD_ID))
         ]);
@@ -1190,12 +1188,12 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1213,9 +1211,8 @@ mod tests {
 
         assert_eq!(Ok(Invoice::Success), state.apply(&transfer.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10 }),
             (asset: (transfer_tracker, 1, SHARD_ID) => { asset_type: asset_type, quantity: 5 }),
@@ -1230,7 +1227,7 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&burn.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10 }),
             (asset: (transfer_tracker, 1, SHARD_ID)),
@@ -1257,13 +1254,12 @@ mod tests {
             administrator: administrator
         );
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1285,7 +1281,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10 }),
             (asset: (transfer_tracker, 1, SHARD_ID) => { asset_type: asset_type, quantity: 5 }),
@@ -1311,13 +1307,12 @@ mod tests {
             administrator: administrator
         );
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1327,7 +1322,7 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&burn.into(), &administrator, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount, administrator: administrator }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (burn_tracker, 0, SHARD_ID))
         ]);
@@ -1345,13 +1340,12 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1376,7 +1370,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata, supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata, supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
             (asset: (transfer_tracker, 0, SHARD_ID))
         ]);
@@ -1395,26 +1389,26 @@ mod tests {
         let metadata1 = "metadata".to_string();
         let mint1 = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata1.clone());
         let mint_tracker1 = mint1.tracker();
-        let asset_type1 = H256::from(AssetSchemeAddress::new(mint_tracker1, SHARD_ID));
+        let asset_type1 = Blake::blake(mint_tracker1);
 
         let metadata2 = "metadata2".to_string();
         let mint2 = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata2.clone());
         let mint_tracker2 = mint2.tracker();
-        let asset_type2 = H256::from(AssetSchemeAddress::new(mint_tracker2, SHARD_ID));
+        let asset_type2 = Blake::blake(mint_tracker2);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint1.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker1, SHARD_ID) => { metadata: metadata1, supply: amount }),
-            (scheme: (mint_tracker2, SHARD_ID)),
+            (scheme: (asset_type1, SHARD_ID) => { metadata: metadata1, supply: amount }),
+            (scheme: (asset_type2, SHARD_ID)),
             (asset: (mint_tracker1, 0, SHARD_ID) => { asset_type: asset_type1, quantity: amount })
         ]);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint2.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker1, SHARD_ID) => { metadata: metadata1, supply: amount }),
-            (scheme: (mint_tracker2, SHARD_ID) => { metadata: metadata2, supply: amount }),
+            (scheme: (asset_type1, SHARD_ID) => { metadata: metadata1, supply: amount }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: metadata2, supply: amount }),
             (asset: (mint_tracker1, 0, SHARD_ID) => { asset_type: asset_type1, quantity: amount }),
             (asset: (mint_tracker2, 0, SHARD_ID) => { asset_type: asset_type2, quantity: amount })
         ]);
@@ -1431,8 +1425,8 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker1, SHARD_ID) => { metadata: metadata1, supply: amount }),
-            (scheme: (mint_tracker2, SHARD_ID) => { metadata: metadata2, supply: amount }),
+            (scheme: (asset_type1, SHARD_ID) => { metadata: metadata1, supply: amount }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: metadata2, supply: amount }),
             (asset: (mint_tracker1, 0, SHARD_ID) => { asset_type: asset_type1, quantity: amount }),
             (asset: (mint_tracker2, 0, SHARD_ID) => { asset_type: asset_type2, quantity: amount }),
             (asset: (transfer_tracker, 0, SHARD_ID))
@@ -1449,13 +1443,12 @@ mod tests {
         let lock_script_hash = H160::from("b042ad154a3359d276835c903587ebafefea22af");
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
+        let asset_type = Blake::blake(mint_tracker);
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, shard_id));
-
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
-            (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
+            (scheme: (asset_type, shard_id) => { metadata: metadata.clone(), supply: amount }),
+            (asset: (mint_tracker, 0, shard_id) => { asset_type: asset_type, quantity: amount })
         ]);
 
         asset_out_point!(mint_tracker, 0, asset_type, amount)
@@ -1511,9 +1504,9 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&transfer.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_output_1.tracker, SHARD_ID) => { metadata: "metadata1".to_string(), supply: 30 }),
-            (scheme: (mint_output_2.tracker, SHARD_ID) => { metadata: "metadata2".to_string(), supply: 30 }),
-            (scheme: (mint_output_3.tracker, SHARD_ID) => { metadata: "metadata3".to_string(), supply: 30 }),
+            (scheme: (asset_type_1, SHARD_ID) => { metadata: "metadata1".to_string(), supply: 30 }),
+            (scheme: (asset_type_2, SHARD_ID) => { metadata: "metadata2".to_string(), supply: 30 }),
+            (scheme: (asset_type_3, SHARD_ID) => { metadata: "metadata3".to_string(), supply: 30 }),
             (asset: (mint_output_1.tracker, 0, SHARD_ID)),
             (asset: (mint_output_2.tracker, 0, SHARD_ID)),
             (asset: (mint_output_3.tracker, 0, SHARD_ID)),
@@ -1538,11 +1531,11 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1553,14 +1546,14 @@ mod tests {
             asset_mint_output!(random_lock_script_hash, supply: 1)
         );
         let compose_tracker = compose.tracker();
-        let composed_asset_type = H256::from(AssetSchemeAddress::new(compose_tracker, SHARD_ID));
+        let composed_asset_type = Blake::blake(compose_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&compose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
     }
@@ -1577,11 +1570,11 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -1591,14 +1584,14 @@ mod tests {
             asset_mint_output!(lock_script_hash, supply: 1)
         );
         let compose_tracker = compose.tracker();
-        let composed_asset_type = H256::from(AssetSchemeAddress::new(compose_tracker, SHARD_ID));
+        let composed_asset_type = Blake::blake(compose_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&compose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
 
@@ -1612,9 +1605,9 @@ mod tests {
         assert_eq!(Ok(Invoice::Success), state.apply(&decompose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID)),
+            (scheme: (composed_asset_type, SHARD_ID)),
             (asset: (compose_tracker, 0, SHARD_ID)),
             (asset: (decompose_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
@@ -1632,25 +1625,25 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
         let mint2 = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), "invalid_asset".to_string());
         let mint2_tracker = mint2.tracker();
-        let asset_type2 = H256::from(AssetSchemeAddress::new(mint2_tracker, SHARD_ID));
+        let asset_type2 = Blake::blake(mint2_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint2.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
             (asset: (mint2_tracker, 0, SHARD_ID) => { asset_type: asset_type2, quantity: amount })
         ]);
 
@@ -1660,16 +1653,16 @@ mod tests {
             asset_mint_output!(lock_script_hash, supply: 1)
         );
         let compose_tracker = compose.tracker();
-        let composed_asset_type = H256::from(AssetSchemeAddress::new(compose_tracker, SHARD_ID));
+        let composed_asset_type = Blake::blake(compose_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&compose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
             (asset: (mint2_tracker, 0, SHARD_ID) => { asset_type: asset_type2, quantity: amount }),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
 
@@ -1682,7 +1675,8 @@ mod tests {
         assert_eq!(
             Ok(Invoice::Failure(
                 TransactionError::InvalidDecomposedInput {
-                    address: asset_type2,
+                    asset_type: asset_type2,
+                    shard_id: SHARD_ID,
                     got: 0,
                 }
                 .into()
@@ -1691,11 +1685,11 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) ),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: amount }),
             (asset: (mint2_tracker, 0, SHARD_ID) => { asset_type: asset_type2, quantity: amount }),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1, pool: [Asset::new(asset_type, amount)] }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
     }
@@ -1712,25 +1706,25 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
         let mint2 = asset_mint!(asset_mint_output!(lock_script_hash, supply: 1), "invalid_asset".to_string());
         let mint2_tracker = mint2.tracker();
-        let asset_type2 = H256::from(AssetSchemeAddress::new(mint2_tracker, SHARD_ID));
+        let asset_type2 = Blake::blake(mint2_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint2.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID) => { asset_type: asset_type2, quantity: 1 })
         ]);
 
@@ -1743,16 +1737,16 @@ mod tests {
             asset_mint_output!(lock_script_hash, supply: 1)
         );
         let compose_tracker = compose.tracker();
-        let composed_asset_type = H256::from(AssetSchemeAddress::new(compose_tracker, SHARD_ID));
+        let composed_asset_type = Blake::blake(compose_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&compose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
 
@@ -1765,7 +1759,8 @@ mod tests {
         assert_eq!(
             Ok(Invoice::Failure(
                 TransactionError::InvalidDecomposedOutput {
-                    address: asset_type2,
+                    asset_type: asset_type2,
+                    shard_id: SHARD_ID,
                     expected: 1,
                     got: 0,
                 }
@@ -1775,11 +1770,11 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
     }
@@ -1797,24 +1792,24 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
         let mint2 = asset_mint!(asset_mint_output!(lock_script_hash, supply: 1), "invalid_asset".to_string());
         let mint2_tracker = mint2.tracker();
-        let asset_type2 = H256::from(AssetSchemeAddress::new(mint2_tracker, SHARD_ID));
+        let asset_type2 = Blake::blake(mint2_tracker);
         assert_eq!(Ok(Invoice::Success), state.apply(&mint2.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID) => { asset_type: asset_type2, quantity: 1 })
         ]);
 
@@ -1827,16 +1822,16 @@ mod tests {
             asset_mint_output!(lock_script_hash, supply: 1)
         );
         let compose_tracker = compose.tracker();
-        let composed_asset_type = H256::from(AssetSchemeAddress::new(compose_tracker, SHARD_ID));
+        let composed_asset_type = Blake::blake(compose_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&compose.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
 
@@ -1852,7 +1847,8 @@ mod tests {
         assert_eq!(
             Ok(Invoice::Failure(
                 TransactionError::InvalidDecomposedOutput {
-                    address: asset_type,
+                    asset_type,
+                    shard_id: SHARD_ID,
                     expected: 30,
                     got: 10,
                 }
@@ -1862,11 +1858,11 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, SHARD_ID) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
-            (scheme: (mint2_tracker, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
+            (scheme: (asset_type2, SHARD_ID) => { metadata: "invalid_asset".to_string(), supply: 1 }),
             (asset: (mint2_tracker, 0, SHARD_ID)),
-            (scheme: (compose_tracker, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
+            (scheme: (composed_asset_type, SHARD_ID) => { metadata: "composed".to_string(), supply: 1 }),
             (asset: (compose_tracker, 0, SHARD_ID) => { asset_type: composed_asset_type, quantity: 1 })
         ]);
     }
@@ -1884,8 +1880,8 @@ mod tests {
 
         let wrap_ccc = asset_wrap_ccc!(tx_hash, asset_wrap_ccc_output!(lock_script_hash, amount));
         let wrap_ccc_tracker = wrap_ccc.tracker();
-        let asset_scheme_address = AssetSchemeAddress::new_with_zero_suffix(SHARD_ID);
-        let asset_type = H256::from(asset_scheme_address);
+        let asset_type = H160::zero();
+        let asset_scheme_address = AssetSchemeAddress::new(asset_type, SHARD_ID);
 
         assert_eq!(wrap_ccc_tracker, tx_hash);
         assert_eq!(Ok(Invoice::Success), state.apply(&wrap_ccc, &sender, &[sender], &[], &get_test_client()));
@@ -1923,8 +1919,8 @@ mod tests {
         assert_eq!(wrap_ccc_tracker, tx_hash);
         assert_eq!(Ok(Invoice::Success), state.apply(&wrap_ccc, &sender, &[sender], &[], &get_test_client()));
 
-        let asset_scheme_address = AssetSchemeAddress::new_with_zero_suffix(SHARD_ID);
-        let asset_type = asset_scheme_address.into();
+        let asset_type = H160::zero();
+        let asset_scheme_address = AssetSchemeAddress::new(asset_type, SHARD_ID);
 
         check_shard_level_state!(state, [
             (scheme: (asset_scheme_address) => { supply: std::u64::MAX }),
@@ -1979,12 +1975,12 @@ mod tests {
         let amount = 30;
         let mint = asset_mint!(asset_mint_output!(lock_script_hash, supply: amount), metadata.clone());
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, 0) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
@@ -2009,7 +2005,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, 0) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount }),
             (asset: (failed_transfer_tracker, 0, SHARD_ID))
         ]);
@@ -2031,7 +2027,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, 0) => { metadata: metadata.clone(), supply: amount }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: amount }),
             (asset: (mint_tracker, 0, SHARD_ID)),
             (asset: (failed_transfer_tracker, 0, SHARD_ID)),
             (asset: (successful_transfer_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: 10 }),
@@ -2057,12 +2053,12 @@ mod tests {
             approver: approver
         );
         let transaction_tracker = transaction.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(transaction_tracker, SHARD_ID));
+        let asset_type = Blake::blake(transaction_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&transaction.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, 0) => { metadata: metadata.clone(), supply: ::std::u64::MAX }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: ::std::u64::MAX }),
             (asset: (transaction_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: ::std::u64::MAX })
         ]);
     }
@@ -2085,6 +2081,7 @@ mod tests {
         );
 
         let transaction_tracker = transaction.tracker();
+        let asset_type = Blake::blake(transaction_tracker);
         let shard_user = address();
 
         assert_eq!(
@@ -2093,7 +2090,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, 0)),
+            (scheme: (asset_type, 0)),
             (asset: (transaction_tracker, 0, SHARD_ID))
         ]);
     }
@@ -2116,11 +2113,12 @@ mod tests {
         );
 
         let transaction_tracker = transaction.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(transaction_tracker, SHARD_ID));
+        let asset_type = Blake::blake(transaction_tracker);
+
         assert_eq!(Ok(Invoice::Success), state.apply(&transaction.into(), &sender, &[], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (transaction_tracker, 0) => { metadata: metadata.clone(), supply: ::std::u64::MAX, approver: approver }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: ::std::u64::MAX, approver: approver }),
             (asset: (transaction_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: ::std::u64::MAX })
         ]);
     }
@@ -2144,18 +2142,19 @@ mod tests {
         );
 
         let mint_tracker = mint.tracker();
-        let asset_type = H256::from(AssetSchemeAddress::new(mint_tracker, SHARD_ID));
+        let asset_type = Blake::blake(mint_tracker);
 
         assert_eq!(Ok(Invoice::Success), state.apply(&mint.into(), &sender, &[sender], &[], &get_test_client()));
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, 0) => { metadata: metadata.clone(), supply: amount, approver, administrator: administrator }),
+            (scheme: (asset_type, 0) => { metadata: metadata.clone(), supply: amount, approver, administrator: administrator }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
 
         let approver = Address::random();
         let change_asset_scheme = ShardTransaction::ChangeAssetScheme {
             network_id: "tc".into(),
+            shard_id: SHARD_ID,
             asset_type,
             metadata: "New metadata".to_string(),
             approver: Some(approver),
@@ -2168,7 +2167,7 @@ mod tests {
         );
 
         check_shard_level_state!(state, [
-            (scheme: (mint_tracker, 0) => { metadata: "New metadata".to_string(), supply: amount, approver: approver, administrator }),
+            (scheme: (asset_type, 0) => { metadata: "New metadata".to_string(), supply: amount, approver: approver, administrator }),
             (asset: (mint_tracker, 0, SHARD_ID) => { asset_type: asset_type, quantity: amount })
         ]);
     }

--- a/state/src/impls/test_helper.rs
+++ b/state/src/impls/test_helper.rs
@@ -129,10 +129,14 @@ macro_rules! asset_mint_output {
 
 macro_rules! asset_out_point {
     ($tracker:expr, $index:expr, $asset_type:expr, $quantity:expr) => {
+        asset_out_point!($tracker, $index, $asset_type, $crate::impls::test_helper::SHARD_ID, $quantity)
+    };
+    ($tracker:expr, $index:expr, $asset_type:expr, $shard_id:expr, $quantity:expr) => {
         $crate::ctypes::transaction::AssetOutPoint {
             tracker: $tracker,
             index: $index,
             asset_type: $asset_type,
+            shard_id: $shard_id,
             quantity: $quantity,
         }
     };
@@ -167,6 +171,7 @@ macro_rules! asset_transfer_output {
             lock_script_hash: $lock_script_hash,
             parameters: Vec::new(),
             asset_type: $asset_type,
+            shard_id: $crate::impls::test_helper::SHARD_ID,
             quantity: $quantity,
         }
     };
@@ -175,6 +180,16 @@ macro_rules! asset_transfer_output {
             lock_script_hash: $lock_script_hash,
             parameters: $parameters,
             asset_type: $asset_type,
+            shard_id: $crate::impls::test_helper::SHARD_ID,
+            quantity: $quantity,
+        }
+    };
+    ($lock_script_hash:expr, $parameters:expr, $asset_type:expr, $shard_id:expr, $quantity:expr) => {
+        $crate::ctypes::transaction::AssetTransferOutput {
+            lock_script_hash: $lock_script_hash,
+            parameters: $parameters,
+            asset_type: $asset_type,
+            shard_id: $shard_id,
             quantity: $quantity,
         }
     };
@@ -272,6 +287,9 @@ macro_rules! order {
             asset_type_from: $from,
             asset_type_to: $to,
             asset_type_fee: $fee,
+            shard_id_from: $crate::impls::test_helper::SHARD_ID,
+            shard_id_to: $crate::impls::test_helper::SHARD_ID,
+            shard_id_fee: $crate::impls::test_helper::SHARD_ID,
             asset_quantity_from: $from_quantity,
             asset_quantity_to: $to_quantity,
             asset_quantity_fee: $fee_quantity,
@@ -523,26 +541,23 @@ macro_rules! check_top_level_state {
 
         check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(scheme: ($tx_hash:expr, $shard_id:expr) => { metadata: $metadata:expr, supply: $supply:expr }) $(,$x:tt)*]) => {
-        let asset_scheme_address = $crate::AssetSchemeAddress::new($tx_hash, $shard_id);
-        let scheme = $state.asset_scheme($shard_id, &asset_scheme_address).unwrap().unwrap();
+    ($state:expr, [(scheme: ($asset_type:expr, $shard_id:expr) => { metadata: $metadata:expr, supply: $supply:expr }) $(,$x:tt)*]) => {
+        let scheme = $state.asset_scheme($shard_id, &$asset_type).unwrap().unwrap();
         assert_eq!(&$metadata, scheme.metadata());
         assert_eq!($supply, scheme.supply());
 
         check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(scheme: ($tx_hash:expr, $shard_id:expr) => { metadata: $metadata:expr, supply: $supply:expr, approver: $approver:expr }) $(,$x:tt)*]) => {
-        let asset_scheme_address = $crate::AssetSchemeAddress::new($tx_hash, $shard_id);
-        let scheme = $state.asset_scheme($shard_id, &asset_scheme_address).unwrap().unwrap();
+    ($state:expr, [(scheme: ($asset_type:expr, $shard_id:expr) => { metadata: $metadata:expr, supply: $supply:expr, approver: $approver:expr }) $(,$x:tt)*]) => {
+        let scheme = $state.asset_scheme($shard_id, &$asset_type).unwrap().unwrap();
         assert_eq!(&$metadata, scheme.metadata());
         assert_eq!($supply, scheme.supply());
         assert_eq!(Some(&$approver), scheme.approver().as_ref());
 
         check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(scheme: ($tx_hash:expr, $shard_id:expr)) $(,$x:tt)*]) => {
-        let asset_scheme_address = $crate::AssetSchemeAddress::new($tx_hash, $shard_id);
-        assert_eq!(Ok(None), $state.asset_scheme($shard_id, &asset_scheme_address));
+    ($state:expr, [(scheme: ($asset_type:expr, $shard_id:expr)) $(,$x:tt)*]) => {
+        assert_eq!(Ok(None), $state.asset_scheme($shard_id, &$asset_type));
 
         check_top_level_state!($state, [$($x),*]);
     };

--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -24,13 +24,9 @@ macro_rules! define_address_constructor {
         }
     };
     (SHARD, $name:ident, $prefix:expr) => {
-        fn from_transaction_hash_with_shard_id(
-            tracker: ::primitives::H256,
-            index: u64,
-            shard_id: ::ctypes::ShardId,
-        ) -> Self {
+        fn from_hash_with_shard_id<T: AsRef<[u8]>>(input_hash: T, index: u64, shard_id: ::ctypes::ShardId) -> Self {
             let mut hash: ::primitives::H256 =
-                ::ccrypto::Blake::blake_with_key(&tracker, &::primitives::H128::from(index));
+                ::ccrypto::Blake::blake_with_key(&input_hash, &::primitives::H128::from(index));
             hash[0..2].copy_from_slice(&[$prefix, 0]);
 
             debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<::ctypes::ShardId>());

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -186,7 +186,7 @@ impl OwnedAssetAddress {
         debug_assert_eq!(::std::mem::size_of::<u64>(), ::std::mem::size_of::<usize>());
         let index = index as u64;
 
-        Self::from_transaction_hash_with_shard_id(transaction_tracker, index, shard_id)
+        Self::from_hash_with_shard_id(transaction_tracker, index, shard_id)
     }
 }
 

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -22,19 +22,19 @@ use crate::CacheableItem;
 
 #[derive(Clone, Debug, PartialEq, RlpEncodable, RlpDecodable)]
 pub struct Asset {
-    asset_type: H256,
+    asset_type: H160,
     quantity: u64,
 }
 
 impl Asset {
-    pub fn new(asset_type: H256, quantity: u64) -> Self {
+    pub fn new(asset_type: H160, quantity: u64) -> Self {
         Self {
             asset_type,
             quantity,
         }
     }
 
-    pub fn asset_type(&self) -> &H256 {
+    pub fn asset_type(&self) -> &H160 {
         &self.asset_type
     }
 
@@ -53,7 +53,7 @@ pub struct OwnedAsset {
 
 impl OwnedAsset {
     pub fn new(
-        asset_type: H256,
+        asset_type: H160,
         lock_script_hash: H160,
         parameters: Vec<Bytes>,
         quantity: u64,
@@ -70,7 +70,7 @@ impl OwnedAsset {
         }
     }
 
-    pub fn asset_type(&self) -> &H256 {
+    pub fn asset_type(&self) -> &H160 {
         &self.asset.asset_type()
     }
 
@@ -92,7 +92,7 @@ impl OwnedAsset {
 
     pub fn init(
         &mut self,
-        asset_type: H256,
+        asset_type: H160,
         lock_script_hash: H160,
         parameters: Vec<Bytes>,
         quantity: u64,
@@ -100,7 +100,7 @@ impl OwnedAsset {
     ) {
         assert_eq!(
             Asset {
-                asset_type: H256::zero(),
+                asset_type: H160::zero(),
                 quantity: 0
             },
             self.asset
@@ -121,7 +121,7 @@ impl Default for OwnedAsset {
     fn default() -> Self {
         Self {
             asset: Asset {
-                asset_type: H256::zero(),
+                asset_type: H160::zero(),
                 quantity: 0,
             },
             lock_script_hash: H160::zero(),

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn encode_and_decode_asset() {
         rlp_encode_and_decode_test!(Asset {
-            asset_type: H256::random(),
+            asset_type: H160::random(),
             quantity: 0,
         });
     }

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -216,33 +216,17 @@ mod tests {
 
     #[test]
     fn asset_from_address() {
-        let origin = {
-            let mut address;
-            'address: loop {
-                address = H256::random();
-                if address[0] == b'S' {
-                    continue
-                }
-                for a in address.iter().take(6).skip(1) {
-                    if *a == 0 {
-                        continue 'address
-                    }
-                }
-                break
-            }
-            address
-        };
+        let origin = H160::random();
         let shard_id = 0xBEE;
         let asset_address = AssetSchemeAddress::new(origin, shard_id);
         let hash: H256 = asset_address.into();
-        assert_ne!(origin, hash);
         assert_eq!(hash[0..2], [PREFIX, 0]);
         assert_eq!(hash[2..4], [0x0B, 0xEE]); // shard id
     }
 
     #[test]
     fn shard_id() {
-        let origin = H256::random();
+        let origin = H160::random();
         let shard_id = 0xCAA;
         let asset_scheme_address = AssetSchemeAddress::new(origin, shard_id);
         assert_eq!(shard_id, asset_scheme_address.shard_id());

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -194,7 +194,7 @@ impl AssetSchemeAddress {
     pub fn new(tracker: H256, shard_id: ShardId) -> Self {
         let index = ::std::u64::MAX;
 
-        Self::from_transaction_hash_with_shard_id(tracker, index, shard_id)
+        Self::from_hash_with_shard_id(tracker, index, shard_id)
     }
     pub fn new_with_zero_suffix(shard_id: ShardId) -> Self {
         let mut hash = H256::zero();

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::mem::size_of;
-
+use ccrypto::Blake;
 use ckey::Address;
 use ctypes::ShardId;
 use primitives::{H160, H256};
@@ -191,21 +190,15 @@ pub struct AssetSchemeAddress(H256);
 impl_address!(SHARD, AssetSchemeAddress, PREFIX);
 
 impl AssetSchemeAddress {
-    pub fn new(tracker: H256, shard_id: ShardId) -> Self {
+    pub fn new(asset_type: H160, shard_id: ShardId) -> Self {
         let index = ::std::u64::MAX;
 
-        Self::from_hash_with_shard_id(tracker, index, shard_id)
+        Self::from_hash_with_shard_id(asset_type, index, shard_id)
     }
-    pub fn new_with_zero_suffix(shard_id: ShardId) -> Self {
-        let mut hash = H256::zero();
-        hash[0..2].copy_from_slice(&[PREFIX, 0]);
 
-        debug_assert_eq!(size_of::<u16>(), size_of::<ShardId>());
-        let shard_id_bytes: [u8; 2] = shard_id.to_be_bytes();
-        assert_eq!(2, shard_id_bytes.len());
-        hash[2..4].copy_from_slice(&shard_id_bytes);
-
-        AssetSchemeAddress(hash)
+    pub fn new_from_tracker(tracker: H256, shard_id: ShardId) -> Self {
+        let asset_type = Blake::blake(tracker);
+        Self::new(asset_type, shard_id)
     }
 }
 

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -20,7 +20,7 @@ use ctypes::invoice::Invoice;
 use ctypes::transaction::ShardTransaction;
 use ctypes::ShardId;
 use cvm::ChainTimeInfo;
-use primitives::{Bytes, H256};
+use primitives::{Bytes, H160, H256};
 
 use crate::{
     Account, ActionData, AssetScheme, AssetSchemeAddress, CacheableItem, Metadata, OwnedAsset, OwnedAssetAddress,
@@ -105,14 +105,13 @@ pub trait TopStateView {
     }
 
     /// Get the asset scheme.
-    fn asset_scheme(
-        &self,
-        shard_id: ShardId,
-        asset_scheme_address: &AssetSchemeAddress,
-    ) -> TrieResult<Option<AssetScheme>> {
+    fn asset_scheme(&self, shard_id: ShardId, asset_type: &H160) -> TrieResult<Option<AssetScheme>> {
         match self.shard_state(shard_id)? {
             None => Ok(None),
-            Some(state) => state.asset_scheme(asset_scheme_address),
+            Some(state) => {
+                let address = AssetSchemeAddress::new(*asset_type, shard_id);
+                state.asset_scheme(&address)
+            }
         }
     }
 

--- a/test/package.json
+++ b/test/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "codechain-sdk": "https://github.com/jhs7jhs/codechain-sdk-js.git#remove-approvals-from-unwrap-ccc-lib",
+    "codechain-sdk": "https://github.com/jhs7jhs/codechain-sdk-js.git#asset-type-split-lib",
     "codechain-test-helper": "https://github.com/sgkim126/codechain-test-helper-js.git#refac-lib",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -468,7 +468,7 @@ export default class CodeChain {
         if (!awaitMint) {
             return { asset: tx.getMintedAsset() };
         }
-        const asset = await this.sdk.rpc.chain.getAsset(tx.tracker(), 0);
+        const asset = await this.sdk.rpc.chain.getAsset(tx.tracker(), 0, 0);
         if (asset === null) {
             throw Error(`Failed to mint asset`);
         }

--- a/test/src/integration.long/orders.test.ts
+++ b/test/src/integration.long/orders.test.ts
@@ -17,10 +17,7 @@
 import * as _ from "lodash";
 import {
     Asset,
-    H256,
     AssetTransferAddress,
-    AssetOutPoint,
-    Order,
     U64,
     H160
 } from "codechain-sdk/lib/core/classes";
@@ -66,7 +63,8 @@ describe("orders", function() {
                         _.times(2, () => ({
                             recipient: aliceAddress,
                             quantity: 5000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }))
                     );
                 await node.signTransactionInput(splitTx, 0);
@@ -83,9 +81,9 @@ describe("orders", function() {
                 const expiration = Math.round(Date.now() / 1000) + 120;
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
-                    assetTypeTo: new H256(
-                        "0000000000000000000000000000000000000000000000000000000000000000"
-                    ), // Fake asset type
+                    assetTypeTo: H160.zero(), // Fake asset type
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 5000,
                     assetQuantityTo: 5000,
                     expiration,
@@ -102,12 +100,14 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 5000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 5000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -163,6 +163,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -176,22 +178,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -217,7 +223,8 @@ describe("orders", function() {
                         _.times(10, () => ({
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }))
                     );
                 await node.signTransactionInput(splitTx, 0);
@@ -236,6 +243,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -251,22 +260,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -294,6 +307,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 10000,
                     assetQuantityTo: 1000,
                     expiration,
@@ -307,17 +322,20 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 10000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -342,6 +360,8 @@ describe("orders", function() {
                 const aliceOrder = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -352,6 +372,8 @@ describe("orders", function() {
                 const bobOrder = node.sdk.core.createOrder({
                     assetTypeFrom: silver.assetType,
                     assetTypeTo: gold.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 1000,
                     assetQuantityTo: 100,
                     expiration,
@@ -366,22 +388,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -412,6 +438,8 @@ describe("orders", function() {
                 const aliceOrder = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -422,6 +450,8 @@ describe("orders", function() {
                 const bobOrder = node.sdk.core.createOrder({
                     assetTypeFrom: silver.assetType,
                     assetTypeTo: gold.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 1000,
                     assetQuantityTo: 50,
                     expiration,
@@ -436,24 +466,28 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         // Bob gets more gold than he wanted.
                         // If there's a relayer, relayer may take it.
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -484,6 +518,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 10000,
                     assetQuantityTo: 1000,
                     expiration,
@@ -497,12 +533,14 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 10000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 10000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -540,6 +578,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -553,22 +593,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000 - 10,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000 + 10,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -606,6 +650,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -620,22 +666,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -677,6 +727,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -690,22 +742,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -744,6 +800,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -757,27 +815,32 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900 - 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -815,6 +878,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -828,27 +893,32 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000 - 100,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 100,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -886,6 +956,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -899,32 +971,38 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900 - 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000 - 100,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 100,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -962,6 +1040,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -977,22 +1057,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1028,6 +1112,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1042,22 +1128,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1094,7 +1184,8 @@ describe("orders", function() {
                         _.times(10, () => ({
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }))
                     );
                 await node.signTransactionInput(splitTx, 0);
@@ -1113,6 +1204,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1130,22 +1223,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1174,7 +1271,8 @@ describe("orders", function() {
                         _.times(10, () => ({
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }))
                     );
                 await node.signTransactionInput(splitTx, 0);
@@ -1193,6 +1291,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1208,22 +1308,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 8900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1251,6 +1355,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1266,22 +1372,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1317,6 +1427,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1332,22 +1444,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1383,6 +1499,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1396,22 +1514,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 1000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 100,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1445,6 +1567,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1459,22 +1583,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9950,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 50,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1501,22 +1629,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9900,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 50,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9000,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1541,6 +1673,8 @@ describe("orders", function() {
                 const order = node.sdk.core.createOrder({
                     assetTypeFrom: gold.assetType,
                     assetTypeTo: silver.assetType,
+                    shardIdFrom: 0,
+                    shardIdTo: 0,
                     assetQuantityFrom: 100,
                     assetQuantityTo: 1000,
                     expiration,
@@ -1554,22 +1688,26 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9950,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: aliceAddress,
                             quantity: 500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 50,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         }
                     )
                     .addOrder({
@@ -1595,12 +1733,14 @@ describe("orders", function() {
                         {
                             recipient: aliceAddress,
                             quantity: 9500,
-                            assetType: silver.assetType
+                            assetType: silver.assetType,
+                            shardId: 0
                         },
                         {
                             recipient: bobAddress,
                             quantity: 9950,
-                            assetType: gold.assetType
+                            assetType: gold.assetType,
+                            shardId: 0
                         }
                     );
                 await node.signTransactionInput(transferTx2, 0);
@@ -1640,12 +1780,14 @@ describe("orders", function() {
                         ..._.range(5).map(i => ({
                             recipient: addresses[i],
                             quantity: 50,
-                            assetType: assets[(i + 1) % 5].assetType
+                            assetType: assets[(i + 1) % 5].assetType,
+                            shardId: 0
                         })),
                         ..._.range(5).map(i => ({
                             recipient: addresses[i],
                             quantity: 9950,
-                            assetType: assets[i].assetType
+                            assetType: assets[i].assetType,
+                            shardId: 0
                         }))
                     ]);
 
@@ -1653,6 +1795,8 @@ describe("orders", function() {
                     const order = node.sdk.core.createOrder({
                         assetTypeFrom: assets[i].assetType,
                         assetTypeTo: assets[(i + 1) % 5].assetType,
+                        shardIdFrom: 0,
+                        shardIdTo: 0,
                         assetQuantityFrom: 100,
                         assetQuantityTo: 100,
                         expiration: U64.MAX_VALUE,

--- a/test/src/integration.long/timelock.test.ts
+++ b/test/src/integration.long/timelock.test.ts
@@ -50,6 +50,7 @@ describe("Timelock", function() {
         tx.addOutputs({
             quantity: 1,
             assetType: asset.assetType,
+            shardId: asset.shardId,
             recipient: await node.createP2PKHAddress()
         });
         await node.signTransactionInput(tx, 0);
@@ -113,6 +114,7 @@ describe("Timelock", function() {
         failedTx.addOutputs({
             quantity: 1,
             assetType: asset.assetType,
+            shardId: asset.shardId,
             recipient: await node.createP2PKHAddress()
         });
         const invoices1 = await node.sendAssetTransaction(failedTx);
@@ -132,6 +134,7 @@ describe("Timelock", function() {
         tx.addOutputs({
             quantity: 1,
             assetType: asset.assetType,
+            shardId: asset.shardId,
             recipient: await node.createP2PKHAddress()
         });
         await node.signTransactionInput(tx, 0);
@@ -202,6 +205,7 @@ describe("Timelock", function() {
         tx.addOutputs({
             quantity: 1,
             assetType: asset.assetType,
+            shardId: asset.shardId,
             recipient: await node.createP2PKHAddress()
         });
         await node.signTransactionInput(tx, 0);
@@ -245,6 +249,7 @@ describe("Timelock", function() {
             transferTx.addOutputs(
                 Array.from(Array(count)).map(_ => ({
                     assetType: asset.assetType,
+                    shardId: asset.shardId,
                     quantity: 1,
                     recipient
                 }))
@@ -256,7 +261,7 @@ describe("Timelock", function() {
 
         it("2 inputs [Block(4), Block(6)] => Block(6)", async function() {
             const assets = await createUTXOs(2);
-            const { assetType } = assets[0];
+            const { assetType, shardId } = assets[0];
             const tx = node.sdk.core.createTransferAssetTransaction();
             tx.addInputs([
                 assets[0].createTransferInput({
@@ -272,7 +277,7 @@ describe("Timelock", function() {
                     }
                 })
             ]);
-            tx.addOutputs({ quantity: 2, recipient, assetType });
+            tx.addOutputs({ quantity: 2, recipient, assetType, shardId });
             await node.signTransactionInput(tx, 0);
             await node.signTransactionInput(tx, 1);
             await node.sendAssetTransaction(tx, { awaitInvoice: false });
@@ -293,7 +298,7 @@ describe("Timelock", function() {
 
         it("2 inputs [Block(6), Block(4)] => Block(4)", async function() {
             const assets = await createUTXOs(2);
-            const { assetType } = assets[0];
+            const { assetType, shardId } = assets[0];
             const tx = node.sdk.core.createTransferAssetTransaction();
             tx.addInputs([
                 assets[0].createTransferInput({
@@ -309,7 +314,7 @@ describe("Timelock", function() {
                     }
                 })
             ]);
-            tx.addOutputs({ quantity: 2, recipient, assetType });
+            tx.addOutputs({ quantity: 2, recipient, assetType, shardId });
             await node.signTransactionInput(tx, 0);
             await node.signTransactionInput(tx, 1);
             await node.sendAssetTransaction(tx, { awaitInvoice: false });
@@ -330,7 +335,7 @@ describe("Timelock", function() {
 
         it("2 inputs [Time(0), Block(4)] => Block(4)", async function() {
             const assets = await createUTXOs(2);
-            const { assetType } = assets[0];
+            const { assetType, shardId } = assets[0];
             const tx = node.sdk.core.createTransferAssetTransaction();
             tx.addInputs([
                 assets[0].createTransferInput({
@@ -346,7 +351,7 @@ describe("Timelock", function() {
                     }
                 })
             ]);
-            tx.addOutputs({ quantity: 2, recipient, assetType });
+            tx.addOutputs({ quantity: 2, recipient, assetType, shardId });
             await node.signTransactionInput(tx, 0);
             await node.signTransactionInput(tx, 1);
             await node.sendAssetTransaction(tx, { awaitInvoice: false });
@@ -362,7 +367,7 @@ describe("Timelock", function() {
 
         it("2 inputs [Time(now + 3 seconds), Block(4)] => Time(..)", async function() {
             const assets = await createUTXOs(2);
-            const { assetType } = assets[0];
+            const { assetType, shardId } = assets[0];
             const tx = node.sdk.core.createTransferAssetTransaction();
             tx.addInputs([
                 assets[0].createTransferInput({
@@ -378,7 +383,7 @@ describe("Timelock", function() {
                     }
                 })
             ]);
-            tx.addOutputs({ quantity: 2, recipient, assetType });
+            tx.addOutputs({ quantity: 2, recipient, assetType, shardId });
             await node.signTransactionInput(tx, 0);
             await node.signTransactionInput(tx, 1);
             await node.sendAssetTransaction(tx, { awaitInvoice: false });

--- a/test/src/integration/mempool.test.ts
+++ b/test/src/integration/mempool.test.ts
@@ -121,6 +121,7 @@ describe("Timelock", function() {
         tx.addOutputs({
             quantity: 1,
             assetType: asset.assetType,
+            shardId: asset.shardId,
             recipient: await node.createP2PKHAddress()
         });
         await node.signTransactionInput(tx, 0);

--- a/test/src/integration/verification.test.ts
+++ b/test/src/integration/verification.test.ts
@@ -150,8 +150,8 @@ describe("solo - 1 node", function() {
             { actionType: 0x13, actionLength: 12 },
             { actionType: 0x14, actionLength: 7 }, // TransferAsset
             { actionType: 0x14, actionLength: 9 },
-            { actionType: 0x15, actionLength: 7 }, // ChangeAssetScheme
-            { actionType: 0x15, actionLength: 9 },
+            { actionType: 0x15, actionLength: 8 }, // ChangeAssetScheme
+            { actionType: 0x15, actionLength: 10 },
             { actionType: 0x16, actionLength: 11 }, // ComposeAsset
             { actionType: 0x16, actionLength: 13 },
             { actionType: 0x17, actionLength: 4 }, // DecomposeAsset
@@ -220,7 +220,8 @@ describe("solo - 1 node", function() {
                 assetOutPoint: {
                     tracker: "0x" + "0".repeat(64),
                     index: 0,
-                    assetType: "0x" + "1".repeat(64),
+                    assetType: "0x" + "1".repeat(40),
+                    shardId: 0,
                     quantity: 12345
                 },
                 timelock: {
@@ -229,7 +230,8 @@ describe("solo - 1 node", function() {
                 }
             });
             output = node.sdk.core.createAssetTransferOutput({
-                assetType: "0x" + "0".repeat(64),
+                assetType: "0x" + "0".repeat(40),
+                shardId: 0,
                 quantity: 12345,
                 recipient
             });

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -875,9 +875,9 @@ codechain-primitives@^0.4.4:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-"codechain-sdk@https://github.com/jhs7jhs/codechain-sdk-js.git#remove-approvals-from-unwrap-ccc-lib":
+"codechain-sdk@https://github.com/jhs7jhs/codechain-sdk-js.git#asset-type-split-lib":
   version "0.5.1"
-  resolved "https://github.com/jhs7jhs/codechain-sdk-js.git#a1584a4e6977569c7671a3e9a41def834045beb5"
+  resolved "https://github.com/jhs7jhs/codechain-sdk-js.git#be34ca7b7266c093ea2cf531fead497ef5777028"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -1106,20 +1106,24 @@ mod tests {
 
     #[test]
     fn verify_transfer_transaction_with_order() {
-        let asset_type_a = H256::random();
-        let asset_type_b = H256::random();
+        let asset_type_a = H160::random();
+        let asset_type_b = H160::random();
         let lock_script_hash = H160::random();
         let parameters = vec![vec![1]];
         let origin_output = AssetOutPoint {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
+            shard_id: 0,
             quantity: 30,
         };
         let order = Order {
             asset_type_from: asset_type_a,
             asset_type_to: asset_type_b,
-            asset_type_fee: H256::zero(),
+            asset_type_fee: H160::zero(),
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 30,
             asset_quantity_to: 10,
             asset_quantity_fee: 0,
@@ -1146,6 +1150,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1158,12 +1163,14 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 30,
                 },
             ],
@@ -1181,9 +1188,9 @@ mod tests {
 
     #[test]
     fn verify_partial_fill_transfer_transaction_with_order() {
-        let asset_type_a = H256::random();
-        let asset_type_b = H256::random();
-        let asset_type_c = H256::random();
+        let asset_type_a = H160::random();
+        let asset_type_b = H160::random();
+        let asset_type_c = H160::random();
         let lock_script_hash = H160::random();
         let parameters1 = vec![vec![1]];
         let parameters2 = vec![vec![2]];
@@ -1192,12 +1199,14 @@ mod tests {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
+            shard_id: 0,
             quantity: 40,
         };
         let origin_output_2 = AssetOutPoint {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_c,
+            shard_id: 0,
             quantity: 30,
         };
 
@@ -1205,6 +1214,9 @@ mod tests {
             asset_type_from: asset_type_a,
             asset_type_to: asset_type_b,
             asset_type_fee: asset_type_c,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 30,
             asset_quantity_to: 20,
             asset_quantity_fee: 30,
@@ -1237,6 +1249,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1249,30 +1262,35 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters1.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 25,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters1.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters1.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 15,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 15,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters2.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 15,
                 },
             ],
@@ -1291,9 +1309,9 @@ mod tests {
 
     #[test]
     fn verify_inconsistent_transfer_transaction_with_order() {
-        let asset_type_a = H256::random();
-        let asset_type_b = H256::random();
-        let asset_type_c = H256::random();
+        let asset_type_a = H160::random();
+        let asset_type_b = H160::random();
+        let asset_type_c = H160::random();
         let lock_script_hash = H160::random();
         let parameters = vec![vec![1]];
         let parameters_fee = vec![vec![2]];
@@ -1303,12 +1321,16 @@ mod tests {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
+            shard_id: 0,
             quantity: 30,
         };
         let order = Order {
             asset_type_from: asset_type_a,
             asset_type_to: asset_type_b,
-            asset_type_fee: H256::zero(),
+            asset_type_fee: H160::zero(),
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 25,
             asset_quantity_to: 10,
             asset_quantity_fee: 0,
@@ -1335,6 +1357,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1347,12 +1370,14 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 30,
                 },
             ],
@@ -1375,18 +1400,23 @@ mod tests {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
+            shard_id: 0,
             quantity: 40,
         };
         let origin_output_2 = AssetOutPoint {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_c,
+            shard_id: 0,
             quantity: 40,
         };
         let order = Order {
             asset_type_from: asset_type_a,
             asset_type_to: asset_type_b,
             asset_type_fee: asset_type_c,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 30,
             asset_quantity_to: 10,
             asset_quantity_fee: 30,
@@ -1420,6 +1450,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1432,36 +1463,42 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 30,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters_fee.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 30,
                 },
             ],
@@ -1501,6 +1538,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1513,36 +1551,42 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 30,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters_fee.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 30,
                 },
             ],
@@ -1582,6 +1626,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type_b,
+                        shard_id: 0,
                         quantity: 10,
                     },
                     timelock: None,
@@ -1594,36 +1639,42 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 5,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 30,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters_fee.clone(),
                     asset_type: asset_type_c,
+                    shard_id: 0,
                     quantity: 30,
                 },
             ],
@@ -1644,27 +1695,32 @@ mod tests {
 
     #[test]
     fn verify_transfer_transaction_with_two_orders() {
-        let asset_type_a = H256::random();
-        let asset_type_b = H256::random();
+        let asset_type_a = H160::random();
+        let asset_type_b = H160::random();
         let lock_script_hash = H160::random();
         let parameters = vec![vec![1]];
         let origin_output_1 = AssetOutPoint {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_a,
+            shard_id: 0,
             quantity: 30,
         };
         let origin_output_2 = AssetOutPoint {
             tracker: H256::random(),
             index: 0,
             asset_type: asset_type_b,
+            shard_id: 0,
             quantity: 10,
         };
 
         let order_1 = Order {
             asset_type_from: asset_type_a,
             asset_type_to: asset_type_b,
-            asset_type_fee: H256::zero(),
+            asset_type_fee: H160::zero(),
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 30,
             asset_quantity_to: 10,
             asset_quantity_fee: 0,
@@ -1678,7 +1734,10 @@ mod tests {
         let order_2 = Order {
             asset_type_from: asset_type_b,
             asset_type_to: asset_type_a,
-            asset_type_fee: H256::zero(),
+            asset_type_fee: H160::zero(),
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 10,
             asset_quantity_to: 20,
             asset_quantity_fee: 0,
@@ -1712,18 +1771,21 @@ mod tests {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_b,
+                    shard_id: 0,
                     quantity: 10,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: parameters.clone(),
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 20,
                 },
                 AssetTransferOutput {
                     lock_script_hash,
                     parameters: vec![],
                     asset_type: asset_type_a,
+                    shard_id: 0,
                     quantity: 10,
                 },
             ],
@@ -1755,7 +1817,8 @@ mod tests {
                 prev_out: AssetOutPoint {
                     tracker: Default::default(),
                     index: 0,
-                    asset_type: H256::zero(),
+                    asset_type: H160::zero(),
+                    shard_id: 0,
                     quantity: 0,
                 },
                 timelock: None,
@@ -1768,7 +1831,7 @@ mod tests {
             Err(TransactionError::ZeroQuantity.into())
         );
 
-        let invalid_asset_type = H256::random();
+        let invalid_asset_type = H160::random();
         let tx_invalid_asset_type = Action::UnwrapCCC {
             network_id: NetworkId::default(),
             burn: AssetTransferInput {
@@ -1776,6 +1839,7 @@ mod tests {
                     tracker: Default::default(),
                     index: 0,
                     asset_type: invalid_asset_type,
+                    shard_id: 0,
                     quantity: 1,
                 },
                 timelock: None,

--- a/types/src/transaction/asset_out_point.rs
+++ b/types/src/transaction/asset_out_point.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use primitives::H256;
+use primitives::{H160, H256};
 
 use crate::ShardId;
 
@@ -22,15 +22,14 @@ use crate::ShardId;
 pub struct AssetOutPoint {
     pub tracker: H256,
     pub index: usize,
-    pub asset_type: H256,
+    pub asset_type: H160,
+    pub shard_id: ShardId,
     pub quantity: u64,
 }
 
 impl AssetOutPoint {
     pub fn related_shard(&self) -> ShardId {
-        debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
-        let shard_id_bytes: [u8; 2] = [self.asset_type[2], self.asset_type[3]];
-        ShardId::from_be_bytes(shard_id_bytes)
+        self.shard_id
     }
 }
 

--- a/types/src/transaction/asset_out_point.rs
+++ b/types/src/transaction/asset_out_point.rs
@@ -32,23 +32,3 @@ impl AssetOutPoint {
         self.shard_id
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn related_shard_of_asset_out_point() {
-        let mut asset_type = H256::new();
-        asset_type[2..4].copy_from_slice(&[0xBE, 0xEF]);
-
-        let p = AssetOutPoint {
-            tracker: H256::random(),
-            index: 3,
-            asset_type,
-            quantity: 34,
-        };
-
-        assert_eq!(0xBEEF, p.related_shard());
-    }
-}

--- a/types/src/transaction/asset_out_point.rs
+++ b/types/src/transaction/asset_out_point.rs
@@ -26,9 +26,3 @@ pub struct AssetOutPoint {
     pub shard_id: ShardId,
     pub quantity: u64,
 }
-
-impl AssetOutPoint {
-    pub fn related_shard(&self) -> ShardId {
-        self.shard_id
-    }
-}

--- a/types/src/transaction/input.rs
+++ b/types/src/transaction/input.rs
@@ -17,7 +17,6 @@
 use primitives::Bytes;
 
 use super::{AssetOutPoint, Timelock};
-use crate::ShardId;
 
 #[derive(Debug, Clone, Eq, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct AssetTransferInput {
@@ -25,10 +24,4 @@ pub struct AssetTransferInput {
     pub timelock: Option<Timelock>,
     pub lock_script: Bytes,
     pub unlock_script: Bytes,
-}
-
-impl AssetTransferInput {
-    pub fn related_shard(&self) -> ShardId {
-        self.prev_out.related_shard()
-    }
 }

--- a/types/src/transaction/order.rs
+++ b/types/src/transaction/order.rs
@@ -151,16 +151,20 @@ impl Order {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use primitives::H256;
 
     #[test]
     fn verify_order_success() {
-        let asset_type_from = H256::random();
-        let asset_type_to = H256::random();
-        let asset_type_fee = H256::random();
+        let asset_type_from = H160::random();
+        let asset_type_to = H160::random();
+        let asset_type_fee = H160::random();
         let order = Order {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
@@ -168,6 +172,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -182,6 +187,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 0,
@@ -189,6 +197,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -203,6 +212,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 0,
             asset_quantity_to: 0,
             asset_quantity_fee: 0,
@@ -210,6 +222,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -224,20 +237,24 @@ mod tests {
     #[test]
     fn verify_order_fail() {
         // 1. origin outputs are invalid
-        let asset_type_from = H256::random();
-        let asset_type_to = H256::random();
-        let asset_type_fee = H256::random();
+        let asset_type_from = H160::random();
+        let asset_type_to = H160::random();
+        let asset_type_fee = H160::random();
         let order = Order {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
             origin_outputs: vec![AssetOutPoint {
                 tracker: H256::random(),
                 index: 0,
-                asset_type: H256::random(),
+                asset_type: H160::random(),
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -252,6 +269,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
@@ -269,6 +289,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 0,
             asset_quantity_fee: 3,
@@ -276,6 +299,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -297,6 +321,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 0,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
@@ -304,6 +331,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -325,6 +353,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 0,
             asset_quantity_to: 0,
             asset_quantity_fee: 3,
@@ -332,6 +363,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -353,6 +385,9 @@ mod tests {
             asset_type_from,
             asset_type_to,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 2,
@@ -360,6 +395,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type: asset_type_from,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -378,11 +414,14 @@ mod tests {
         );
 
         // 3. asset types are same
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let order = Order {
             asset_type_from: asset_type,
             asset_type_to: asset_type,
             asset_type_fee,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
@@ -390,6 +429,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -398,20 +438,16 @@ mod tests {
             lock_script_hash_fee: H160::random(),
             parameters_fee: vec![vec![1]],
         };
-        assert_eq!(
-            order.verify(),
-            Err(Error::InvalidOrderAssetTypes {
-                from: asset_type,
-                to: asset_type,
-                fee: asset_type_fee,
-            })
-        );
+        assert_eq!(order.verify(), Err(Error::InvalidOrderAssetTypes));
 
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let order = Order {
             asset_type_from: asset_type,
             asset_type_to,
             asset_type_fee: asset_type,
+            shard_id_from: 0,
+            shard_id_to: 0,
+            shard_id_fee: 0,
             asset_quantity_from: 3,
             asset_quantity_to: 2,
             asset_quantity_fee: 3,
@@ -419,6 +455,7 @@ mod tests {
                 tracker: H256::random(),
                 index: 0,
                 asset_type,
+                shard_id: 0,
                 quantity: 10,
             }],
             expiration: 10,
@@ -427,13 +464,6 @@ mod tests {
             lock_script_hash_fee: H160::random(),
             parameters_fee: vec![vec![1]],
         };
-        assert_eq!(
-            order.verify(),
-            Err(Error::InvalidOrderAssetTypes {
-                from: asset_type,
-                to: asset_type_to,
-                fee: asset_type,
-            })
-        );
+        assert_eq!(order.verify(), Err(Error::InvalidOrderAssetTypes));
     }
 }

--- a/types/src/transaction/output.rs
+++ b/types/src/transaction/output.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use primitives::{Bytes, H160, H256};
+use primitives::{Bytes, H160};
 
 use crate::ShardId;
 
@@ -22,15 +22,14 @@ use crate::ShardId;
 pub struct AssetTransferOutput {
     pub lock_script_hash: H160,
     pub parameters: Vec<Bytes>,
-    pub asset_type: H256,
+    pub asset_type: H160,
+    pub shard_id: ShardId,
     pub quantity: u64,
 }
 
 impl AssetTransferOutput {
     pub fn related_shard(&self) -> ShardId {
-        debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
-        let shard_id_bytes: [u8; 2] = [self.asset_type[2], self.asset_type[3]];
-        ShardId::from_be_bytes(shard_id_bytes)
+        self.shard_id
     }
 }
 

--- a/types/src/transaction/output.rs
+++ b/types/src/transaction/output.rs
@@ -27,12 +27,6 @@ pub struct AssetTransferOutput {
     pub quantity: u64,
 }
 
-impl AssetTransferOutput {
-    pub fn related_shard(&self) -> ShardId {
-        self.shard_id
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssetMintOutput {
     pub lock_script_hash: H160,

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -142,8 +142,8 @@ impl ShardTransaction {
             } => {
                 let mut shards: Vec<ShardId> = burns
                     .iter()
-                    .map(AssetTransferInput::related_shard)
-                    .chain(inputs.iter().map(AssetTransferInput::related_shard))
+                    .map(|v| v.prev_out.shard_id)
+                    .chain(inputs.iter().map(|v| v.prev_out.shard_id))
                     .collect();
                 shards.sort_unstable();
                 shards.dedup();
@@ -162,7 +162,7 @@ impl ShardTransaction {
                 shard_id,
                 ..
             } => {
-                let mut shards: Vec<ShardId> = inputs.iter().map(AssetTransferInput::related_shard).collect();
+                let mut shards: Vec<ShardId> = inputs.iter().map(|v| v.prev_out.shard_id).collect();
                 shards.push(*shard_id);
                 shards.sort_unstable();
                 shards.dedup();
@@ -172,7 +172,7 @@ impl ShardTransaction {
                 outputs,
                 ..
             } => {
-                let mut shards: Vec<ShardId> = outputs.iter().map(AssetTransferOutput::related_shard).collect();
+                let mut shards: Vec<ShardId> = outputs.iter().map(|v| v.shard_id).collect();
                 shards.sort_unstable();
                 shards.dedup();
                 shards
@@ -180,7 +180,7 @@ impl ShardTransaction {
             ShardTransaction::UnwrapCCC {
                 burn,
                 ..
-            } => vec![burn.related_shard()],
+            } => vec![burn.prev_out.shard_id],
             ShardTransaction::WrapCCC {
                 shard_id,
                 ..
@@ -238,7 +238,7 @@ impl ShardTransaction {
             ShardTransaction::TransferAsset {
                 outputs,
                 ..
-            } => id == outputs[index].related_shard(),
+            } => id == outputs[index].shard_id,
             ShardTransaction::ChangeAssetScheme {
                 ..
             } => unreachable!("AssetSchemeChange doesn't have a valid index"),
@@ -249,7 +249,7 @@ impl ShardTransaction {
             ShardTransaction::DecomposeAsset {
                 outputs,
                 ..
-            } => id == outputs[index].related_shard(),
+            } => id == outputs[index].shard_id,
             ShardTransaction::UnwrapCCC {
                 ..
             } => unreachable!("UnwrapCCC doesn't have a valid index"),

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -47,7 +47,8 @@ pub enum ShardTransaction {
     },
     ChangeAssetScheme {
         network_id: NetworkId,
-        asset_type: H256,
+        shard_id: ShardId,
+        asset_type: H160,
         metadata: String,
         approver: Option<Address>,
         administrator: Option<Address>,
@@ -153,9 +154,9 @@ impl ShardTransaction {
                 ..
             } => vec![*shard_id],
             ShardTransaction::ChangeAssetScheme {
-                asset_type,
+                shard_id,
                 ..
-            } => vec![(ShardId::from(asset_type[2]) << 8) + ShardId::from(asset_type[3])],
+            } => vec![*shard_id],
             ShardTransaction::ComposeAsset {
                 inputs,
                 shard_id,
@@ -502,16 +503,17 @@ impl Decodable for ShardTransaction {
                 })
             }
             ASSET_SCHEME_CHANGE_ID => {
-                if d.item_count()? != 7 {
+                if d.item_count()? != 8 {
                     return Err(DecoderError::RlpIncorrectListLen)
                 }
                 Ok(ShardTransaction::ChangeAssetScheme {
                     network_id: d.val_at(1)?,
-                    asset_type: d.val_at(2)?,
-                    metadata: d.val_at(3)?,
-                    approver: d.val_at(4)?,
-                    administrator: d.val_at(5)?,
-                    allowed_script_hashes: d.list_at(6)?,
+                    shard_id: d.val_at(2)?,
+                    asset_type: d.val_at(3)?,
+                    metadata: d.val_at(4)?,
+                    approver: d.val_at(5)?,
+                    administrator: d.val_at(6)?,
+                    allowed_script_hashes: d.list_at(7)?,
                 })
             }
             ASSET_COMPOSE_ID => {
@@ -603,15 +605,17 @@ impl Encodable for ShardTransaction {
             }
             ShardTransaction::ChangeAssetScheme {
                 network_id,
+                shard_id,
                 asset_type,
                 metadata,
                 approver,
                 administrator,
                 allowed_script_hashes,
             } => {
-                s.begin_list(7)
+                s.begin_list(8)
                     .append(&ASSET_SCHEME_CHANGE_ID)
                     .append(network_id)
+                    .append(shard_id)
                     .append(asset_type)
                     .append(metadata)
                     .append(approver)

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -682,30 +682,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn related_shard_of_asset_transfer_input() {
-        let mut asset_type = H256::new();
-        asset_type[2..4].copy_from_slice(&[0xBE, 0xEF]);
-
-        let prev_out = AssetOutPoint {
-            tracker: H256::random(),
-            index: 3,
-            asset_type,
-            quantity: 34,
-        };
-
-        let input = AssetTransferInput {
-            prev_out,
-            timelock: None,
-            lock_script: vec![],
-            unlock_script: vec![],
-        };
-
-        assert_eq!(0xBEEF, input.related_shard());
-    }
-
-    #[test]
     fn _is_input_and_output_consistent() {
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let quantity = 100;
 
         assert!(is_input_and_output_consistent(
@@ -714,6 +692,7 @@ mod tests {
                     tracker: H256::random(),
                     index: 0,
                     asset_type,
+                    shard_id: 0,
                     quantity,
                 },
                 timelock: None,
@@ -724,6 +703,7 @@ mod tests {
                 lock_script_hash: H160::random(),
                 parameters: vec![],
                 asset_type,
+                shard_id: 0,
                 quantity,
             }]
         ));
@@ -731,11 +711,11 @@ mod tests {
 
     #[test]
     fn multiple_asset_is_input_and_output_consistent() {
-        let asset_type1 = H256::random();
+        let asset_type1 = H160::random();
         let asset_type2 = {
-            let mut asset_type = H256::random();
+            let mut asset_type = H160::random();
             while asset_type == asset_type1 {
-                asset_type = H256::random();
+                asset_type = H160::random();
             }
             asset_type
         };
@@ -749,6 +729,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type1,
+                        shard_id: 0,
                         quantity: quantity1,
                     },
                     timelock: None,
@@ -760,6 +741,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type2,
+                        shard_id: 0,
                         quantity: quantity2,
                     },
                     timelock: None,
@@ -772,12 +754,14 @@ mod tests {
                     lock_script_hash: H160::random(),
                     parameters: vec![],
                     asset_type: asset_type1,
+                    shard_id: 0,
                     quantity: quantity1,
                 },
                 AssetTransferOutput {
                     lock_script_hash: H160::random(),
                     parameters: vec![],
                     asset_type: asset_type2,
+                    shard_id: 0,
                     quantity: quantity2,
                 },
             ]
@@ -786,11 +770,11 @@ mod tests {
 
     #[test]
     fn multiple_asset_different_order_is_input_and_output_consistent() {
-        let asset_type1 = H256::random();
+        let asset_type1 = H160::random();
         let asset_type2 = {
-            let mut asset_type = H256::random();
+            let mut asset_type = H160::random();
             while asset_type == asset_type1 {
-                asset_type = H256::random();
+                asset_type = H160::random();
             }
             asset_type
         };
@@ -804,6 +788,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type1,
+                        shard_id: 0,
                         quantity: quantity1,
                     },
                     timelock: None,
@@ -815,6 +800,7 @@ mod tests {
                         tracker: H256::random(),
                         index: 0,
                         asset_type: asset_type2,
+                        shard_id: 0,
                         quantity: quantity2,
                     },
                     timelock: None,
@@ -827,12 +813,14 @@ mod tests {
                     lock_script_hash: H160::random(),
                     parameters: vec![],
                     asset_type: asset_type2,
+                    shard_id: 0,
                     quantity: quantity2,
                 },
                 AssetTransferOutput {
                     lock_script_hash: H160::random(),
                     parameters: vec![],
                     asset_type: asset_type1,
+                    shard_id: 0,
                     quantity: quantity1,
                 },
             ]
@@ -846,7 +834,7 @@ mod tests {
 
     #[test]
     fn fail_if_output_has_more_asset() {
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let output_quantity = 100;
         assert!(!is_input_and_output_consistent(
             &[],
@@ -854,6 +842,7 @@ mod tests {
                 lock_script_hash: H160::random(),
                 parameters: vec![],
                 asset_type,
+                shard_id: 0,
                 quantity: output_quantity,
             }]
         ));
@@ -861,7 +850,7 @@ mod tests {
 
     #[test]
     fn fail_if_input_has_more_asset() {
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let input_quantity = 100;
 
         assert!(!is_input_and_output_consistent(
@@ -870,6 +859,7 @@ mod tests {
                     tracker: H256::random(),
                     index: 0,
                     asset_type,
+                    shard_id: 0,
                     quantity: input_quantity,
                 },
                 timelock: None,
@@ -882,7 +872,7 @@ mod tests {
 
     #[test]
     fn fail_if_input_is_larger_than_output() {
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let input_quantity = 100;
         let output_quantity = 80;
 
@@ -892,6 +882,7 @@ mod tests {
                     tracker: H256::random(),
                     index: 0,
                     asset_type,
+                    shard_id: 0,
                     quantity: input_quantity,
                 },
                 timelock: None,
@@ -902,6 +893,7 @@ mod tests {
                 lock_script_hash: H160::random(),
                 parameters: vec![],
                 asset_type,
+                shard_id: 0,
                 quantity: output_quantity,
             }]
         ));
@@ -909,7 +901,7 @@ mod tests {
 
     #[test]
     fn fail_if_input_is_smaller_than_output() {
-        let asset_type = H256::random();
+        let asset_type = H160::random();
         let input_quantity = 80;
         let output_quantity = 100;
 
@@ -919,6 +911,7 @@ mod tests {
                     tracker: H256::random(),
                     index: 0,
                     asset_type,
+                    shard_id: 0,
                     quantity: input_quantity,
                 },
                 timelock: None,
@@ -929,6 +922,7 @@ mod tests {
                 lock_script_hash: H160::random(),
                 parameters: vec![],
                 asset_type,
+                shard_id: 0,
                 quantity: output_quantity,
             }]
         ));
@@ -943,7 +937,8 @@ mod tests {
                 prev_out: AssetOutPoint {
                     tracker: Default::default(),
                     index: 0,
-                    asset_type: H256::default(),
+                    asset_type: H160::default(),
+                    shard_id: 0,
                     quantity: 30,
                 },
                 timelock: None,
@@ -963,7 +958,8 @@ mod tests {
                 prev_out: AssetOutPoint {
                     tracker: Default::default(),
                     index: 0,
-                    asset_type: H256::zero(),
+                    asset_type: H160::zero(),
+                    shard_id: 0,
                     quantity: 30,
                 },
                 timelock: None,
@@ -983,7 +979,8 @@ mod tests {
                 prev_out: AssetOutPoint {
                     tracker: H256::random(),
                     index: 0,
-                    asset_type: H256::random(),
+                    asset_type: H160::random(),
+                    shard_id: 0,
                     quantity: 30,
                 },
                 timelock: None,
@@ -993,21 +990,26 @@ mod tests {
             outputs: vec![AssetTransferOutput {
                 lock_script_hash: H160::random(),
                 parameters: vec![vec![1]],
-                asset_type: H256::random(),
+                asset_type: H160::random(),
+                shard_id: 0,
                 quantity: 30,
             }],
             orders: vec![OrderOnTransfer {
                 order: Order {
-                    asset_type_from: H256::random(),
-                    asset_type_to: H256::random(),
-                    asset_type_fee: H256::random(),
+                    asset_type_from: H160::random(),
+                    asset_type_to: H160::random(),
+                    asset_type_fee: H160::random(),
+                    shard_id_from: 0,
+                    shard_id_to: 0,
+                    shard_id_fee: 0,
                     asset_quantity_from: 10,
                     asset_quantity_to: 10,
                     asset_quantity_fee: 0,
                     origin_outputs: vec![AssetOutPoint {
                         tracker: H256::random(),
                         index: 0,
-                        asset_type: H256::random(),
+                        asset_type: H160::random(),
+                        shard_id: 0,
                         quantity: 30,
                     }],
                     expiration: 10,
@@ -1030,7 +1032,8 @@ mod tests {
             prev_out: AssetOutPoint {
                 tracker: Default::default(),
                 index: 0,
-                asset_type: H256::default(),
+                asset_type: H160::default(),
+                shard_id: 0,
                 quantity: 0,
             },
             timelock: None,
@@ -1042,7 +1045,8 @@ mod tests {
                 prev_out: AssetOutPoint {
                     tracker: Default::default(),
                     index: 0,
-                    asset_type: H256::default(),
+                    asset_type: H160::default(),
+                    shard_id: 0,
                     quantity: 0,
                 },
                 timelock: None,
@@ -1054,7 +1058,8 @@ mod tests {
             .map(|_| AssetTransferOutput {
                 lock_script_hash: H160::default(),
                 parameters: Vec::new(),
-                asset_type: H256::default(),
+                asset_type: H160::default(),
+                shard_id: 0,
                 quantity: 0,
             })
             .collect();
@@ -1117,13 +1122,12 @@ mod tests {
 
     // FIXME: Remove it and reuse the same function declared in action.rs
     fn is_input_and_output_consistent(inputs: &[AssetTransferInput], outputs: &[AssetTransferOutput]) -> bool {
-        let mut sum: HashMap<H256, u128> = HashMap::new();
+        let mut sum: HashMap<H160, u128> = HashMap::new();
 
         for input in inputs {
             let asset_type = input.prev_out.asset_type;
             let quantity = u128::from(input.prev_out.quantity);
-            let current_quantity = sum.get(&asset_type).cloned().unwrap_or_default();
-            sum.insert(asset_type, current_quantity + quantity);
+            *sum.entry(asset_type).or_insert_with(Default::default) += quantity;
         }
         for output in outputs {
             let asset_type = output.asset_type;

--- a/vm/tests/chk_multi_sig.rs
+++ b/vm/tests/chk_multi_sig.rs
@@ -27,7 +27,7 @@ mod common;
 use ccrypto::{blake128, blake256_with_key};
 use ckey::{sign, KeyPair, NetworkId, Private};
 use ctypes::transaction::{AssetOutPoint, AssetTransferInput, ShardTransaction};
-use primitives::H256;
+use primitives::H160;
 use rlp::Encodable;
 use secp256k1::key::{MINUS_ONE_KEY, ONE_KEY, TWO_KEY};
 
@@ -50,7 +50,8 @@ fn valid_multi_sig_0_of_2() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -91,7 +92,8 @@ fn valid_multi_sig_1_of_2() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -144,7 +146,8 @@ fn valid_multi_sig_2_of_2() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -199,7 +202,8 @@ fn valid_multi_sig_2_of_3_110() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -257,7 +261,8 @@ fn valid_multi_sig_2_of_3_101() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -315,7 +320,8 @@ fn valid_multi_sig_2_of_3_011() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -373,7 +379,8 @@ fn invalid_multi_sig_1_of_2() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -427,7 +434,8 @@ fn invalid_multi_sig_2_of_2() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -482,7 +490,8 @@ fn invalid_multi_sig_2_of_2_with_1_invalid_sig() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -548,7 +557,8 @@ fn invalid_multi_sig_2_of_2_with_changed_order_sig() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -603,7 +613,8 @@ fn invalid_multi_sig_with_less_sig_than_m() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -656,7 +667,8 @@ fn invalid_multi_sig_with_more_sig_than_m() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -711,7 +723,8 @@ fn invalid_multi_sig_with_too_many_arg() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,

--- a/vm/tests/chk_sig.rs
+++ b/vm/tests/chk_sig.rs
@@ -27,7 +27,7 @@ mod common;
 use ccrypto::{blake128, blake256_with_key};
 use ckey::{sign, KeyPair, NetworkId, Private};
 use ctypes::transaction::{AssetOutPoint, AssetTransferInput, AssetTransferOutput, ShardTransaction};
-use primitives::{H160, H256};
+use primitives::H160;
 use rlp::Encodable;
 use secp256k1::key::{MINUS_ONE_KEY, ONE_KEY};
 
@@ -50,7 +50,8 @@ fn valid_pay_to_public_key() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -94,7 +95,8 @@ fn invalid_pay_to_public_key() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -133,7 +135,8 @@ fn sign_all_input_all_output() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -146,7 +149,8 @@ fn sign_all_input_all_output() {
     let out1 = AssetOutPoint {
         tracker: Default::default(),
         index: 1,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let input1 = AssetTransferInput {
@@ -159,14 +163,16 @@ fn sign_all_input_all_output() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     // Make output indexed 1
     let output1 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let transaction = ShardTransaction::TransferAsset {
@@ -209,7 +215,8 @@ fn sign_single_input_all_output() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -222,7 +229,8 @@ fn sign_single_input_all_output() {
     let out1 = AssetOutPoint {
         tracker: Default::default(),
         index: 1,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let input1 = AssetTransferInput {
@@ -235,14 +243,16 @@ fn sign_single_input_all_output() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     // Make output indexed 1
     let output1 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let transaction = ShardTransaction::TransferAsset {
@@ -284,7 +294,8 @@ fn sign_all_input_partial_output() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -297,7 +308,8 @@ fn sign_all_input_partial_output() {
     let out1 = AssetOutPoint {
         tracker: Default::default(),
         index: 1,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let input1 = AssetTransferInput {
@@ -310,14 +322,16 @@ fn sign_all_input_partial_output() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     // Make output indexed 1
     let output1 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let transaction = ShardTransaction::TransferAsset {
@@ -359,7 +373,8 @@ fn sign_single_input_partial_output() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -372,7 +387,8 @@ fn sign_single_input_partial_output() {
     let out1 = AssetOutPoint {
         tracker: Default::default(),
         index: 1,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let input1 = AssetTransferInput {
@@ -385,14 +401,16 @@ fn sign_single_input_partial_output() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     // Make output indexed 1
     let output1 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 1,
     };
     let transaction = ShardTransaction::TransferAsset {
@@ -434,7 +452,8 @@ fn distinguish_sign_single_input_with_sign_all() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -447,7 +466,8 @@ fn distinguish_sign_single_input_with_sign_all() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let transaction = ShardTransaction::TransferAsset {
@@ -490,7 +510,8 @@ fn distinguish_sign_single_output_with_sign_all() {
     let out0 = AssetOutPoint {
         tracker: Default::default(),
         index: 0,
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let input0 = AssetTransferInput {
@@ -503,7 +524,8 @@ fn distinguish_sign_single_output_with_sign_all() {
     let output0 = AssetTransferOutput {
         lock_script_hash: H160::default(),
         parameters: Vec::new(),
-        asset_type: H256::default(),
+        asset_type: H160::default(),
+        shard_id: 0,
         quantity: 0,
     };
     let transaction = ShardTransaction::TransferAsset {

--- a/vm/tests/executor.rs
+++ b/vm/tests/executor.rs
@@ -45,7 +45,8 @@ fn simple_success() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -77,7 +78,8 @@ fn simple_failure() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -108,7 +110,8 @@ fn simple_burn() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -135,7 +138,8 @@ fn underflow() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -162,7 +166,8 @@ fn out_of_memory() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -201,7 +206,8 @@ fn invalid_unlock_script() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -228,7 +234,8 @@ fn conditional_burn() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -278,7 +285,8 @@ fn _blake256() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -354,7 +362,8 @@ fn _ripemd160() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -438,7 +447,8 @@ fn _sha256() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -522,7 +532,8 @@ fn _keccak256() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -608,7 +619,8 @@ fn dummy_input() -> AssetTransferInput {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,
@@ -848,7 +860,8 @@ fn copy_stack_underflow() {
         prev_out: AssetOutPoint {
             tracker: Default::default(),
             index: 0,
-            asset_type: H256::default(),
+            asset_type: H160::default(),
+            shard_id: 0,
             quantity: 0,
         },
         timelock: None,


### PR DESCRIPTION
Resolves: #1148 / Resolves: #1166 

Old: (H256 of tracker of mint tx) + (shard id)
New: H160 of tracker of mint tx only.

`AssetSchemeAddress` was exactly same as the asset type in the old definition.
From the new definition, `AssetSchemeAddress` is calculated from the shard id and the blake256 hash of the asset type.

`shard_id` field is added to each struct which has `asset_type` field.