### PR TITLE
Fix a bug that prevents creating a connection to a remote node

### DIFF
--- a/network/src/p2p/connection/outgoing.rs
+++ b/network/src/p2p/connection/outgoing.rs
@@ -36,8 +36,13 @@ pub struct OutgoingConnection {
 }
 
 impl OutgoingConnection {
-    pub fn new(stream: Stream, initiator_pub_key: Public, network_id: NetworkId, initiator_port: u16) -> Result<Self> {
-        let peer_addr = stream.peer_addr()?;
+    pub fn new(
+        stream: Stream,
+        initiator_pub_key: Public,
+        network_id: NetworkId,
+        initiator_port: u16,
+        peer_addr: SocketAddr,
+    ) -> Result<Self> {
         Ok(Self {
             stream,
             initiator_pub_key,

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -202,7 +202,8 @@ impl Handler {
             let mut outgoing_connections = self.outgoing_connections.write();
             // Please make sure there is no early return after it.
             let initiator_port = self.socket_address.port();
-            let con = OutgoingConnection::new(stream, initiator_pub_key, self.network_id, initiator_port)?;
+            let con =
+                OutgoingConnection::new(stream, initiator_pub_key, self.network_id, initiator_port, socket_address)?;
             let token = outgoing_tokens.gen().ok_or("Too many outgoing connections")?;
             let t = outgoing_connections.insert(token, con);
             assert!(t.is_none());


### PR DESCRIPTION
It's because I queried the peer address right after I request a connection.
There can be no peer because creating a connection also non-blocking.