### PR TITLE
Make the network module try to have at least one connection

### DIFF
--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -56,8 +56,16 @@ fn network_start(
     let addr = cfg.address.parse().map_err(|_| format!("Invalid NETWORK listen host given: {}", cfg.address))?;
     let sockaddress = SocketAddr::new(addr, cfg.port);
     let filters = Filters::new(cfg.whitelist.clone(), cfg.blacklist.clone());
-    let service = NetworkService::start(network_id, timer_loop, sockaddress, cfg.min_peers, cfg.max_peers, filters)
-        .map_err(|e| format!("Network service error: {:?}", e))?;
+    let service = NetworkService::start(
+        network_id,
+        timer_loop,
+        sockaddress,
+        cfg.bootstrap_addresses.clone(),
+        cfg.min_peers,
+        cfg.max_peers,
+        filters,
+    )
+    .map_err(|e| format!("Network service error: {:?}", e))?;
 
     Ok(service)
 }
@@ -281,9 +289,6 @@ pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
 
             scheme.engine.register_network_extension_to_service(&service);
 
-            for address in network_config.bootstrap_addresses {
-                service.connect_to(address)?;
-            }
             service
         } else {
             Arc::new(DummyNetworkService::new())

--- a/network/src/routing_table.rs
+++ b/network/src/routing_table.rs
@@ -136,6 +136,14 @@ impl RoutingTable {
         })
     }
 
+    pub fn is_banned(&self, target: &SocketAddr) -> bool {
+        let entries = self.entries.read();
+        match entries.get(target) {
+            Some(State::Banned) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_establishing_or_established(&self, target: &SocketAddr) -> bool {
         let entries = self.entries.read();
         match entries.get(target) {

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -44,6 +44,7 @@ impl Service {
         network_id: NetworkId,
         timer_loop: TimerLoop,
         address: SocketAddr,
+        bootstrap_addresses: Vec<SocketAddr>,
         min_peers: usize,
         max_peers: usize,
         filters_control: Arc<FiltersControl>,
@@ -61,6 +62,7 @@ impl Service {
             Arc::clone(&client),
             Arc::clone(&routing_table),
             Arc::clone(&filters_control),
+            bootstrap_addresses,
             min_peers,
             max_peers,
         )?);


### PR DESCRIPTION
This patch makes the network module try to connect to bootstrap nodes
when there are no connections.
The module selects three nodes from the bootstrap addresses randomly to
make a various form of connection graph. But 3 is an unfounded magic
number. The number should be adjusted.