### PR TITLE
Add test case for rejected-by-limit-and-reaccepted

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2015",
     "types": ["node"],
     "module": "commonjs",
+    "lib": ["es2017"],
     "declaration": true,
     "outDir": "lib",
     "strict": true


### PR DESCRIPTION
Test case for the situation where some transactions rejected to enter the mempool because of the mempool size limit but accepted by next request.