### PR TITLE
Run e2e test and unit test on the same worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,68 +10,48 @@ stages:
 jobs:
   include:
     - stage: test
-      name: test-osx
-      os: osx
-      before_install:
-        - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-        - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-        - SKIP=`.travis/check-change '^test/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-      install:
-        - rustup toolchain install nightly-2018-12-06
-        - rustup component add rustfmt-preview --toolchain nightly-2018-12-06
-        - rustup component add clippy-preview --toolchain nightly-2018-12-06
-      before_script:
-        - cargo fetch --verbose
-      script:
-        - cargo +nightly-2018-12-06 fmt -- --check || exit 1
-        - cargo +nightly-2018-12-06 clippy --all --all-targets -- -D warnings || exit 1
-        - RUST_BACKTRACE=1 cargo test --verbose --all || exit 1
-    - name: int-test-osx
       os: osx
       before_install:
         - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
         - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
       install:
+        - SKIP=`.travis/check-change '^test/'` && if [[ "$SKIP" != "skip" ]]; then RUN_UNIT_TEST=1; fi
+        - test $RUN_UNIT_TEST && rustup toolchain install nightly-2018-12-06
+        - test $RUN_UNIT_TEST && rustup component add rustfmt-preview --toolchain nightly-2018-12-06
+        - test $RUN_UNIT_TEST && rustup component add clippy-preview --toolchain nightly-2018-12-06
         - nvm install 10
         - nvm use 10
         - npm install -g yarn
       before_script:
         - cargo fetch --verbose
       script:
+        - test $RUN_UNIT_TEST && (cargo +nightly-2018-12-06 fmt -- --check || exit 1)
+        - test $RUN_UNIT_TEST && (cargo +nightly-2018-12-06 clippy --all --all-targets -- -D warnings || exit 1)
+        - test $RUN_UNIT_TEST && (RUST_BACKTRACE=1 cargo test --verbose --all || exit 1)
         - cd test && yarn && yarn lint || exit 1
         - cargo build || exit 1
         - INT_TEST_FLAG=true && yarn start-short
         - yarn start-long
       after_failure:
         - test $INT_TEST_FLAG && ./upload_logs.sh
-    - name: test-linux
-      os: linux
-      before_install:
-        - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-        - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-        - SKIP=`.travis/check-change '^test/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
-      install:
-        - rustup toolchain install nightly-2018-12-06
-        - rustup component add rustfmt-preview --toolchain nightly-2018-12-06
-        - rustup component add clippy-preview --toolchain nightly-2018-12-06
-      before_script:
-        - cargo fetch --verbose
-      script:
-        - cargo +nightly-2018-12-06 fmt -- --check || exit 1
-        - cargo +nightly-2018-12-06 clippy --all --all-targets -- -D warnings || exit 1
-        - RUST_BACKTRACE=1 cargo test --verbose --all || exit 1
-    - name: int-test-linux
-      os: linux
+    - os: linux
       before_install:
         - SKIP=`.travis/check-mergify-merge` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
         - SKIP=`.travis/check-change '^(docs|spec)/'` && if [[ "$SKIP" = "skip" ]]; then exit 0; fi
       install:
+        - SKIP=`.travis/check-change '^test/'` && if [[ "$SKIP" != "skip" ]]; then RUN_UNIT_TEST=1; fi
+        - test $RUN_UNIT_TEST && rustup toolchain install nightly-2018-12-06
+        - test $RUN_UNIT_TEST && rustup component add rustfmt-preview --toolchain nightly-2018-12-06
+        - test $RUN_UNIT_TEST && rustup component add clippy-preview --toolchain nightly-2018-12-06
         - nvm install 10
         - nvm use 10
         - npm install -g yarn
       before_script:
         - cargo fetch --verbose
       script:
+        - test $RUN_UNIT_TEST && (cargo +nightly-2018-12-06 fmt -- --check || exit 1)
+        - test $RUN_UNIT_TEST && (cargo +nightly-2018-12-06 clippy --all --all-targets -- -D warnings || exit 1)
+        - test $RUN_UNIT_TEST && (RUST_BACKTRACE=1 cargo test --verbose --all || exit 1)
         - cd test && yarn && yarn lint || exit 1
         - cargo build || exit 1
         - INT_TEST_FLAG=true && yarn start-short


### PR DESCRIPTION
The e2e tests were not stable and it needed to be re-run separately. But now, it becomes stable and no reason to split the worker.

It will save about 20 minutes per work.