### PR TITLE
Change AssetMintOutput.supply not to be optional

### DIFF
--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -1207,7 +1207,7 @@ pub mod test {
                 output: Box::new(AssetMintOutput {
                     lock_script_hash: H160::zero(),
                     parameters: vec![],
-                    supply: None,
+                    supply: ::std::u64::MAX,
                 }),
                 approver: None,
                 administrator: None,
@@ -1367,7 +1367,7 @@ pub mod test {
                 output: Box::new(AssetMintOutput {
                     lock_script_hash: H160::zero(),
                     parameters: vec![],
-                    supply: None,
+                    supply: ::std::u64::MAX,
                 }),
                 approvals: vec![],
             },
@@ -1456,7 +1456,7 @@ pub mod test {
                 output: Box::new(AssetMintOutput {
                     lock_script_hash: H160::zero(),
                     parameters: vec![],
-                    supply: None,
+                    supply: ::std::u64::MAX,
                 }),
                 approvals: vec![],
             },

--- a/rpc/src/v1/impls/devel.rs
+++ b/rpc/src/v1/impls/devel.rs
@@ -159,7 +159,7 @@ where
                         output: Box::new(AssetMintOutput {
                             lock_script_hash: lock_script_hash_empty_sig,
                             parameters: vec![],
-                            supply: Some($supply),
+                            supply: $supply,
                         }),
                         approvals: vec![],
                     },

--- a/rpc/src/v1/types/action.rs
+++ b/rpc/src/v1/types/action.rs
@@ -719,7 +719,7 @@ mod tests {
             output: AssetMintOutput {
                 lock_script_hash: Default::default(),
                 parameters: vec![],
-                supply: Some(1.into()),
+                supply: 1.into(),
             }
             .into(),
 
@@ -746,7 +746,7 @@ mod tests {
             output: AssetMintOutput {
                 lock_script_hash: Default::default(),
                 parameters: vec![],
-                supply: Some(1.into()),
+                supply: 1.into(),
             }
             .into(),
 
@@ -770,7 +770,7 @@ mod tests {
             output: AssetMintOutput {
                 lock_script_hash: Default::default(),
                 parameters: vec![],
-                supply: Some(1.into()),
+                supply: 1.into(),
             }
             .into(),
 
@@ -792,7 +792,7 @@ mod tests {
             output: AssetMintOutput {
                 lock_script_hash: Default::default(),
                 parameters: vec![],
-                supply: Some(1.into()),
+                supply: 1.into(),
             }
             .into(),
 

--- a/rpc/src/v1/types/asset_output.rs
+++ b/rpc/src/v1/types/asset_output.rs
@@ -62,7 +62,7 @@ impl From<AssetTransferOutput> for Result<AssetTransferOutputType, FromHexError>
 pub struct AssetMintOutput {
     pub lock_script_hash: H160,
     pub parameters: Vec<String>,
-    pub supply: Option<Uint>,
+    pub supply: Uint,
 }
 
 impl From<AssetMintOutputType> for AssetMintOutput {
@@ -70,7 +70,7 @@ impl From<AssetMintOutputType> for AssetMintOutput {
         AssetMintOutput {
             lock_script_hash: from.lock_script_hash,
             parameters: from.parameters.iter().map(|bytes| bytes.to_hex()).collect(),
-            supply: from.supply.map(|supply| supply.into()),
+            supply: from.supply.into(),
         }
     }
 }
@@ -80,7 +80,7 @@ impl From<AssetMintOutput> for Result<AssetMintOutputType, FromHexError> {
         Ok(AssetMintOutputType {
             lock_script_hash: from.lock_script_hash,
             parameters: Result::from_iter(from.parameters.iter().map(|hexstr| hexstr.from_hex()))?,
-            supply: from.supply.map(|supply| supply.into()),
+            supply: from.supply.into(),
         })
     }
 }

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -112,20 +112,13 @@ impl<'db> ShardLevelState<'db> {
                 approver,
                 administrator,
                 allowed_script_hashes,
-                output:
-                    AssetMintOutput {
-                        lock_script_hash,
-                        supply,
-                        parameters,
-                    },
+                output,
                 ..
             } => {
                 self.mint_asset(
                     transaction.tracker(),
                     metadata,
-                    lock_script_hash,
-                    &parameters,
-                    *supply,
+                    output,
                     approver,
                     approvers,
                     administrator,
@@ -216,9 +209,7 @@ impl<'db> ShardLevelState<'db> {
         &mut self,
         transaction_tracker: H256,
         metadata: &str,
-        lock_script_hash: &H160,
-        parameters: &[Bytes],
-        supply: u64,
+        output: &AssetMintOutput,
         approver: &Option<Address>,
         approvers: &[Address],
         administrator: &Option<Address>,
@@ -247,7 +238,7 @@ impl<'db> ShardLevelState<'db> {
             self.shard_id,
             asset_type,
             metadata.to_string(),
-            supply,
+            output.supply,
             *approver,
             *administrator,
             allowed_script_hashes.to_vec(),
@@ -256,7 +247,15 @@ impl<'db> ShardLevelState<'db> {
 
         ctrace!(TX, "{:?} is minted on {}:{:?}", asset_scheme, self.shard_id, asset_type);
 
-        self.create_asset(transaction_tracker, 0, asset_type, *lock_script_hash, parameters.to_vec(), supply, None)?;
+        self.create_asset(
+            transaction_tracker,
+            0,
+            asset_type,
+            output.lock_script_hash,
+            output.parameters.clone(),
+            output.supply,
+            None,
+        )?;
         ctrace!(TX, "Created asset on {}:{}:{}", self.shard_id, transaction_tracker, 0);
         Ok(())
     }
@@ -635,9 +634,7 @@ impl<'db> ShardLevelState<'db> {
         self.mint_asset(
             transaction.tracker(),
             metadata,
-            &output.lock_script_hash,
-            &output.parameters,
-            output.supply,
+            output,
             approver,
             approvers,
             administrator,

--- a/state/src/impls/test_helper.rs
+++ b/state/src/impls/test_helper.rs
@@ -115,14 +115,14 @@ macro_rules! asset_mint_output {
         $crate::ctypes::transaction::AssetMintOutput {
             lock_script_hash: $lock_script_hash,
             parameters: $params,
-            supply: None,
+            supply: ::std::u64::MAX,
         }
     };
     ($lock_script_hash:expr, $params:expr, $supply:expr) => {
         $crate::ctypes::transaction::AssetMintOutput {
             lock_script_hash: $lock_script_hash,
             parameters: $params,
-            supply: Some($supply),
+            supply: $supply,
         }
     };
 }

--- a/test/package.json
+++ b/test/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "codechain-sdk": "https://github.com/foriequal0/codechain-sdk-js.git#feature/increase_asset_supply",
+    "codechain-sdk": "https://github.com/foriequal0/codechain-sdk-js.git#build/mandatory-supply",
     "codechain-test-helper": "https://github.com/sgkim126/codechain-test-helper-js.git#rename-lib",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/test/package.json
+++ b/test/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#invoice-lib",
+    "codechain-sdk": "https://github.com/foriequal0/codechain-sdk-js.git#feature/increase_asset_supply",
     "codechain-test-helper": "https://github.com/sgkim126/codechain-test-helper-js.git#rename-lib",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/test/src/e2e/verification.test.ts
+++ b/test/src/e2e/verification.test.ts
@@ -262,7 +262,7 @@ describe("solo - 1 node", function() {
                 amount
             ) {
                 it(`amount: ${amount}`, async function() {
-                    encoded[3][6][0] = amount;
+                    encoded[3][6] = amount;
                     try {
                         await node.sendSignedTransactionWithRlpBytes(
                             RLP.encode(encoded)

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -891,9 +891,9 @@ codechain-primitives@^0.4.5:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-"codechain-sdk@https://github.com/foriequal0/codechain-sdk-js.git#feature/increase_asset_supply":
+"codechain-sdk@https://github.com/foriequal0/codechain-sdk-js.git#build/mandatory-supply":
   version "0.5.1"
-  resolved "https://github.com/foriequal0/codechain-sdk-js.git#e2fb53b710b9429ee5294505226d650ed91aeb04"
+  resolved "https://github.com/foriequal0/codechain-sdk-js.git#e4a61b4dc69733c3b0efe9baff378fffa9e3fe3f"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -891,9 +891,9 @@ codechain-primitives@^0.4.5:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#invoice-lib":
+"codechain-sdk@https://github.com/foriequal0/codechain-sdk-js.git#feature/increase_asset_supply":
   version "0.5.1"
-  resolved "https://github.com/sgkim126/codechain-sdk-js.git#37ee0e3a9ff6726f65cc157e7df425e798cf90b4"
+  resolved "https://github.com/foriequal0/codechain-sdk-js.git#e2fb53b710b9429ee5294505226d650ed91aeb04"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -201,9 +201,8 @@ impl Action {
                 if metadata.len() > max_asset_scheme_metadata_size {
                     return Err(SyntaxError::MetadataTooBig)
                 }
-                match output.supply {
-                    Some(supply) if supply == 0 => return Err(SyntaxError::ZeroQuantity),
-                    _ => {}
+                if output.supply == 0 {
+                    return Err(SyntaxError::ZeroQuantity)
                 }
             }
             Action::TransferAsset {
@@ -256,7 +255,7 @@ impl Action {
                 output,
                 ..
             } => {
-                if output.supply.unwrap_or(0) == 0 {
+                if output.supply == 0 {
                     return Err(SyntaxError::ZeroQuantity)
                 }
                 if asset_type.is_zero() {
@@ -280,13 +279,10 @@ impl Action {
                     return Err(SyntaxError::ZeroQuantity)
                 }
                 check_duplication_in_prev_out(&[], inputs)?;
-                match output.supply {
-                    Some(supply) if supply == 1 => {}
-                    _ => {
-                        return Err(SyntaxError::InvalidComposedOutputAmount {
-                            got: output.supply.unwrap_or_default(),
-                        })
-                    }
+                if output.supply != 1 {
+                    return Err(SyntaxError::InvalidComposedOutputAmount {
+                        got: output.supply,
+                    })
                 }
                 if metadata.len() > max_asset_scheme_metadata_size {
                     return Err(SyntaxError::MetadataTooBig)
@@ -1091,7 +1087,7 @@ mod tests {
             output: Box::new(AssetMintOutput {
                 lock_script_hash: H160::random(),
                 parameters: vec![],
-                supply: Some(10000),
+                supply: 10000,
             }),
             approver: None,
             administrator: None,
@@ -1109,7 +1105,7 @@ mod tests {
             output: Box::new(AssetMintOutput {
                 lock_script_hash: H160::random(),
                 parameters: vec![vec![1, 2, 3], vec![4, 5, 6], vec![0, 7]],
-                supply: Some(10000),
+                supply: 10000,
             }),
             approver: None,
             administrator: None,
@@ -1127,7 +1123,7 @@ mod tests {
             output: Box::new(AssetMintOutput {
                 lock_script_hash: H160::random(),
                 parameters: vec![vec![1, 2, 3], vec![4, 5, 6], vec![0, 7]],
-                supply: Some(10000),
+                supply: 10000,
             }),
             approver: None,
             administrator: None,
@@ -1145,7 +1141,7 @@ mod tests {
             output: Box::new(AssetMintOutput {
                 lock_script_hash: H160::random(),
                 parameters: vec![vec![1, 2, 3], vec![4, 5, 6], vec![0, 7]],
-                supply: Some(10000),
+                supply: 10000,
             }),
             approver: None,
             administrator: None,

--- a/types/src/transaction/output.rs
+++ b/types/src/transaction/output.rs
@@ -27,9 +27,9 @@ pub struct AssetTransferOutput {
     pub quantity: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct AssetMintOutput {
     pub lock_script_hash: H160,
     pub parameters: Vec<Bytes>,
-    pub supply: Option<u64>,
+    pub supply: u64,
 }

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -382,11 +382,7 @@ impl PartialHashing for ShardTransaction {
                 let new_output = if tag.sign_all_outputs {
                     output.clone()
                 } else {
-                    AssetMintOutput {
-                        lock_script_hash: H160::default(),
-                        parameters: Vec::new(),
-                        supply: None,
-                    }
+                    AssetMintOutput::default()
                 };
 
                 Ok(blake256_with_key(


### PR DESCRIPTION
* Add e2e test for IncreaseAssetAmount
* AssetMintOutput.supply is not optional anymore.

SDK issue: https://github.com/CodeChain-io/codechain-sdk-js/pull/315

Resolve: https://github.com/CodeChain-io/codechain/issues/1250
