### PR TITLE
Remove the base id of e2e tests

### DIFF
--- a/test/src/e2e.long/account.test.ts
+++ b/test/src/e2e.long/account.test.ts
@@ -21,14 +21,13 @@ import { makeRandomH256, makeRandomPassphrase } from "../helper/random";
 import CodeChain from "../helper/spawn";
 
 describe("account", function() {
-    const BASE = 0;
     describe("account scenario test", function() {
         let node: CodeChain;
         const testSize = 30;
         const randomTestSize = 100;
 
         beforeEach(async function() {
-            node = new CodeChain({ base: BASE });
+            node = new CodeChain();
             await node.start();
         });
 

--- a/test/src/e2e.long/accountUnlock.test.ts
+++ b/test/src/e2e.long/accountUnlock.test.ts
@@ -22,12 +22,11 @@ import { makeRandomH256, makeRandomPassphrase } from "../helper/random";
 import CodeChain from "../helper/spawn";
 
 describe("account unlock", function() {
-    const BASE = 50;
     let node: CodeChain;
     const unlockTestSize = 15;
 
     beforeEach(async function() {
-        node = new CodeChain({ base: BASE });
+        node = new CodeChain();
         await node.start();
     });
 

--- a/test/src/e2e.long/discovery2.test.ts
+++ b/test/src/e2e.long/discovery2.test.ts
@@ -18,13 +18,12 @@ import "mocha";
 import CodeChain from "../helper/spawn";
 
 describe("discovery2 nodes", function() {
-    const BASE = 150;
     let nodeA: CodeChain;
     let nodeB: CodeChain;
 
     beforeEach(async function() {
-        nodeA = new CodeChain({ base: BASE });
-        nodeB = new CodeChain({ base: BASE });
+        nodeA = new CodeChain();
+        nodeB = new CodeChain();
         await Promise.all([nodeA.start(), nodeB.start()]);
     });
 

--- a/test/src/e2e.long/discovery5.test.ts
+++ b/test/src/e2e.long/discovery5.test.ts
@@ -19,13 +19,12 @@ import "mocha";
 import CodeChain from "../helper/spawn";
 
 describe("discovery5 nodes", function() {
-    const BASE = 100;
     const numOfNodes = 5;
     let nodes: CodeChain[];
     let bootstrapNode: CodeChain;
 
     beforeEach(async function() {
-        nodes = [new CodeChain({ base: BASE })];
+        nodes = [new CodeChain()];
         bootstrapNode = nodes[0];
 
         const startBootstrap = bootstrapNode.start([
@@ -35,7 +34,7 @@ describe("discovery5 nodes", function() {
 
         const nonBootstrapNodes = [];
         for (let i = 1; i < numOfNodes; i++) {
-            const node = new CodeChain({ base: BASE });
+            const node = new CodeChain();
             nodes.push(node);
             nonBootstrapNodes.push(node);
         }

--- a/test/src/e2e.long/futureTransaction.test.ts
+++ b/test/src/e2e.long/futureTransaction.test.ts
@@ -18,16 +18,12 @@ import "mocha";
 import { PromiseExpect } from "../helper/promise";
 import CodeChain from "../helper/spawn";
 
-const BASE = 1100;
-
 describe("Handle future transactions", function() {
     let nodeA: CodeChain;
     const promiseExpect = new PromiseExpect();
 
     beforeEach(async function() {
-        nodeA = new CodeChain({
-            base: BASE
-        });
+        nodeA = new CodeChain();
 
         await nodeA.start(["--no-tx-relay"]);
     });
@@ -45,9 +41,7 @@ describe("Handle future transactions", function() {
 
         beforeEach(async function() {
             this.timeout(60_000);
-            nodeB = new CodeChain({
-                base: BASE
-            });
+            nodeB = new CodeChain();
             await nodeB.start(["--no-tx-relay"]);
             await promiseExpect.shouldFulfill("connect", nodeB.connect(nodeA));
         });

--- a/test/src/e2e.long/invalidBlockPropagation.helper.ts
+++ b/test/src/e2e.long/invalidBlockPropagation.helper.ts
@@ -23,10 +23,9 @@ import "mocha";
 import Test = Mocha.Test;
 import CodeChain from "../helper/spawn";
 
-async function setup(base: number): Promise<[Header, Block, Header]> {
+async function setup(): Promise<[Header, Block, Header]> {
     const temporaryNode = new CodeChain({
-        argv: ["--force-sealing"],
-        base
+        argv: ["--force-sealing"]
     });
     await temporaryNode.start();
 
@@ -88,8 +87,8 @@ async function setup(base: number): Promise<[Header, Block, Header]> {
     return [header0, block1, header2];
 }
 
-async function setupEach(base: number): Promise<[CodeChain, TestHelper]> {
-    const node = new CodeChain({ base });
+async function setupEach(): Promise<[CodeChain, TestHelper]> {
+    const node = new CodeChain();
     await node.start();
     const TH = new TestHelper("0.0.0.0", node.port, "tc");
     await TH.establish();
@@ -211,18 +210,16 @@ export function createTestSuite(
         let block1: Block;
         let header2: Header;
 
-        const BASE = 300 + testNumber * 5;
-
         // tslint:disable only-arrow-functions
         before(async function() {
             // tslint:enable only-arrow-functions
-            [header0, block1, header2] = await setup(BASE);
+            [header0, block1, header2] = await setup();
         });
 
         // tslint:disable only-arrow-functions
         beforeEach(async function() {
             // tslint:enable only-arrow-functions
-            [node, TH] = await setupEach(BASE);
+            [node, TH] = await setupEach();
         });
 
         afterEach(async function() {

--- a/test/src/e2e.long/mempool.test.ts
+++ b/test/src/e2e.long/mempool.test.ts
@@ -20,16 +20,13 @@ import { wait } from "../helper/promise";
 import CodeChain from "../helper/spawn";
 import { SignedTransaction } from "codechain-sdk/lib/core/classes";
 
-const BASE = 200;
-
 describe("Memory pool size test", function() {
     let nodeA: CodeChain;
     const sizeLimit: number = 4;
 
     beforeEach(async function() {
         nodeA = new CodeChain({
-            argv: ["--mem-pool-size", sizeLimit.toString()],
-            base: BASE
+            argv: ["--mem-pool-size", sizeLimit.toString()]
         });
         await nodeA.start();
         await nodeA.sdk.rpc.devel.stopSealing();
@@ -55,8 +52,7 @@ describe("Memory pool size test", function() {
                     sizeLimit.toString(),
                     "--bootstrap-addresses",
                     `127.0.0.1:${nodeA.port}`
-                ],
-                base: BASE
+                ]
             });
             await nodeB.start();
             await nodeB.sdk.rpc.devel.stopSealing();
@@ -161,8 +157,7 @@ describe("Memory pool memory limit test", function() {
     beforeEach(async function() {
         nodeA = new CodeChain({
             chain: `${__dirname}/../scheme/mempool.json`,
-            argv: ["--mem-pool-mem-limit", memoryLimit.toString()],
-            base: BASE
+            argv: ["--mem-pool-mem-limit", memoryLimit.toString()]
         });
         await nodeA.start();
         await nodeA.sdk.rpc.devel.stopSealing();
@@ -183,8 +178,7 @@ describe("Memory pool memory limit test", function() {
             this.timeout(60_000);
             nodeB = new CodeChain({
                 chain: `${__dirname}/../scheme/mempool.json`,
-                argv: ["--mem-pool-mem-limit", memoryLimit.toString()],
-                base: BASE
+                argv: ["--mem-pool-mem-limit", memoryLimit.toString()]
             });
             await nodeB.start();
             await nodeB.sdk.rpc.devel.stopSealing();

--- a/test/src/e2e.long/onChainBlockValid.test.ts
+++ b/test/src/e2e.long/onChainBlockValid.test.ts
@@ -42,12 +42,9 @@ describe("Test onChain block communication", async function() {
         "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0"
     );
 
-    const BASE = 350;
-
     before(async function() {
         const node = new CodeChain({
-            argv: ["--force-sealing"],
-            base: BASE
+            argv: ["--force-sealing"]
         });
         await node.start();
 
@@ -113,7 +110,7 @@ describe("Test onChain block communication", async function() {
         VALID_STATEROOT = block1.stateRoot;
         VALID_INVOICEROOT = block1.invoicesRoot;
 
-        nodeA = new CodeChain({ base: BASE });
+        nodeA = new CodeChain();
         await nodeA.start();
         TH = new TestHelper("0.0.0.0", nodeA.port, "tc");
         await TH.establish();

--- a/test/src/e2e.long/onChainTx.test.ts
+++ b/test/src/e2e.long/onChainTx.test.ts
@@ -63,10 +63,8 @@ describe("Test onChain transaction communication", function() {
         }
     ];
 
-    const BASE = 400;
-
     beforeEach(async function() {
-        nodeA = new CodeChain({ base: BASE });
+        nodeA = new CodeChain();
         await nodeA.start();
     });
 

--- a/test/src/e2e.long/orders.test.ts
+++ b/test/src/e2e.long/orders.test.ts
@@ -32,11 +32,10 @@ import { ERROR } from "../helper/error";
 import CodeChain from "../helper/spawn";
 
 describe("orders", function() {
-    const BASE = 750;
     let node: CodeChain;
 
     before(async function() {
-        node = new CodeChain({ base: BASE });
+        node = new CodeChain();
         await node.start();
     });
 

--- a/test/src/e2e.long/reward2.test.ts
+++ b/test/src/e2e.long/reward2.test.ts
@@ -24,18 +24,14 @@ describe("reward2", function() {
     let nodeA: CodeChain;
     let nodeB: CodeChain;
 
-    const BASE = 500;
-
     beforeEach(async function() {
         nodeA = new CodeChain({
             chain: `${__dirname}/../scheme/solo-block-reward-50.json`,
-            argv: ["--author", aliceAddress.toString(), "--force-sealing"],
-            base: BASE
+            argv: ["--author", aliceAddress.toString(), "--force-sealing"]
         });
         nodeB = new CodeChain({
             chain: `${__dirname}/../scheme/solo-block-reward-50.json`,
-            argv: ["--author", bobAddress.toString(), "--force-sealing"],
-            base: BASE
+            argv: ["--author", bobAddress.toString(), "--force-sealing"]
         });
 
         await Promise.all([nodeA.start(), nodeB.start()]);

--- a/test/src/e2e.long/sync2.test.ts
+++ b/test/src/e2e.long/sync2.test.ts
@@ -23,14 +23,13 @@ const describeSkippedInTravis =
     process.env.TRAVIS_OS_NAME === "osx" ? describe.skip : describe;
 
 describeSkippedInTravis("sync 2 nodes", function() {
-    const BASE = 600;
     let nodeA: CodeChain;
     let nodeB: CodeChain;
 
     describe("2 nodes", function() {
         beforeEach(async function() {
-            nodeA = new CodeChain({ base: BASE });
-            nodeB = new CodeChain({ base: BASE });
+            nodeA = new CodeChain();
+            nodeB = new CodeChain();
 
             await Promise.all([nodeA.start(), nodeB.start()]);
         });
@@ -315,8 +314,8 @@ describeSkippedInTravis("sync 2 nodes", function() {
         const testSize: number = 5;
 
         beforeEach(async function() {
-            nodeA = new CodeChain({ base: BASE });
-            nodeB = new CodeChain({ base: BASE });
+            nodeA = new CodeChain();
+            nodeB = new CodeChain();
 
             await Promise.all([
                 nodeA.start(["--no-tx-relay"]),

--- a/test/src/e2e.long/sync3.test.ts
+++ b/test/src/e2e.long/sync3.test.ts
@@ -22,7 +22,6 @@ const describeSkippedInTravis =
     process.env.TRAVIS_OS_NAME === "osx" ? describe.skip : describe;
 
 describeSkippedInTravis("sync 3 nodes", function() {
-    const BASE = 650;
     const NUM_NODES = 3;
     let nodes: CodeChain[];
 
@@ -32,8 +31,7 @@ describeSkippedInTravis("sync 3 nodes", function() {
         nodes = [];
         for (let i = 0; i < NUM_NODES; i++) {
             const node = new CodeChain({
-                argv: ["--no-discovery"],
-                base: BASE
+                argv: ["--no-discovery"]
             });
             nodes.push(node);
         }

--- a/test/src/e2e.long/sync5.test.ts
+++ b/test/src/e2e.long/sync5.test.ts
@@ -22,7 +22,6 @@ const describeSkippedInTravis =
     process.env.TRAVIS_OS_NAME === "osx" ? describe.skip : describe;
 
 describeSkippedInTravis("sync 5 nodes", function() {
-    const BASE = 900;
     const NUM_NODES = 5;
     let nodes: CodeChain[];
 
@@ -32,8 +31,7 @@ describeSkippedInTravis("sync 5 nodes", function() {
         nodes = [];
         for (let i = 0; i < NUM_NODES; i++) {
             const node = new CodeChain({
-                argv: ["--no-discovery"],
-                base: BASE
+                argv: ["--no-discovery"]
             });
             nodes.push(node);
         }

--- a/test/src/e2e.long/tendermint.test.ts
+++ b/test/src/e2e.long/tendermint.test.ts
@@ -38,7 +38,6 @@ const RLP = require("rlp");
 
 describeSkippedInTravis("Tendermint ", function() {
     const promiseExpect = new PromiseExpect();
-    const BASE = 800;
     let nodes: CodeChain[];
 
     beforeEach(async function() {
@@ -61,7 +60,6 @@ describeSkippedInTravis("Tendermint ", function() {
                     "--force-sealing",
                     "--no-discovery"
                 ],
-                base: BASE,
                 additionalKeysPath: "tendermint/keys"
             });
         });
@@ -357,7 +355,6 @@ describeSkippedInTravis("Tendermint ", function() {
                     "test/tendermint/password.json",
                     "--no-discovery"
                 ],
-                base: BASE,
                 additionalKeysPath: "tendermint/keys"
             });
         }

--- a/test/src/e2e.long/timelock.test.ts
+++ b/test/src/e2e.long/timelock.test.ts
@@ -25,15 +25,12 @@ import "mocha";
 import { wait } from "../helper/promise";
 import CodeChain from "../helper/spawn";
 
-const BASE = 250;
-
 describe("Timelock", function() {
     let node: CodeChain;
 
     beforeEach(async function() {
         node = new CodeChain({
-            argv: ["--force-sealing", "--no-reseal-timer"],
-            base: BASE
+            argv: ["--force-sealing", "--no-reseal-timer"]
         });
         await node.start();
     });

--- a/test/src/e2e.long/transactions.test.ts
+++ b/test/src/e2e.long/transactions.test.ts
@@ -45,9 +45,8 @@ import CodeChain from "../helper/spawn";
 
 describe("transactions", function() {
     let node: CodeChain;
-    const BASE = 700;
     before(async function() {
-        node = new CodeChain({ base: BASE });
+        node = new CodeChain();
         await node.start();
     });
 

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -110,12 +110,11 @@ export default class CodeChain {
             chain?: ChainType;
             argv?: string[];
             additionalKeysPath?: string;
-            base?: number;
             rpcPort?: number;
         } = {}
     ) {
-        const { chain, argv, additionalKeysPath, base = 0 } = options;
-        this._id = base + CodeChain.idCounter++;
+        const { chain, argv, additionalKeysPath } = options;
+        this._id = CodeChain.idCounter++;
 
         const { rpcPort = 8081 + this.id } = options;
         this._rpcPort = rpcPort;

--- a/test/src/tendermint.test/local.ts
+++ b/test/src/tendermint.test/local.ts
@@ -27,7 +27,6 @@ import { makeRandomH256 } from "../helper/random";
 import CodeChain from "../helper/spawn";
 
 (async () => {
-    const BASE = 1000;
     let nodes: CodeChain[];
 
     const validatorAddresses = [
@@ -48,7 +47,6 @@ import CodeChain from "../helper/spawn";
                 "--no-discovery",
                 "--enable-devel-api"
             ],
-            base: BASE,
             additionalKeysPath: "tendermint/keys"
         });
     });


### PR DESCRIPTION
It was introduced to run the tests in parallel. But it was not used anymore because parallel running doesn't reduce tests time.