### PR TITLE
When the height is changed, the step should be the Propose step

### DIFF
--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -1364,7 +1364,7 @@ impl ChainNotify for TendermintChainNotify {
                 }
             }
             if height_changed {
-                t.move_to_step(Step::Commit, false);
+                t.move_to_step(Step::Propose, false);
                 return
             }
         }


### PR DESCRIPTION
In the past, since the Commit state is the first state of the height,
the step is changed to the Commit step after a block is imported.

However, in the current, the Commit step is the last step of the
height.

This patch fixes the unchanged code in the past.