### PR TITLE
Make db lock the cache while it reads data

### DIFF
--- a/core/src/blockchain/invoice_db.rs
+++ b/core/src/blockchain/invoice_db.rs
@@ -79,7 +79,7 @@ impl InvoiceProvider for InvoiceDB {
 
     /// Get invoices of block with given hash.
     fn block_invoices(&self, hash: &H256) -> Option<BlockInvoices> {
-        let result = self.db.read_with_cache(db::COL_EXTRA, &self.invoice_cache, hash)?;
+        let result = self.db.read_with_cache(db::COL_EXTRA, &mut *self.invoice_cache.write(), hash)?;
         Some(result)
     }
 

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -190,21 +190,19 @@ pub trait Readable {
         R: Deref<Target = [u8]>;
 
     /// Returns value for given key either in cache or in database.
-    fn read_with_cache<K, T, C>(&self, col: Option<u32>, cache: &RwLock<C>, key: &K) -> Option<T>
+    fn read_with_cache<K, T, C>(&self, col: Option<u32>, cache: &mut C, key: &K) -> Option<T>
     where
         K: Key<T> + Eq + Hash + Clone,
         T: Clone + rlp::Decodable,
         C: Cache<K, T>, {
         {
-            let read = cache.read();
-            if let Some(v) = read.get(key) {
+            if let Some(v) = cache.get(key) {
                 return Some(v.clone())
             }
         }
 
         self.read(col, key).map(|value: T| {
-            let mut write = cache.write();
-            write.insert(key.clone(), value.clone());
+            cache.insert(key.clone(), value.clone());
             value
         })
     }


### PR DESCRIPTION
Currently, read_with_cache locks the cache twice, when checking whether
the cache has the data and write the reading data to cache. So someone
can update the cache between two lockings.