### PR TITLE
Make the MemPool's Timelock check condition consistent with the VM

### DIFF
--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::cmp;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
@@ -26,7 +25,6 @@ use kvdb::{DBTransaction, KeyValueDB};
 use primitives::H256;
 use rlp;
 use table::Table;
-use time::get_time;
 
 use super::backup;
 use super::mem_pool_types::{
@@ -963,12 +961,12 @@ impl MemPool {
     /// Checks the given timelock with the current time/timestamp.
     fn should_wait_timelock(timelock: &TxTimelock, best_block_number: BlockNumber, best_block_timestamp: u64) -> bool {
         if let Some(block_number) = timelock.block {
-            if block_number > best_block_number + 1 {
+            if block_number > best_block_number {
                 return true
             }
         }
         if let Some(timestamp) = timelock.timestamp {
-            if timestamp > cmp::max(get_time().sec as u64, best_block_timestamp) {
+            if timestamp > best_block_timestamp {
                 return true
             }
         }

--- a/test/src/e2e.long/timelock.test.ts
+++ b/test/src/e2e.long/timelock.test.ts
@@ -76,15 +76,13 @@ describe("Timelock", function() {
             await checkTx(tracker, true);
         });
 
-
-        it(`Minted at block 1, send transfer with Timelock::BlockAge(0)`, async function() { 
+        it(`Minted at block 1, send transfer with Timelock::BlockAge(0)`, async function() {
             const tracker = await sendTxWithTimelock({
                 type: "blockAge",
                 value: 0
             });
             await checkTx(tracker, true);
         });
-
 
         it("send transfer with Timelock::Time(0)", async function() {
             const tracker = await sendTxWithTimelock({
@@ -237,7 +235,7 @@ describe("Timelock", function() {
             expect(await node.getBestBlockNumber()).to.equal(2);
             await checkTx(tracker1, false);
             await checkTx(tracker2, true);
-        });
+        }).timeout(10_000);
     });
 
     describe("Multiple timelocks", async function() {

--- a/test/src/e2e.long/timelock.test.ts
+++ b/test/src/e2e.long/timelock.test.ts
@@ -68,25 +68,23 @@ describe("Timelock", function() {
     }
 
     describe("Transaction should go into the current queue", async function() {
-        [1, 2].forEach(function(target) {
-            it(`Minted at block 1, send transfer with Timelock::Block(${target})`, async function() {
-                const tracker = await sendTxWithTimelock({
-                    type: "block",
-                    value: target
-                });
-                await checkTx(tracker, true);
+        it(`Minted at block 1, send transfer with Timelock::Block(0)`, async function() {
+            const tracker = await sendTxWithTimelock({
+                type: "block",
+                value: 0
             });
+            await checkTx(tracker, true);
         });
 
-        [0, 1].forEach(function(target) {
-            it(`Minted at block 1, send transfer with Timelock::BlockAge(${target})`, async function() {
-                const tracker = await sendTxWithTimelock({
-                    type: "blockAge",
-                    value: target
-                });
-                await checkTx(tracker, true);
+
+        it(`Minted at block 1, send transfer with Timelock::BlockAge(0)`, async function() { 
+            const tracker = await sendTxWithTimelock({
+                type: "blockAge",
+                value: 0
             });
+            await checkTx(tracker, true);
         });
+
 
         it("send transfer with Timelock::Time(0)", async function() {
             const tracker = await sendTxWithTimelock({
@@ -168,8 +166,10 @@ describe("Timelock", function() {
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
+            await checkTx(tracker, false);
+            await node.sdk.rpc.devel.startSealing();
 
-            expect(await node.getBestBlockNumber()).to.equal(3);
+            expect(await node.getBestBlockNumber()).to.equal(4);
             await checkTx(tracker, true);
         });
 
@@ -180,14 +180,14 @@ describe("Timelock", function() {
                 value: 3
             });
 
-            for (let i = 1; i <= 3; i++) {
+            for (let i = 1; i <= 4; i++) {
                 expect(await node.getBestBlockNumber()).to.equal(i);
                 await checkTx(tracker, false);
 
                 await node.sdk.rpc.devel.startSealing();
             }
 
-            expect(await node.getBestBlockNumber()).to.equal(4);
+            expect(await node.getBestBlockNumber()).to.equal(5);
             await checkTx(tracker, true);
         });
     });
@@ -292,12 +292,13 @@ describe("Timelock", function() {
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(4);
+            await node.sdk.rpc.devel.startSealing();
+            expect(await node.getBestBlockNumber()).to.equal(5);
             await checkTx(tx.tracker(), false);
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(6);
+            expect(await node.getBestBlockNumber()).to.equal(7);
             await checkTx(tx.tracker(), true);
         }).timeout(10_000);
 
@@ -329,12 +330,13 @@ describe("Timelock", function() {
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(4);
+            await node.sdk.rpc.devel.startSealing();
+            expect(await node.getBestBlockNumber()).to.equal(5);
             await checkTx(tx.tracker(), false);
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(6);
+            expect(await node.getBestBlockNumber()).to.equal(7);
             await checkTx(tx.tracker(), true);
         }).timeout(10_000);
 
@@ -366,7 +368,8 @@ describe("Timelock", function() {
 
             await node.sdk.rpc.devel.startSealing();
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(4);
+            await node.sdk.rpc.devel.startSealing();
+            expect(await node.getBestBlockNumber()).to.equal(5);
             await checkTx(tx.tracker(), true);
         }).timeout(10_000);
 

--- a/test/src/e2e/mempool.test.ts
+++ b/test/src/e2e/mempool.test.ts
@@ -143,12 +143,13 @@ describe("Timelock", function() {
             await checkTx(txhash2, false);
 
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(2);
+            await node.sdk.rpc.devel.startSealing();
+            expect(await node.getBestBlockNumber()).to.equal(3);
             await checkTx(txhash1, false);
             await checkTx(txhash2, false);
 
             await node.sdk.rpc.devel.startSealing();
-            expect(await node.getBestBlockNumber()).to.equal(3);
+            expect(await node.getBestBlockNumber()).to.equal(4);
             await checkTx(txhash1, false);
             await checkTx(txhash2, true);
         });


### PR DESCRIPTION
Currently, the VM compares the Timelock value with the best block's
information. And the MemPool compares the Timelock value with the next
block's data or current time.

Even though a transaction has the same Timelock condition in the
transaction's input field and its script, the MemPool's test is passed
and the script's test is failed.

After this commit, the two tests return the same result.