### PR TITLE
Give range to pending tx

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::ops::Range;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, Weak};
 use std::time::Instant;
@@ -53,7 +54,7 @@ use crate::error::{BlockImportError, Error, ImportError, SchemeError};
 use crate::miner::{Miner, MinerService};
 use crate::scheme::{CommonParams, Scheme};
 use crate::service::ClientIoMessage;
-use crate::transaction::{LocalizedTransaction, SignedTransaction, UnverifiedTransaction};
+use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, UnverifiedTransaction};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 
 const MAX_MEM_POOL_SIZE: usize = 4096;
@@ -637,12 +638,12 @@ impl BlockChainClient for Client {
         }
     }
 
-    fn ready_transactions(&self) -> Vec<SignedTransaction> {
-        self.importer.miner.ready_transactions()
+    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+        self.importer.miner.ready_transactions(range)
     }
 
-    fn count_pending_transactions(&self) -> usize {
-        self.importer.miner.count_pending_transactions()
+    fn count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.importer.miner.count_pending_transactions(range)
     }
 
     fn is_pending_queue_empty(&self) -> bool {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -29,6 +29,7 @@ pub use self::config::ClientConfig;
 pub use self::error::Error;
 pub use self::test_client::TestBlockChainClient;
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use ckey::{Address, PlatformAddress, Public};
@@ -47,7 +48,7 @@ use crate::blockchain_info::BlockChainInfo;
 use crate::encoded;
 use crate::error::{BlockImportError, Error as CoreError};
 use crate::scheme::CommonParams;
-use crate::transaction::{LocalizedTransaction, SignedTransaction};
+use crate::transaction::{LocalizedTransaction, PendingSignedTransactions};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 
 /// Provides `chain_info` method
@@ -230,10 +231,10 @@ pub trait BlockChainClient:
     fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: NodeId);
 
     /// List all transactions that are allowed into the next block.
-    fn ready_transactions(&self) -> Vec<SignedTransaction>;
+    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 
     /// Get the count of all pending transactions currently in the mem_pool.
-    fn count_pending_transactions(&self) -> usize;
+    fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Check there are transactions which are allowed into the next block.
     fn is_pending_queue_empty(&self) -> bool;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -32,6 +32,7 @@
 
 use std::collections::HashMap;
 use std::mem;
+use std::ops::Range;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrder};
 use std::sync::Arc;
 
@@ -65,7 +66,7 @@ use crate::error::BlockImportError;
 use crate::header::Header as BlockHeader;
 use crate::miner::{Miner, MinerService, TransactionImportResult};
 use crate::scheme::Scheme;
-use crate::transaction::{LocalizedTransaction, SignedTransaction};
+use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
 use crate::types::{BlockId, TransactionId, VerificationQueueInfo as QueueInfo};
 
 /// Test client.
@@ -494,12 +495,12 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.import_external_tranasctions(self, transactions);
     }
 
-    fn ready_transactions(&self) -> Vec<SignedTransaction> {
-        self.miner.ready_transactions()
+    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+        self.miner.ready_transactions(range)
     }
 
-    fn count_pending_transactions(&self) -> usize {
-        self.miner.count_pending_transactions()
+    fn count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.miner.count_pending_transactions(range)
     }
 
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,6 +54,7 @@ extern crate util_error;
 
 #[macro_use]
 extern crate log;
+extern crate core;
 
 mod account_provider;
 pub mod block;
@@ -92,5 +93,7 @@ pub use crate::header::{Header, Seal};
 pub use crate::miner::{Miner, MinerOptions, MinerService, Stratum, StratumConfig, StratumError};
 pub use crate::scheme::Scheme;
 pub use crate::service::ClientService;
-pub use crate::transaction::{LocalizedTransaction, SignedTransaction, UnverifiedTransaction};
+pub use crate::transaction::{
+    LocalizedTransaction, PendingSignedTransactions, SignedTransaction, UnverifiedTransaction,
+};
 pub use crate::types::{BlockId, TransactionId};

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -16,6 +16,7 @@
 
 use std::cmp;
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::ops::Range;
 use std::sync::Arc;
 
 use ckey::{public_to_address, Public};
@@ -34,7 +35,7 @@ use super::mem_pool_types::{
 };
 use super::TransactionImportResult;
 use crate::client::{AccountData, BlockChain, RegularKeyOwner};
-use crate::transaction::SignedTransaction;
+use crate::transaction::{PendingSignedTransactions, SignedTransaction};
 use crate::Error as CoreError;
 
 const DEFAULT_POOLING_PERIOD: BlockNumber = 128;
@@ -276,7 +277,7 @@ impl MemPool {
 
             let id = self.next_transaction_id;
             self.next_transaction_id += 1;
-            let item = MemPoolItem::new(tx, origin, inserted_block_number, id, timelock);
+            let item = MemPoolItem::new(tx, origin, inserted_block_number, inserted_timestamp, id, timelock);
             let order = TransactionOrder::for_transaction(&item, client_account.seq);
             let order_with_tag = TransactionOrderWithTag::new(order, QueueTag::New);
 
@@ -881,11 +882,18 @@ impl MemPool {
         self.next_seqs.clear();
     }
 
-    /// Returns top transactions from the pool ordered by priority.
+    /// Returns top transactions whose timestamp are in the given range from the pool ordered by priority.
     // FIXME: current_timestamp should be `u64`, not `Option<u64>`.
-    pub fn top_transactions(&self, size_limit: usize, current_timestamp: Option<u64>) -> Vec<SignedTransaction> {
+    // FIXME: if range_contains becomes stable, use range.contains instead of inequality.
+    pub fn top_transactions(
+        &self,
+        size_limit: usize,
+        current_timestamp: Option<u64>,
+        range: Range<u64>,
+    ) -> PendingSignedTransactions {
         let mut current_size: usize = 0;
-        self.current
+        let pending_items: Vec<_> = self
+            .current
             .queue
             .iter()
             .map(|t| {
@@ -901,19 +909,37 @@ impl MemPool {
                 }
                 true
             })
+            .filter(|t| range.start <= t.inserted_timestamp && t.inserted_timestamp < range.end)
             .take_while(|t| {
                 let encoded_byte_array: Vec<u8> = rlp::encode(&t.tx).into_vec();
                 let size_in_byte = encoded_byte_array.len();
                 current_size += size_in_byte;
                 current_size < size_limit
             })
-            .map(|t| t.tx.clone())
-            .collect()
+            .collect();
+
+        let transactions = pending_items.iter().map(|t| t.tx.clone()).collect();
+        let last_timestamp = pending_items.into_iter().map(|t| t.inserted_timestamp).max();
+
+        PendingSignedTransactions {
+            transactions,
+            last_timestamp,
+        }
     }
 
-    /// Return all transactions in the memory pool.
-    pub fn count_pending_transactions(&self) -> usize {
-        self.current.queue.len() + self.future.queue.len()
+    /// Return all transactions whose timestamp are in the given range in the memory pool.
+    pub fn count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.current
+            .queue
+            .iter()
+            .chain(self.future.queue.iter())
+            .map(|t| {
+                self.by_hash
+                    .get(&t.hash)
+                    .expect("All transactions in `current` and `future` are always included in `by_hash`")
+            })
+            .filter(|t| range.start <= t.inserted_timestamp && t.inserted_timestamp < range.end)
+            .count()
     }
 
     /// Return all future transactions.
@@ -1233,7 +1259,7 @@ pub mod test {
         };
         let keypair = Random.generate().unwrap();
         let signed = SignedTransaction::new_with_sign(tx, keypair.private());
-        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, timelock);
+        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, 0, timelock);
 
         assert_eq!(fee, item.cost());
     }
@@ -1262,7 +1288,7 @@ pub mod test {
         };
         let keypair = Random.generate().unwrap();
         let signed = SignedTransaction::new_with_sign(tx, keypair.private());
-        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, timelock);
+        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, 0, timelock);
 
         assert_eq!(fee, item.cost());
     }
@@ -1287,7 +1313,7 @@ pub mod test {
             timestamp: None,
         };
         let signed = SignedTransaction::new_with_sign(tx, keypair.private());
-        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, timelock);
+        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, 0, timelock);
 
         assert_eq!(fee + quantity, item.cost());
     }
@@ -1389,7 +1415,7 @@ pub mod test {
             timestamp: None,
         };
         let signed = SignedTransaction::new_with_sign(tx, keypair.private());
-        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, timelock);
+        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, 0, timelock);
 
         rlp_encode_and_decode_test!(item);
     }
@@ -1512,7 +1538,7 @@ pub mod test {
             timestamp: None,
         };
         let signed = SignedTransaction::new_with_sign(tx, keypair.private());
-        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, timelock);
+        let item = MemPoolItem::new(signed, TxOrigin::Local, 0, 0, 0, timelock);
         TransactionOrder::for_transaction(&item, 0)
     }
 }

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -211,6 +211,8 @@ pub struct MemPoolItem {
     pub origin: TxOrigin,
     /// Insertion time
     pub inserted_block_number: PoolingInstant,
+    /// Insertion timstamp
+    pub inserted_timestamp: u64,
     /// ID assigned upon insertion, should be unique.
     pub insertion_id: u64,
     /// A timelock.
@@ -222,6 +224,7 @@ impl MemPoolItem {
         tx: SignedTransaction,
         origin: TxOrigin,
         inserted_block_number: PoolingInstant,
+        inserted_timestamp: u64,
         insertion_id: u64,
         timelock: TxTimelock,
     ) -> Self {
@@ -229,6 +232,7 @@ impl MemPoolItem {
             tx,
             origin,
             inserted_block_number,
+            inserted_timestamp,
             insertion_id,
             timelock,
         }

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -23,6 +23,8 @@ mod sealing_queue;
 mod stratum;
 mod work_notify;
 
+use std::ops::Range;
+
 use ckey::{Address, Password, PlatformAddress};
 use cstate::{FindActionHandler, TopStateView};
 use ctypes::transaction::IncompleteTransaction;
@@ -39,7 +41,7 @@ use crate::client::{
 };
 use crate::consensus::EngineType;
 use crate::error::Error;
-use crate::transaction::{SignedTransaction, UnverifiedTransaction};
+use crate::transaction::{PendingSignedTransactions, SignedTransaction, UnverifiedTransaction};
 use crate::BlockId;
 
 /// Miner client API
@@ -136,10 +138,10 @@ pub trait MinerService: Send + Sync {
     ) -> Result<(H256, u64), Error>;
 
     /// Get a list of all pending transactions in the mem pool.
-    fn ready_transactions(&self) -> Vec<SignedTransaction>;
+    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 
     /// Get a count of all pending transactions in the mem pool.
-    fn count_pending_transactions(&self) -> usize;
+    fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Get a list of all future transactions.
     fn future_transactions(&self) -> Vec<SignedTransaction>;

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -157,6 +157,12 @@ pub struct SignedTransaction {
     signer_public: Public,
 }
 
+pub struct PendingSignedTransactions {
+    pub transactions: Vec<SignedTransaction>,
+    pub last_timestamp: Option<u64>,
+}
+
+
 impl rlp::Encodable for SignedTransaction {
     fn rlp_append(&self, s: &mut RlpStream) {
         self.tx.rlp_append_sealed_transaction(s)

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -35,7 +35,9 @@ use jsonrpc_core::Result;
 
 use super::super::errors;
 use super::super::traits::Chain;
-use super::super::types::{AssetScheme, Block, BlockNumberAndHash, OwnedAsset, Text, Transaction, UnsignedTransaction};
+use super::super::types::{
+    AssetScheme, Block, BlockNumberAndHash, OwnedAsset, PendingTransactions, Text, Transaction, UnsignedTransaction,
+};
 
 pub struct ChainClient<C, M>
 where
@@ -300,12 +302,12 @@ where
         Ok(self.client.block(&BlockId::Hash(block_hash)).map(|block| block.transactions_count()))
     }
 
-    fn get_pending_transactions(&self) -> Result<Vec<Transaction>> {
-        Ok(self.client.ready_transactions().into_iter().map(|signed| signed.into()).collect())
+    fn get_pending_transactions(&self, from: Option<u64>, to: Option<u64>) -> Result<PendingTransactions> {
+        Ok(self.client.ready_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
     }
 
-    fn get_pending_transactions_count(&self) -> Result<usize> {
-        Ok(self.client.count_pending_transactions())
+    fn get_pending_transactions_count(&self, from: Option<u64>, to: Option<u64>) -> Result<usize> {
+        Ok(self.client.count_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)))
     }
 
     fn get_mining_reward(&self, block_number: u64) -> Result<Option<u64>> {

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -23,7 +23,9 @@ use primitives::{Bytes as BytesArray, H160, H256};
 
 use jsonrpc_core::Result;
 
-use super::super::types::{AssetScheme, Block, BlockNumberAndHash, OwnedAsset, Text, Transaction, UnsignedTransaction};
+use super::super::types::{
+    AssetScheme, Block, BlockNumberAndHash, OwnedAsset, PendingTransactions, Text, Transaction, UnsignedTransaction,
+};
 
 build_rpc_trait! {
     pub trait Chain {
@@ -137,11 +139,11 @@ build_rpc_trait! {
 
         /// Gets transactions in the current mem pool.
         # [rpc(name = "chain_getPendingTransactions")]
-        fn get_pending_transactions(&self) -> Result<Vec<Transaction>>;
+        fn get_pending_transactions(&self, Option<u64>, Option<u64>) -> Result<PendingTransactions>;
 
        /// Gets the count of transactions in the current mem pool.
         # [rpc(name = "chain_getPendingTransactionsCount")]
-        fn get_pending_transactions_count(&self) -> Result<usize>;
+        fn get_pending_transactions_count(&self, Option<u64>, Option<u64>) -> Result<usize>;
 
         /// Gets the mining given block number
         # [rpc(name = "chain_getMiningReward")]

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -39,7 +39,7 @@ pub use self::asset_scheme::AssetScheme;
 pub use self::block::Block;
 pub use self::block::BlockNumberAndHash;
 pub use self::text::Text;
-pub use self::transaction::Transaction;
+pub use self::transaction::{PendingTransactions, Transaction};
 pub use self::unsigned_transaction::UnsignedTransaction;
 pub use self::work::Work;
 

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ccore::{LocalizedTransaction, SignedTransaction};
+use ccore::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
 use cjson::uint::Uint;
 use ckey::{NetworkId, Signature};
 use primitives::H256;
@@ -34,6 +34,23 @@ pub struct Transaction {
     pub action: ActionWithTracker,
     pub hash: H256,
     pub sig: Signature,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingTransactions {
+    transactions: Vec<Transaction>,
+    last_timestamp: Option<u64>,
+}
+
+impl From<PendingSignedTransactions> for PendingTransactions {
+    fn from(p: PendingSignedTransactions) -> Self {
+        let transactions = p.transactions.into_iter().map(From::from).collect();
+        Self {
+            transactions,
+            last_timestamp: p.last_timestamp,
+        }
+    }
 }
 
 impl Transaction {

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1376,19 +1376,20 @@ Errors: `KVDB Error`, `Invalid Params`
 [Back to **List of methods**](#list-of-methods)
 
 ## chain_getPendingTransactions
-Gets transactions in the current transaction queue.
+Gets transactions that have insertion_timestamps within the given range from the current transaction queue.
 
 ### Params
-No parameters
+ 1. from: `number | null` - The lower bound of collected pending transactions. If null, there is no lower bound.
+ 2. to: `number | null` - The upper bound of collected pending transactions. If null, there is no upper bound.
 
 ### Returns
-`Transaction[]`
+`{ transactions: Transaction[], lastTimestamp: number }`
 
 ### Request Example
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getPendingTransactions", "params": [], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "chain_getPendingTransactions", "params": [null, null], "id": null}' \
     localhost:8080
 ```
 
@@ -1396,8 +1397,9 @@ No parameters
 ```
 {
   "jsonrpc":"2.0",
-  "result":[
-    {
+  "result":{
+    "lastTimestamp": null,
+    "transactions": [{
       "blockHash":null,
       "blockNumber":null,
       "fee":"0xa",
@@ -1417,8 +1419,8 @@ No parameters
         }
       ],
       "v":0
-    }
-  ],
+    }]
+  },
   "id":null
 }
 ```
@@ -1426,10 +1428,11 @@ No parameters
 [Back to **List of methods**](#list-of-methods)
 
 ## chain_getPendingTransactionsCount
-Returns a count of the transactions that are in the current transaction queue.
+Returns a count of the transactions that have insertion_timestamps within the given range from the transaction queues.
 
 ### Params
-No parameters
+ 1. from: `number | null` - The lower bound of collected pending transactions. If null, there is no lower bound.
+ 2. to: `number | null` - The upper bound of collected pending transactions. If null, there is no upper bound.
 
 ### Returns
 `number`
@@ -1438,7 +1441,7 @@ No parameters
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getPendingTransactionsCount", "params": [], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "chain_getPendingTransactionsCount", "params": [null, null], "id": null}' \
     localhost:8080
 ```
 

--- a/sync/src/transaction/extension.rs
+++ b/sync/src/transaction/extension.rs
@@ -138,7 +138,7 @@ impl NetworkExtension for Extension {
 
 impl Extension {
     fn random_broadcast(&self) {
-        let transactions = self.client.ready_transactions();
+        let transactions = self.client.ready_transactions(0..(::std::u64::MAX)).transactions;
         if transactions.is_empty() {
             ctrace!(SYNC_TX, "No transactions to propagate");
             return

--- a/test/package.json
+++ b/test/package.json
@@ -44,7 +44,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "codechain-primitives": "^0.4.6",
-    "codechain-sdk": "https://github.com/HoOngEe/codechain-sdk-js.git#registrar-lib",
+    "codechain-sdk": "https://github.com/HoOngEe/codechain-sdk-js.git#range-pendingTx-lib",
     "crypto": "^1.0.1",
     "dgram": "^1.0.1",
     "elliptic": "^6.4.1",

--- a/test/src/e2e.long/mempool.test.ts
+++ b/test/src/e2e.long/mempool.test.ts
@@ -39,7 +39,7 @@ describe("Memory pool size test", function() {
         }
         await Promise.all(sending);
         const pendingTransactions = await nodeA.sdk.rpc.chain.getPendingTransactions();
-        expect(pendingTransactions.length).to.equal(sizeLimit * 2);
+        expect(pendingTransactions.transactions.length).to.equal(sizeLimit * 2);
     }).timeout(10_000);
 
     describe("To others", async function() {
@@ -67,14 +67,14 @@ describe("Memory pool size test", function() {
             }
 
             while (
-                (await nodeB.sdk.rpc.chain.getPendingTransactions()).length <
-                sizeLimit
+                (await nodeB.sdk.rpc.chain.getPendingTransactions())
+                    .transactions.length < sizeLimit
             ) {
                 await wait(500);
             }
 
             const pendingTransactions = await nodeB.sdk.rpc.chain.getPendingTransactions();
-            expect(pendingTransactions.length).to.equal(sizeLimit);
+            expect(pendingTransactions.transactions.length).to.equal(sizeLimit);
         }).timeout(60_000);
 
         it("Rejected by limit and reaccepted", async function() {
@@ -89,14 +89,14 @@ describe("Memory pool size test", function() {
             }
 
             while (
-                (await nodeB.sdk.rpc.chain.getPendingTransactions()).length <
-                sizeLimit
+                (await nodeB.sdk.rpc.chain.getPendingTransactions())
+                    .transactions.length < sizeLimit
             ) {
                 await wait(500);
             }
 
             const pendingTransactions = await nodeB.sdk.rpc.chain.getPendingTransactions();
-            const pendingTransactionHashes = pendingTransactions.map(
+            const pendingTransactionHashes = pendingTransactions.transactions.map(
                 (tx: SignedTransaction) => tx.hash().value
             );
             const rejectedTransactions = sent.filter(
@@ -106,7 +106,8 @@ describe("Memory pool size test", function() {
             await nodeB.sdk.rpc.devel.startSealing();
 
             while (
-                (await nodeB.sdk.rpc.chain.getPendingTransactions()).length > 0
+                (await nodeB.sdk.rpc.chain.getPendingTransactions())
+                    .transactions.length > 0
             ) {
                 await wait(500);
             }
@@ -124,7 +125,7 @@ describe("Memory pool size test", function() {
             );
 
             const pendingTransactionsAfterResend = await nodeB.sdk.rpc.chain.getPendingTransactions();
-            const pendingTransactionHashesAfterResend = pendingTransactionsAfterResend.map(
+            const pendingTransactionHashesAfterResend = pendingTransactionsAfterResend.transactions.map(
                 (tx: SignedTransaction) => tx.hash().value
             );
 
@@ -168,7 +169,7 @@ describe("Memory pool memory limit test", function() {
             await nodeA.mintAsset({ supply: 1, seq: i, awaitMint: false });
         }
         const pendingTransactions = await nodeA.sdk.rpc.chain.getPendingTransactions();
-        expect(pendingTransactions.length).to.equal(sizeLimit);
+        expect(pendingTransactions.transactions.length).to.equal(sizeLimit);
     }).timeout(50_000);
 
     describe("To others", async function() {
@@ -208,7 +209,7 @@ describe("Memory pool memory limit test", function() {
             await wait(3_000);
 
             const pendingTransactions = await nodeB.sdk.rpc.chain.getPendingTransactions();
-            expect(pendingTransactions.length).to.equal(0);
+            expect(pendingTransactions.transactions.length).to.equal(0);
             expect(await nodeA.sdk.rpc.chain.getBestBlockNumber()).to.equal(
                 aBlockNumber
             );

--- a/test/src/e2e.long/onChainTx.test.ts
+++ b/test/src/e2e.long/onChainTx.test.ts
@@ -94,9 +94,12 @@ describe("Test onChain transaction communication", function() {
         await sdk.rpc.devel.stopSealing();
         await mock.sendEncodedTransaction([signed.toEncodeObject()]);
 
-        while ((await sdk.rpc.chain.getPendingTransactions()).length !== 1) {}
+        while (
+            (await sdk.rpc.chain.getPendingTransactions()).transactions
+                .length !== 1
+        ) {}
         const transactions = await sdk.rpc.chain.getPendingTransactions();
-        expect(transactions.length).to.equal(1);
+        expect(transactions.transactions.length).to.equal(1);
 
         await mock.end();
     }).timeout(20_000);
@@ -135,7 +138,7 @@ describe("Test onChain transaction communication", function() {
 
                 await mock.sendEncodedTransaction([data]);
                 const txs = await sdk.rpc.chain.getPendingTransactions();
-                expect(txs.length).to.equal(0);
+                expect(txs.transactions.length).to.equal(0);
 
                 await mock.end();
             }).timeout(30_000);

--- a/test/src/e2e.long/sync2.test.ts
+++ b/test/src/e2e.long/sync2.test.ts
@@ -333,12 +333,14 @@ describe("sync 2 nodes", function() {
                     awaitResult: false
                 });
                 expect(
-                    (await nodeA.sdk.rpc.chain.getPendingTransactions()).length
+                    (await nodeA.sdk.rpc.chain.getPendingTransactions())
+                        .transactions.length
                 ).to.equal(i + 1);
             }
             await wait(2000);
             expect(
-                (await nodeB.sdk.rpc.chain.getPendingTransactions()).length
+                (await nodeB.sdk.rpc.chain.getPendingTransactions())
+                    .transactions.length
             ).to.equal(0);
         }).timeout(500 * testSize + 4000);
     });

--- a/test/src/e2e/chain.test.ts
+++ b/test/src/e2e/chain.test.ts
@@ -136,7 +136,7 @@ describe("chain", function() {
 
     it("getPendingTransactions", async function() {
         const pending = await node.sdk.rpc.chain.getPendingTransactions();
-        expect(pending.length).to.equal(0);
+        expect(pending.transactions.length).to.equal(0);
     });
 
     it("sendPayTx, getTransactionResult, getTransaction", async function() {

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -437,9 +437,9 @@ codechain-primitives@^0.4.6:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-"codechain-sdk@https://github.com/HoOngEe/codechain-sdk-js.git#registrar-lib":
+"codechain-sdk@https://github.com/HoOngEe/codechain-sdk-js.git#range-pendingTx-lib":
   version "0.5.1"
-  resolved "https://github.com/HoOngEe/codechain-sdk-js.git#d5dc24b5270073f28228b25eae4871851d71c430"
+  resolved "https://github.com/HoOngEe/codechain-sdk-js.git#f1bc57820a42d48ba683e66e11374fba38a908b4"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"


### PR DESCRIPTION
Now the rpc `getPendingTransactions` and `getPendingTransactionsCount` take timestamp range parameters `from` and `to`. They return the pendingTransactions and the count of the transactions that have the insertion timestamp within the range.

It closes #1368 