### PR TITLE
Use best_proposal_block_hash in the sync extension

### DIFF
--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -303,6 +303,7 @@ impl BlockChain {
             pending_total_score: best_block_detail.total_score,
             genesis_hash: self.genesis_hash(),
             best_block_hash: best_block_header.hash(),
+            best_proposal_block_hash,
             best_block_number: best_block_detail.number,
             best_block_timestamp: best_block_header.timestamp(),
         }

--- a/core/src/blockchain_info.rs
+++ b/core/src/blockchain_info.rs
@@ -30,6 +30,8 @@ pub struct BlockChainInfo {
     pub genesis_hash: H256,
     /// Best blockchain block hash.
     pub best_block_hash: H256,
+    /// Best blockchain proposal block hash.
+    pub best_proposal_block_hash: H256,
     /// Best blockchain block number.
     pub best_block_number: BlockNumber,
     /// Best blockchain block timestamp.

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -379,6 +379,7 @@ impl ChainInfo for TestBlockChainClient {
             pending_total_score: *self.score.read(),
             genesis_hash: self.genesis_hash,
             best_block_hash: *self.last_hash.read(),
+            best_proposal_block_hash: *self.last_hash.read(),
             best_block_number: number,
             best_block_timestamp: number,
         }

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -216,7 +216,7 @@ impl NetworkExtension<Event> for Extension {
             Arc::new(
                 Message::Status {
                     total_score: chain_info.best_proposal_score,
-                    best_hash: chain_info.best_block_hash,
+                    best_hash: chain_info.best_proposal_block_hash,
                     genesis_hash: chain_info.genesis_hash,
                 }
                 .rlp_bytes()
@@ -422,7 +422,7 @@ impl Extension {
                 Arc::new(
                     Message::Status {
                         total_score: chain_info.best_proposal_score,
-                        best_hash: chain_info.best_block_hash,
+                        best_hash: chain_info.best_proposal_block_hash,
                         genesis_hash: chain_info.genesis_hash,
                     }
                     .rlp_bytes()


### PR DESCRIPTION
Tendermint consensus:
Block sync was using best proposal block's score. Although currently
the best hash is not used, it should be matched with the score.

Other consensuses:
Best proposal block is the same as the best block. Nothing changed.