### PR TITLE
Fix the test to wait until the transaction goes into the mempool

### DIFF
--- a/test/src/e2e.long/onChainTx.test.ts
+++ b/test/src/e2e.long/onChainTx.test.ts
@@ -94,6 +94,7 @@ describe("Test onChain transaction communication", function() {
         await sdk.rpc.devel.stopSealing();
         await TH.sendEncodedTransaction([signed.toEncodeObject()]);
 
+        while ((await sdk.rpc.chain.getPendingTransactions()).length !== 1) {}
         const transactions = await sdk.rpc.chain.getPendingTransactions();
         expect(transactions.length).to.equal(1);
 


### PR DESCRIPTION
There can be some time between the node receives a transaction, and the transaction goes into the mempool.
The test failed if `getPendingTransaction` is called between them.