### PR TITLE
Reduce cloning of network extension messages

### DIFF
--- a/network/src/extension.rs
+++ b/network/src/extension.rs
@@ -16,9 +16,11 @@
 
 use std::convert::From;
 use std::result;
+use std::sync::Arc;
 
 use cio::IoError;
 use ctimer::{TimerScheduleError, TimerToken};
+use primitives::Bytes;
 use time::Duration;
 
 use crate::NodeId;
@@ -47,7 +49,7 @@ impl From<TimerScheduleError> for Error {
 pub type Result<T> = result::Result<T, Error>;
 
 pub trait Api {
-    fn send(&self, node: &NodeId, message: &[u8]);
+    fn send(&self, node: &NodeId, message: Arc<Bytes>);
 
     fn set_timer(&self, timer: TimerToken, d: Duration) -> Result<()>;
     fn set_timer_once(&self, timer: TimerToken, d: Duration) -> Result<()>;

--- a/network/src/p2p/connection/established.rs
+++ b/network/src/p2p/connection/established.rs
@@ -15,11 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::io;
+use std::sync::Arc;
 
 use cio::IoManager;
 use mio::deprecated::EventLoop;
 use mio::unix::UnixReady;
 use mio::{PollOpt, Ready, Token};
+use primitives::Bytes;
 
 use super::super::message::{Message, Version};
 use super::super::stream::SignedStream;
@@ -58,7 +60,7 @@ impl EstablishedConnection {
         &mut self,
         extension_name: String,
         need_encryption: bool,
-        message: Vec<u8>,
+        message: Arc<Bytes>,
     ) -> Result<()> {
         let message = if need_encryption {
             ExtensionMessage::encrypted_from_unencrypted_data(extension_name, &message, self.stream.session())?

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -27,6 +27,7 @@ use finally::finally;
 use mio::deprecated::EventLoop;
 use mio::{PollOpt, Ready, Token};
 use parking_lot::{Mutex, RwLock};
+use primitives::Bytes;
 use rand::prelude::SliceRandom;
 use rand::rngs::OsRng;
 use rand::Rng;
@@ -616,7 +617,7 @@ impl IoHandler<Message> for Handler {
                                 unreachable!("Node id for {}:{} must exist", stream_token, con.peer_addr())
                             });
                             let unencrypted = msg.unencrypted_data(con.session()).map_err(|e| format!("{:?}", e))?;
-                            self.client.on_message(msg.extension_name(), &remote_node_id, &unencrypted);
+                            self.client.on_message(msg.extension_name(), &remote_node_id, unencrypted);
                         }
                         Some(NetworkMessage::Negotiation(NegotiationMessage::Request {
                             extension_name,
@@ -678,7 +679,7 @@ impl IoHandler<Message> for Handler {
                                 unreachable!("Node id for {}:{} must exist", stream_token, con.peer_addr())
                             });
                             let unencrypted = msg.unencrypted_data(con.session()).map_err(|e| format!("{:?}", e))?;
-                            self.client.on_message(msg.extension_name(), &remote_node_id, &unencrypted);
+                            self.client.on_message(msg.extension_name(), &remote_node_id, unencrypted);
                         }
                         Some(NetworkMessage::Negotiation(NegotiationMessage::Request {
                             ..
@@ -1090,7 +1091,7 @@ pub enum Message {
         node_id: NodeId,
         extension_name: &'static str,
         need_encryption: bool,
-        data: Vec<u8>,
+        data: Arc<Bytes>,
     },
     Disconnect(SocketAddr),
     ApplyFilters,

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -113,7 +113,7 @@ impl Extension {
             let request_id = self.last_request;
             self.last_request += 1;
             requests.push((request_id, request.clone()));
-            self.api.send(id, &Message::Request(request_id, request).rlp_bytes());
+            self.api.send(id, Arc::new(Message::Request(request_id, request).rlp_bytes().into_vec()));
         }
     }
 
@@ -136,7 +136,7 @@ impl Extension {
                 let request_id = self.last_request;
                 self.last_request += 1;
                 requests.push((request_id, request.clone()));
-                self.api.send(id, &Message::Request(request_id, request).rlp_bytes());
+                self.api.send(id, Arc::new(Message::Request(request_id, request).rlp_bytes().into_vec()));
 
                 let token = &self.tokens[id];
                 let token_info = self.tokens_info.get_mut(token).unwrap();
@@ -212,12 +212,15 @@ impl NetworkExtension<Event> for Extension {
         let chain_info = self.client.chain_info();
         self.api.send(
             id,
-            &Message::Status {
-                total_score: chain_info.best_proposal_score,
-                best_hash: chain_info.best_block_hash,
-                genesis_hash: chain_info.genesis_hash,
-            }
-            .rlp_bytes(),
+            Arc::new(
+                Message::Status {
+                    total_score: chain_info.best_proposal_score,
+                    best_hash: chain_info.best_block_hash,
+                    genesis_hash: chain_info.genesis_hash,
+                }
+                .rlp_bytes()
+                .into_vec(),
+            ),
         );
         let t = self.connected_nodes.insert(*id);
         debug_assert!(t, "{} is already added to peer list", id);
@@ -415,12 +418,15 @@ impl Extension {
         for id in &self.connected_nodes {
             self.api.send(
                 id,
-                &Message::Status {
-                    total_score: chain_info.best_proposal_score,
-                    best_hash: chain_info.best_block_hash,
-                    genesis_hash: chain_info.genesis_hash,
-                }
-                .rlp_bytes(),
+                Arc::new(
+                    Message::Status {
+                        total_score: chain_info.best_proposal_score,
+                        best_hash: chain_info.best_block_hash,
+                        genesis_hash: chain_info.genesis_hash,
+                    }
+                    .rlp_bytes()
+                    .into_vec(),
+                ),
             );
         }
     }
@@ -478,7 +484,7 @@ impl Extension {
             } => self.create_state_chunk_response(block_hash, tree_root),
         };
 
-        self.api.send(from, &Message::Response(id, response).rlp_bytes());
+        self.api.send(from, Arc::new(Message::Response(id, response).rlp_bytes().into_vec()));
     }
 
     fn is_valid_request(&self, request: &RequestMessage) -> bool {

--- a/sync/src/transaction/extension.rs
+++ b/sync/src/transaction/extension.rs
@@ -163,7 +163,7 @@ impl Extension {
             }
             cdebug!(SYNC_TX, "Send {} transactions to {}", unsent.len(), token);
             ctrace!(SYNC_TX, "Send {:?}", unsent_hashes);
-            self.api.send(token, &Message::Transactions(unsent).rlp_bytes());
+            self.api.send(token, Arc::new(Message::Transactions(unsent).rlp_bytes().into_vec()));
         }
     }
 }


### PR DESCRIPTION
Currently, the network module clones a message when it sends and
receives the message. It can be a burden if the message size is large,
such as block propagation.