### PR TITLE
Add a type wrapper for a password

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -26,6 +26,7 @@ pub mod aes;
 mod blake;
 pub mod error;
 mod hash;
+mod password;
 pub mod pbkdf2;
 pub mod scrypt;
 
@@ -38,10 +39,11 @@ pub const KEY_ITERATIONS: usize = 10240;
 pub const KEY_LENGTH_AES: usize = KEY_LENGTH / 2;
 
 pub use crate::blake::*;
-
 pub use crate::hash::{keccak256, ripemd160, sha1, sha256};
+pub use crate::password::Password;
 
-pub fn derive_key_iterations(password: &str, salt: &[u8; 32], c: NonZeroU32) -> (Vec<u8>, Vec<u8>) {
+// Do not move Password. It will make debugger print the password.
+pub fn derive_key_iterations(password: &Password, salt: &[u8; 32], c: NonZeroU32) -> (Vec<u8>, Vec<u8>) {
     let mut derived_key = [0u8; KEY_LENGTH];
     pbkdf2::sha256(c, &pbkdf2::Salt(salt), &pbkdf2::Secret(password.as_bytes()), &mut derived_key);
     let derived_right_bits = &derived_key[0..KEY_LENGTH_AES];

--- a/crypto/src/password.rs
+++ b/crypto/src/password.rs
@@ -1,0 +1,27 @@
+// Copyright 2019 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::ops::Deref;
+
+pub struct Password<'a>(pub &'a str);
+
+impl<'a> Deref for Password<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crypto/src/scrypt.rs
+++ b/crypto/src/scrypt.rs
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::error::ScryptError;
-use crate::{KEY_LENGTH, KEY_LENGTH_AES};
 use rcrypto::scrypt::{scrypt, ScryptParams};
 
-pub fn derive_key(pass: &str, salt: &[u8; 32], n: u32, p: u32, r: u32) -> Result<(Vec<u8>, Vec<u8>), ScryptError> {
+use crate::error::ScryptError;
+use crate::{Password, KEY_LENGTH, KEY_LENGTH_AES};
+
+// Do not move Password. It will make debugger print the password.
+pub fn derive_key(pass: &Password, salt: &[u8; 32], n: u32, p: u32, r: u32) -> Result<(Vec<u8>, Vec<u8>), ScryptError> {
     // sanity checks
     let log_n = (32 - n.leading_zeros() - 1) as u8;
     if u32::from(log_n) >= r * 16 {

--- a/key/src/password.rs
+++ b/key/src/password.rs
@@ -17,6 +17,7 @@
 use std::str::FromStr;
 use std::{fmt, ptr};
 
+use crypto::Password as CryptoPassword;
 use never::Never;
 
 #[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,12 +30,8 @@ impl fmt::Debug for Password {
 }
 
 impl Password {
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
+    pub fn as_crypto_password(&self) -> CryptoPassword {
+        CryptoPassword(self.0.as_str())
     }
 }
 


### PR DESCRIPTION
Currently, crypto module uses &str for a password. It makes a debugger
print the password on a back trace. The wrapper cannot protect from
memory reading since it's still on a continuous memory. But it will help
to prevent the users leak their password unintentionally when they
report a bug.
Of course, using a prettier in debugger cannot be prevented. This is
just a minimal action.