### PR TITLE
Forbid non-active user be registered as special users

### DIFF
--- a/state/src/impls/test_helper.rs
+++ b/state/src/impls/test_helper.rs
@@ -481,6 +481,11 @@ macro_rules! set_top_level_state {
 
         set_top_level_state!($state, [$($x),*]);
     };
+    ($state:expr, [(account: $addr:expr => seq: $seq:expr) $(,$x:tt)*]) => {
+        assert_eq!(Ok(()), $state.set_seq(&$addr, $seq));
+
+        set_top_level_state!($state, [$($x),*]);
+    };
     ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*]) $(,$x:tt)*]) => {
         set_top_level_state!($state, [(shard: $shard_id => owners: [$($owner),*], users: Vec::new()) $(,$x)*]);
     };

--- a/state/src/item/account.rs
+++ b/state/src/item/account.rs
@@ -52,6 +52,10 @@ impl Account {
         }
     }
 
+    pub fn is_active(&self) -> bool {
+        !self.is_null()
+    }
+
     /// return the balance associated with this account.
     pub fn balance(&self) -> u64 {
         self.balance
@@ -87,6 +91,11 @@ impl Account {
     #[cfg(test)]
     pub fn set_balance(&mut self, x: u64) {
         self.balance = x;
+    }
+
+    #[cfg(test)]
+    pub fn set_seq(&mut self, x: u64) {
+        self.seq = x;
     }
 
     /// Set the regular key of the account.

--- a/test/src/e2e/shard.test.ts
+++ b/test/src/e2e/shard.test.ts
@@ -35,9 +35,16 @@ describe("CreateShard", function() {
 
     it("Create 1 shard", async function() {
         const seq: number = (await node.sdk.rpc.chain.getSeq(faucetAddress))!;
+
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: aliceAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq, fee: 10 })
+        );
+
         const tx = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress] })
-            .sign({ secret: faucetSecret, seq, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 });
         const beforeShardId = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
             [tx.hash(), null]
@@ -83,9 +90,20 @@ describe("CreateShard", function() {
 
     it("setShardUsers", async function() {
         const seq: number = (await node.sdk.rpc.chain.getSeq(faucetAddress))!;
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: aliceAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq, fee: 10 })
+        );
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: bobAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 })
+        );
+
         const tx = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress] })
-            .sign({ secret: faucetSecret, seq, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 2, fee: 10 });
         await node.sdk.rpc.chain.sendSignedTransaction(tx);
         const shardId = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
@@ -95,7 +113,7 @@ describe("CreateShard", function() {
         const users = [aliceAddress, bobAddress];
         const setShardUsers = node.sdk.core
             .createSetShardUsersTransaction({ shardId, users })
-            .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 3, fee: 10 });
         await node.sdk.rpc.chain.sendSignedTransaction(setShardUsers);
         const shardUsers = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardUsers",
@@ -106,9 +124,19 @@ describe("CreateShard", function() {
 
     it("setShardOwners", async function() {
         const seq: number = (await node.sdk.rpc.chain.getSeq(faucetAddress))!;
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: aliceAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq, fee: 10 })
+        );
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: bobAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 })
+        );
         const tx = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress, bobAddress] })
-            .sign({ secret: faucetSecret, seq, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 2, fee: 10 });
         await node.sdk.rpc.chain.sendSignedTransaction(tx);
         const shardId = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
@@ -118,7 +146,7 @@ describe("CreateShard", function() {
         const owners = [aliceAddress, faucetAddress, bobAddress];
         const setShardOwners = node.sdk.core
             .createSetShardOwnersTransaction({ shardId, owners })
-            .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 3, fee: 10 });
         await node.sdk.rpc.chain.sendSignedTransaction(setShardOwners);
         const shardOwners = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardOwners",
@@ -129,9 +157,19 @@ describe("CreateShard", function() {
 
     it("Create 2 shards", async function() {
         const seq: number = (await node.sdk.rpc.chain.getSeq(faucetAddress))!;
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: aliceAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq, fee: 10 })
+        );
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: bobAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 })
+        );
         const tx1 = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress, bobAddress] })
-            .sign({ secret: faucetSecret, seq, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 2, fee: 10 });
         const beforeShardId1 = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
             [tx1.hash(), null]
@@ -151,7 +189,7 @@ describe("CreateShard", function() {
 
         const tx2 = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress, bobAddress] })
-            .sign({ secret: faucetSecret, seq: seq + 1, fee: 10 });
+            .sign({ secret: faucetSecret, seq: seq + 3, fee: 10 });
         const beforeShardId2 = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
             [tx2.hash(), null]
@@ -174,9 +212,19 @@ describe("CreateShard", function() {
         const faucetSeq: number = (await node.sdk.rpc.chain.getSeq(
             faucetAddress
         ))!;
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: aliceAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq: faucetSeq, fee: 10 })
+        );
+        await node.sdk.rpc.chain.sendSignedTransaction(
+            node.sdk.core
+                .createPayTransaction({ recipient: bobAddress, quantity: 1 })
+                .sign({ secret: faucetSecret, seq: faucetSeq + 1, fee: 10 })
+        );
         const createShard = node.sdk.core
             .createCreateShardTransaction({ users: [aliceAddress] })
-            .sign({ secret: faucetSecret, seq: faucetSeq, fee: 10 });
+            .sign({ secret: faucetSecret, seq: faucetSeq + 2, fee: 10 });
         await node.sdk.rpc.chain.sendSignedTransaction(createShard);
         const shardId = await node.sdk.rpc.sendRpcRequest(
             "chain_getShardIdByHash",
@@ -188,7 +236,7 @@ describe("CreateShard", function() {
                     recipient: bobAddress,
                     quantity: 100
                 })
-                .sign({ secret: faucetSecret, seq: faucetSeq + 1, fee: 10 })
+                .sign({ secret: faucetSecret, seq: faucetSeq + 3, fee: 10 })
         );
 
         const bobSeq: number = (await node.sdk.rpc.chain.getSeq(bobAddress))!;


### PR DESCRIPTION
The active account means the account that has ever had the balance. In
other words, it's the account that has non-zero balance or seq. This
term is introduced in this commit but the concept is already used. The
public key of the account that has non-zero balance or seq cannot be
used as a regular key.

This commit forbids the non-active account becoming the shard users,
shard owners, the administrator of the asset or the approver. If it's
allowed the regular account to be special users, criteria for which of
the master account and the regular account becomes a special user is not
intuitive. It's a restriction to make the logic simple.