### PR TITLE
Remove votes after inserting votes from the new proposal

### DIFF
--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -561,12 +561,6 @@ impl TendermintInner {
             return
         }
 
-        self.votes.throw_out_old(&VoteStep {
-            height: (proposal.number() - 1) as usize,
-            view: 0,
-            step: Step::Propose,
-        });
-
         let height = proposal.number() as Height;
         let prev_block_view = previous_block_view(proposal).expect("The proposal is verified");
         let on = VoteOn {
@@ -584,6 +578,14 @@ impl TendermintInner {
                 self.votes.vote(message);
             }
         }
+
+        // Since the votes needs at least one vote to check the old votes,
+        // we should remove old votes after inserting current votes.
+        self.votes.throw_out_old(&VoteStep {
+            height: (proposal.number() - 1) as usize,
+            view: 0,
+            step: Step::Propose,
+        });
 
         let proposal_view = consensus_view(proposal).unwrap();
         let current_height = self.height;

--- a/core/src/consensus/vote_collector.rs
+++ b/core/src/consensus/vote_collector.rs
@@ -138,6 +138,7 @@ impl<M: Message + Default + Encodable + Debug> VoteCollector<M> {
     pub fn throw_out_old(&self, vote_round: &M::Round) {
         let mut guard = self.votes.write();
         let new_collector = guard.split_off(vote_round);
+        assert!(!new_collector.is_empty());
         *guard = new_collector;
     }
 


### PR DESCRIPTION
Since the `VoteCollector` should always have at least one vote, we
should insert new votes before deleting old votes.

Fix https://github.com/CodeChain-io/codechain/issues/1247