### PR TITLE
Fix travis scripts to comply with shellcheck

### DIFF
--- a/.travis/check-change
+++ b/.travis/check-change
@@ -29,8 +29,8 @@
 exec 3>&1 1>&2 # fd 3 = fd 1; fd 1 = fd 2
 
 function return_to_travis {
-    STRATEGY="${1}"
-    echo ${STRATEGY} >&3
+    STRATEGY=$1
+    echo "${STRATEGY}" >&3
     exit 0
 }
 function skip_travis { return_to_travis "skip" ; }
@@ -84,7 +84,7 @@ push)
         # we can find common ancestor of master and the branch.
         echo "Branch push"
         git fetch origin master:master;
-        BASE=`git merge-base master ${TRAVIS_COMMIT}`
+        BASE=$(git merge-base master "${TRAVIS_COMMIT}")
         COMMIT_RANGE="${BASE}...${TRAVIS_COMMIT}"
     fi
     ;;
@@ -101,7 +101,7 @@ esac
 
 git log --oneline --decorate --all --graph | head -n 10;
 echo "Check changes for: ${COMMIT_RANGE}"
-if ! git diff --name-only ${COMMIT_RANGE} | grep -qvE "$1"
+if ! git diff --name-only "${COMMIT_RANGE}" | grep -qvE "$1"
 then
     echo "Only '$1' were updated, or there's no change, not running the CI."
     skip_travis

--- a/.travis/check-change
+++ b/.travis/check-change
@@ -47,8 +47,8 @@ case ${TRAVIS_EVENT_TYPE} in
 push)
     if [[ "${TRAVIS_BRANCH}" = master ]]
     then
-        COMMIT_FROM=$(awk -F'\\.\\.\\.' '{ print $1 }' <<< "${TRAVIS_COMMIT_RANGE}")
-        COMMIT_TO=$(awk -F'\\.\\.\\.' '{ print $2 }' <<< "$TRAVIS_COMMIT_RANGE")
+        COMMIT_FROM=${TRAVIS_COMMIT_RANGE%...*}
+        COMMIT_TO=${TRAVIS_COMMIT_RANGE#*...}
 
         if ! git cat-file -e "${COMMIT_FROM}^{commit}"
         then

--- a/.travis/check-mergify-merge
+++ b/.travis/check-mergify-merge
@@ -7,7 +7,7 @@ exec 3>&1 1>&2 # fd 3 = fd 1; fd 1 = fd 2
 
 function return_to_travis {
     STRATEGY="${1}"
-    echo ${STRATEGY} >&3
+    echo "${STRATEGY}" >&3
     exit 0
 }
 function skip_travis { return_to_travis "skip" ; }
@@ -36,7 +36,7 @@ push)
 esac
 
 MERGIFY_COMMITTER="mergify[bot] <mergify[bot]@users.noreply.github.com>"
-COMMITTER=`git show --format="%cN <%cE>" --no-patch "${TRAVIS_COMMIT}"`
+COMMITTER=$(git show --format="%cN <%cE>" --no-patch "${TRAVIS_COMMIT}")
 
 if [[ "${COMMITTER}" = "${MERGIFY_COMMITTER}" ]]
 then


### PR DESCRIPTION
[shellcheck](https://www.shellcheck.net/) is a static analysis tool for shell scripts.

* quoting RHS of an assignment isn't necessary.
* ```SC2006: Use $(...) notation instead of legacy backticked `...` ```
* `A...B` format can be decomposed using bash [Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion)
 without using `awk`