### PR TITLE
Change the supply of WCCC on Wrap/Unwrap

### DIFF
--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -693,7 +693,7 @@ impl<'db> ShardLevelState<'db> {
             let asset_scheme = self.create_asset_scheme(
                 self.shard_id,
                 asset_type,
-                format!("{{\"name\":\"Wrapped CCC\",\"description\":\"Wrapped CCC in shard {}\"}}", self.shard_id),
+                String::new(),
                 0,
                 None,
                 None,

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -119,6 +119,13 @@ impl AssetScheme {
         self.allowed_script_hashes = allowed_script_hashes;
     }
 
+    pub fn increase_supply(&mut self, quantity: u64) -> u64 {
+        assert!(std::u64::MAX - quantity > self.supply, "AssetScheme supply shouldn't be overflowed");
+        let previous = self.supply;
+        self.supply += quantity;
+        previous
+    }
+
     pub fn reduce_supply(&mut self, quantity: u64) -> u64 {
         assert!(self.supply >= quantity, "AssetScheme supply shouldn't be depleted");
         let previous = self.supply;

--- a/test/src/e2e/wrap.test.ts
+++ b/test/src/e2e/wrap.test.ts
@@ -32,8 +32,9 @@ describe("WrapCCC", function() {
     });
 
     it("WCCC can be burnt", async function() {
+        const shardId = 0;
         const wrapCCC = node.sdk.core.createWrapCCCTransaction({
-            shardId: 0,
+            shardId,
             recipient: await node.createP2PKHBurnAddress(),
             quantity: 30
         });
@@ -54,6 +55,14 @@ describe("WrapCCC", function() {
         ))!;
         expect(invoice1).not.to.be.null;
         expect(invoice1.success).be.equal(true);
+
+        const schemeAfterWrap = (await node.sdk.rpc.chain.getAssetSchemeByType(
+            H160.zero(),
+            shardId
+        ))!;
+        expect(schemeAfterWrap.supply.isEqualTo(30)).to.be.true;
+
+        const blockNumberBeforeBurn = await node.sdk.rpc.chain.getBestBlockNumber();
 
         const WCCC = wrapCCC.getAsset();
 
@@ -78,6 +87,19 @@ describe("WrapCCC", function() {
         ))!;
         expect(invoice2).not.to.be.null;
         expect(invoice2.success).be.equal(true);
+
+        const schemeAfterBurn = (await node.sdk.rpc.chain.getAssetSchemeByType(
+            H160.zero(),
+            shardId
+        ))!;
+        expect(schemeAfterBurn.supply.isEqualTo(0)).to.be.true;
+
+        const schemeBeforeBurn = (await node.sdk.rpc.chain.getAssetSchemeByType(
+            H160.zero(),
+            shardId,
+            blockNumberBeforeBurn
+        ))!;
+        expect(schemeBeforeBurn.supply.isEqualTo(30)).to.be.true;
     }).timeout(30_000);
 
     it("Changing asset scheme of WCCC causes syntax error", async function() {


### PR DESCRIPTION
Currently, the supply of WCCC is fixed to 0xFFFF_FFFF_FFFF_FFFF, the maximum quantity of the CCC. It changed the supply to the amount of WCCC on the shard.

And it removes the meaningless metadata of WCCC.