### PR TITLE
No need to use sudo-enabled Travis worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
         - test $INT_TEST_FLAG && ./upload_logs.sh
     - name: test-linux
       os: linux
-      sudo: required
+      sudo: false
       before_install:
         - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
         - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
@@ -63,7 +63,7 @@ jobs:
         - RUST_BACKTRACE=1 cargo test --verbose --all || exit 1
     - name: int-test-linux
       os: linux
-      sudo: required
+      sudo: false
       before_install:
         - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
         - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi


### PR DESCRIPTION
We used sudo-enabled workers because container-based workers don't give
enough memory to compile CodeChain. But after the machine spec has been
changed, container-based works have enough memory.