### PR TITLE
Fix typo in spec/JSON-RPC.md

### DIFF
--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1487,7 +1487,7 @@ It returns `null` if the given block number is not mined yet.
 Executes the transactions and returns the current shard root and the changed shard root.
 
 ### Params
- 1. transaction: `Transaction`
+ 1. transaction: `UnsignedTransaction`
  2. sender: `PlatformAddress`
 
 ### Returns


### PR DESCRIPTION
I fixed a typo. 
The first argument of chain_executeTransaction is an UnsignedTransaction. (Not Transaction)