### PR TITLE
Fix timelock test

### DIFF
--- a/test/src/e2e.long/timelock.test.ts
+++ b/test/src/e2e.long/timelock.test.ts
@@ -371,7 +371,7 @@ describe("Timelock", function() {
                 assets[0].createTransferInput({
                     timelock: {
                         type: "time",
-                        value: Math.ceil(Date.now() / 1000) + 3
+                        value: Math.floor(Date.now() / 1000) + 3
                     }
                 }),
                 assets[1].createTransferInput({


### PR DESCRIPTION
Since the test used `ceil`, the transaction can be locked 4 seconds in
the worst case.
But the test doesn't guarantee it, the test guarantees it passed only 3
seconds.
So this patch changes `ceil` to `floor`.