### PR TITLE
Modify the calculation method of view_proposer

### DIFF
--- a/core/res/corgi.json
+++ b/core/res/corgi.json
@@ -82,7 +82,7 @@
       }
     },
     "score": "0x20000",
-    "author": "wccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp38gf7",
+    "author": "wccq959puf2uj2587x86am0ycxeqjqgnrm9uy7qyjhr",
     "timestamp": "0x00",
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "extraData": "0x"

--- a/core/res/tendermint.json
+++ b/core/res/tendermint.json
@@ -58,7 +58,7 @@
       }
     },
     "score": "0x20000",
-    "author": "tccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhhn9p3",
+    "author": "tccq8qlwpt7xcs9lec3c8tyt3kqxlgsus8q4qp3m6ft",
     "timestamp": "0x00",
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "extraData": "0x"

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -360,6 +360,9 @@ pub enum EngineError {
         height: u64,
         index: usize,
     },
+    PrevBlockNotExist {
+        height: u64,
+    },
     /// The same author issued different votes at the same step.
     DoubleVote(Address),
     /// The received block is from an incorrect proposer.
@@ -390,6 +393,9 @@ impl fmt::Display for EngineError {
                 height,
                 index,
             } => format!("The {}th validator on height {} does not exist. (out of bound)", index, height),
+            PrevBlockNotExist {
+                height,
+            } => format!("The previous block of height {} does not exist.", height),
             DoubleVote(address) => format!("Author {} issued too many blocks.", address),
             NotProposer(mis) => format!("Author is not a current proposer: {}", mis),
             UnexpectedMessage => "This Engine should not be fed messages.".into(),

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -788,7 +788,7 @@ impl TendermintInner {
             return Err(BlockError::InvalidSeal.into())
         }
 
-        if bitset_count < precommits_count {
+        if bitset_count > precommits_count {
             cwarn!(
                 ENGINE,
                 "verify_block_external: The header({})'s bitset count is greater than the precommits count",

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -184,23 +184,25 @@ impl TendermintInner {
 
     /// Get previous block hash to determine validator set
     fn prev_block_hash(&self) -> H256 {
-        self.prev_block_of_height(self.height).hash()
+        self.prev_block_header_of_height(self.height)
+            .expect("Height is increased when previous block is imported")
+            .hash()
     }
 
     /// Get the proposer of previous block to check new proposer is valid.
-    fn prev_block_proposer_idx(&self, height: Height) -> usize {
-        let prev_proposer = self.prev_block_of_height(height).author();
-        self.validators
-            .get_index_by_address(&self.prev_block_hash(), &prev_proposer)
-            .expect("The proposer must be in the validator set")
+    fn prev_block_proposer_idx(&self, height: Height) -> Option<usize> {
+        self.prev_block_header_of_height(height).map(|prev_header| {
+            let prev_proposer = prev_header.author();
+            self.validators
+                .get_index_by_address(&self.prev_block_hash(), &prev_proposer)
+                .expect("The proposer must be in the validator set")
+        })
     }
 
-    /// Get previous block of given height
-    fn prev_block_of_height(&self, height: Height) -> encoded::Header {
+    /// Get previous block header of given height
+    fn prev_block_header_of_height(&self, height: Height) -> Option<encoded::Header> {
         let prev_height = (height - 1) as u64;
-        self.client()
-            .block_header(&BlockId::Number(prev_height))
-            .expect("Height is increased when previous block is imported")
+        self.client().block_header(&BlockId::Number(prev_height))
     }
 
     /// Check the committed block of the current height is imported to the canonical chain
@@ -215,10 +217,12 @@ impl TendermintInner {
     }
 
     /// Find the designated for the given view.
-    fn view_proposer(&self, bh: &H256, height: Height, view: View) -> Address {
-        let proposer_nonce = self.prev_block_proposer_idx(height) + 1 + view;
-        ctrace!(ENGINE, "Proposer nonce: {}", proposer_nonce);
-        self.validators.get_address(bh, proposer_nonce)
+    fn view_proposer(&self, bh: &H256, height: Height, view: View) -> Option<Address> {
+        self.prev_block_proposer_idx(height).map(|prev_proposer_idx| {
+            let proposer_nonce = prev_proposer_idx + 1 + view;
+            ctrace!(ENGINE, "Proposer nonce: {}", proposer_nonce);
+            self.validators.get_address(bh, proposer_nonce)
+        })
     }
 
     pub fn proposal_at(&self, height: Height, view: View) -> Option<(SchnorrSignature, usize, Bytes)> {
@@ -261,21 +265,26 @@ impl TendermintInner {
 
     /// Check if address is a proposer for given view.
     fn check_view_proposer(&self, bh: &H256, height: Height, view: View, address: &Address) -> Result<(), EngineError> {
-        let proposer = self.view_proposer(bh, height, view);
-        if proposer == *address {
-            Ok(())
-        } else {
-            Err(EngineError::NotProposer(Mismatch {
-                expected: proposer,
-                found: *address,
-            }))
-        }
+        self.view_proposer(bh, height, view).map_or(
+            Err(EngineError::PrevBlockNotExist {
+                height: height as u64,
+            }),
+            |proposer| {
+                if proposer == *address {
+                    Ok(())
+                } else {
+                    Err(EngineError::NotProposer(Mismatch {
+                        expected: proposer,
+                        found: *address,
+                    }))
+                }
+            },
+        )
     }
 
     /// Check if current signer is the current proposer.
     fn is_signer_proposer(&self, bh: &H256) -> bool {
-        let proposer = self.view_proposer(bh, self.height, self.view);
-        self.signer.is_address(&proposer)
+        self.view_proposer(bh, self.height, self.view).map_or(false, |proposer| self.signer.is_address(&proposer))
     }
 
     fn is_view(&self, message: &ConsensusMessage) -> bool {
@@ -919,7 +928,9 @@ impl TendermintInner {
                 if self.proposal.is_none() {
                     // Report the proposer if no proposal was received.
                     let height = self.height;
-                    let current_proposer = self.view_proposer(&self.prev_block_hash(), height, self.view);
+                    let current_proposer = self
+                        .view_proposer(&self.prev_block_hash(), height, self.view)
+                        .expect("Height is increased when previous block is imported");
                     self.validators.report_benign(&current_proposer, height as BlockNumber, height as BlockNumber);
                 }
                 Some(Step::Prevote)
@@ -1963,12 +1974,14 @@ mod tests {
     use super::*;
 
     /// Accounts inserted with "0" and "1" are validators. First proposer is "0".
-    fn setup() -> (Scheme, Arc<AccountProvider>, Arc<EngineClient>) {
+    fn setup() -> (Scheme, Arc<AccountProvider>, Arc<TestBlockChainClient>) {
         let tap = AccountProvider::transient_provider();
         let scheme = Scheme::new_test_tendermint();
-        let test_client: Arc<EngineClient> =
-            Arc::new(TestBlockChainClient::new_with_scheme(Scheme::new_test_tendermint()));
-        scheme.engine.register_client(Arc::downgrade(&test_client));
+        let test = TestBlockChainClient::new_with_scheme(Scheme::new_test_tendermint());
+
+        let test_client: Arc<TestBlockChainClient> = Arc::new(test);
+        let engine_client = Arc::clone(&test_client) as Arc<EngineClient>;
+        scheme.engine.register_client(Arc::downgrade(&engine_client));
         (scheme, tap, test_client)
     }
 

--- a/core/src/consensus/validator_set/mod.rs
+++ b/core/src/consensus/validator_set/mod.rs
@@ -52,6 +52,9 @@ pub trait ValidatorSet: Send + Sync {
     /// Draws a validator from nonce modulo number of validators.
     fn get_index(&self, parent: &H256, public: &Public) -> Option<usize>;
 
+    /// Draws a validator index from validator address.
+    fn get_index_by_address(&self, parent: &H256, address: &Address) -> Option<usize>;
+
     /// Returns the current number of validators.
     fn count(&self, parent: &H256) -> usize;
 

--- a/core/src/consensus/validator_set/validator_list.rs
+++ b/core/src/consensus/validator_set/validator_list.rs
@@ -88,6 +88,10 @@ impl ValidatorSet for ValidatorList {
         self.validators.iter().position(|v| v == public)
     }
 
+    fn get_index_by_address(&self, _bh: &H256, address: &Address) -> Option<usize> {
+        self.validators.iter().position(|v| public_to_address(v) == *address)
+    }
+
     fn count(&self, _bh: &H256) -> usize {
         self.validators.len()
     }


### PR DESCRIPTION
To give each validator an equal chance of proposing, tendermint
should check new propser if its index is the same as
 `previous block's proposer index` + `view` + 1. Previous checking
was problematic when a node is inactive.

It closes #1279