### PR TITLE
Fix sync extension bugs

### DIFF
--- a/sync/src/block/downloader/header.rs
+++ b/sync/src/block/downloader/header.rs
@@ -73,9 +73,14 @@ impl HeaderDownloader {
         }
     }
 
-    pub fn update(&mut self, total_score: U256, best_hash: H256) {
-        self.total_score = total_score;
-        self.best_hash = best_hash;
+    pub fn update(&mut self, total_score: U256, best_hash: H256) -> bool {
+        if self.total_score < total_score {
+            self.total_score = total_score;
+            self.best_hash = best_hash;
+            true
+        } else {
+            false
+        }
     }
 
     fn is_valid(&self) -> bool {


### PR DESCRIPTION
It fixes two bugs.
1. If a block is created between an on_node_added event and a status update message, the status update message for the new block is not propagated.

2. The sync module keeps the last status message. So if there is two status message in a short period, and the on_message event order is changed, it keeps the old best hash.