### PR TITLE
Allow struct/array to overflow

### DIFF
--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -237,15 +237,11 @@ impl Importer {
             cdebug!(CLIENT, "Epoch transition at block {}", header.hash());
 
             let mut batch = DBTransaction::new();
-            chain.insert_epoch_transition(
-                &mut batch,
-                header.number(),
-                EpochTransition {
-                    block_hash: header.hash(),
-                    block_number: header.number(),
-                    proof,
-                },
-            );
+            chain.insert_epoch_transition(&mut batch, header.number(), EpochTransition {
+                block_hash: header.hash(),
+                block_number: header.number(),
+                proof,
+            });
 
             // always write the batch directly since epoch transition proofs are
             // fetched from a DB iterator and DB iterators are only available on

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -918,16 +918,13 @@ impl Worker {
     }
 
     fn backup(&self) {
-        backup(
-            self.client().get_kvdb().as_ref(),
-            BackupView {
-                height: &self.height,
-                view: &self.view,
-                step: &self.step.to_step(),
-                votes: &self.votes.get_all(),
-                last_confirmed_view: &self.last_confirmed_view,
-            },
-        );
+        backup(self.client().get_kvdb().as_ref(), BackupView {
+            height: &self.height,
+            view: &self.view,
+            step: &self.step.to_step(),
+            votes: &self.votes.get_all(),
+            last_confirmed_view: &self.last_confirmed_view,
+        });
     }
 
     fn restore(&mut self) {

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -1447,14 +1447,10 @@ pub mod test {
         let mut inputs: Vec<MemPoolInput> = Vec::new();
 
         inputs.push(create_mempool_input_with_pay(1u64, keypair, no_timelock));
-        inputs.push(create_mempool_input_with_pay(
-            3u64,
-            keypair,
-            TxTimelock {
-                block: Some(10),
-                timestamp: None,
-            },
-        ));
+        inputs.push(create_mempool_input_with_pay(3u64, keypair, TxTimelock {
+            block: Some(10),
+            timestamp: None,
+        }));
         inputs.push(create_mempool_input_with_pay(5u64, keypair, no_timelock));
         mem_pool.add(inputs, inserted_block_number, inserted_timestamp, &fetch_account);
 

--- a/core/src/miner/work_notify.rs
+++ b/core/src/miner/work_notify.rs
@@ -69,21 +69,15 @@ impl NotifyWork for WorkPoster {
         let body = format!(r#"{{ "result": ["0x{:x}","0x{:x}"] }}"#, pow_hash, target);
         let mut client = self.client.lock();
         for u in &self.urls {
-            if let Err(e) = client.request(
-                u.clone(),
-                PostHandler {
-                    body: body.clone(),
-                },
-            ) {
+            if let Err(e) = client.request(u.clone(), PostHandler {
+                body: body.clone(),
+            }) {
                 cwarn!(MINER, "Error sending HTTP notification to {} : {}, retrying", u, e);
                 // TODO: remove this once https://github.com/hyperium/hyper/issues/848 is fixed
                 *client = WorkPoster::create_client();
-                if let Err(e) = client.request(
-                    u.clone(),
-                    PostHandler {
-                        body: body.clone(),
-                    },
-                ) {
+                if let Err(e) = client.request(u.clone(), PostHandler {
+                    body: body.clone(),
+                }) {
                     cwarn!(MINER, "Error sending HTTP notification to {} : {}", u, e);
                 }
             }

--- a/json/src/hash.rs
+++ b/json/src/hash.rs
@@ -109,13 +109,10 @@ mod test {
     fn hash_deserialization() {
         let s = r#"["", "5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae"]"#;
         let deserialized: Vec<H256> = serde_json::from_str(s).unwrap();
-        assert_eq!(
-            deserialized,
-            vec![
-                H256(primitives::H256::from(0)),
-                H256(primitives::H256::from("5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae")),
-            ]
-        );
+        assert_eq!(deserialized, vec![
+            H256(primitives::H256::from(0)),
+            H256(primitives::H256::from("5a39ed1020c04d4d84539975b893a4e7c53eab6c2965db8bc3468093a31bc5ae")),
+        ]);
     }
 
     #[test]

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -151,17 +151,14 @@ mod test {
     fn uint_deserialization() {
         let s = r#"["0xa", "10", "", "0x", 0, "0xffffffffffffffff"]"#;
         let deserialized: Vec<Uint> = serde_json::from_str(s).unwrap();
-        assert_eq!(
-            deserialized,
-            vec![
-                Uint(U256::from(10)),
-                Uint(U256::from(10)),
-                Uint(U256::from(0)),
-                Uint(U256::from(0)),
-                Uint(U256::from(0)),
-                ::std::u64::MAX.into(),
-            ]
-        );
+        assert_eq!(deserialized, vec![
+            Uint(U256::from(10)),
+            Uint(U256::from(10)),
+            Uint(U256::from(0)),
+            Uint(U256::from(0)),
+            Uint(U256::from(0)),
+            ::std::u64::MAX.into(),
+        ]);
     }
 
     #[test]

--- a/keystore/tests/api.rs
+++ b/keystore/tests/api.rs
@@ -109,10 +109,10 @@ fn ciphertext_path() -> &'static str {
 fn secret_store_load_pat_files() {
     let dir = RootDiskDirectory::at(pat_path());
     let store = KeyStore::open(Box::new(dir)).unwrap();
-    assert_eq!(
-        store.accounts().unwrap(),
-        vec!["0x3fc74504d2b491d73079975e302279540bf6e44e".into(), "0x41178717678e402bdb663d98fe47669d93b29603".into()]
-    );
+    assert_eq!(store.accounts().unwrap(), vec![
+        "0x3fc74504d2b491d73079975e302279540bf6e44e".into(),
+        "0x41178717678e402bdb663d98fe47669d93b29603".into()
+    ]);
 }
 
 #[test]
@@ -128,10 +128,10 @@ fn decrypting_files_with_short_ciphertext() {
     let dir = RootDiskDirectory::at(ciphertext_path());
     let store = KeyStore::open(Box::new(dir)).unwrap();
     let accounts = store.accounts().unwrap();
-    assert_eq!(
-        accounts,
-        vec!["0x77a477c745390977a72f44437ac1dac19b705571".into(), "0x8267cb8df20e1dc57fef31322e16bddd83d4cc3d".into()]
-    );
+    assert_eq!(accounts, vec![
+        "0x77a477c745390977a72f44437ac1dac19b705571".into(),
+        "0x8267cb8df20e1dc57fef31322e16bddd83d4cc3d".into()
+    ]);
 
     let message = Default::default();
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -49,7 +49,7 @@ use_try_shorthand = true # false
 # format_doc_comments = false
 wrap_comments = false
 match_arm_blocks = true
-overflow_delimited_expr = false
+overflow_delimited_expr = true
 blank_lines_upper_bound = 2 # 1
 blank_lines_lower_bound = 0
 # required_version

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -2470,10 +2470,9 @@ mod tests_tx {
         let asset_type = H160::zero();
         let transfer = transfer_asset!(
             inputs:
-                asset_transfer_inputs![(
-                    asset_out_point!(H256::random(), 0, asset_type, shard_id, 30),
-                    vec![0x30, 0x01]
-                )],
+                asset_transfer_inputs![(asset_out_point!(H256::random(), 0, asset_type, shard_id, 30), vec![
+                    0x30, 0x01
+                ])],
             asset_transfer_outputs![
                 (H160::random(), vec![vec![1]], asset_type, shard_id, 10),
                 (H160::random(), vec![], asset_type, shard_id, 5),

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -920,16 +920,13 @@ mod tests {
     fn fail_if_output_has_more_asset() {
         let asset_type = H160::random();
         let output_quantity = 100;
-        assert!(!is_input_and_output_consistent(
-            &[],
-            &[AssetTransferOutput {
-                lock_script_hash: H160::random(),
-                parameters: vec![],
-                asset_type,
-                shard_id: 0,
-                quantity: output_quantity,
-            }]
-        ));
+        assert!(!is_input_and_output_consistent(&[], &[AssetTransferOutput {
+            lock_script_hash: H160::random(),
+            parameters: vec![],
+            asset_type,
+            shard_id: 0,
+            quantity: output_quantity,
+        }]));
     }
 
     #[test]

--- a/types/src/util/tag.rs
+++ b/types/src/util/tag.rs
@@ -78,19 +78,16 @@ mod tests {
         assert_eq!(tag.sign_all_inputs, true);
         assert_eq!(tag.sign_all_outputs, false);
         assert_eq!(tag.filter_len, 8);
-        assert_eq!(
-            tag.filter.clone(),
-            vec![
-                0b1000_0000,
-                0b0100_0000,
-                0b0010_0000,
-                0b0001_0000,
-                0b0000_1000,
-                0b0000_0100,
-                0b0000_0010,
-                0b0000_0001
-            ]
-        );
+        assert_eq!(tag.filter.clone(), vec![
+            0b1000_0000,
+            0b0100_0000,
+            0b0010_0000,
+            0b0001_0000,
+            0b0000_1000,
+            0b0000_0100,
+            0b0000_0010,
+            0b0000_0001
+        ]);
     }
 
     #[test]

--- a/util/io/src/service.rs
+++ b/util/io/src/service.rs
@@ -277,14 +277,11 @@ where
                 once,
             } => {
                 let timeout = event_loop.timeout(Token(token), delay).expect("Error registering user timer");
-                self.timers.write().insert(
-                    token,
-                    UserTimer {
-                        delay,
-                        timeout,
-                        once,
-                    },
-                );
+                self.timers.write().insert(token, UserTimer {
+                    delay,
+                    timeout,
+                    once,
+                });
             }
             IoMessage::RemoveTimer {
                 token,

--- a/util/rlp/tests/tests.rs
+++ b/util/rlp/tests/tests.rs
@@ -47,22 +47,16 @@ fn rlp_at_err() {
         assert!(rlp.is_list());
 
         let cat_err = rlp.at(0).unwrap_err();
-        assert_eq!(
-            cat_err,
-            DecoderError::RlpIsTooShort {
-                expected: 1,
-                got: 0
-            }
-        );
+        assert_eq!(cat_err, DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0
+        });
 
         let dog_err = rlp.at(1).unwrap_err();
-        assert_eq!(
-            dog_err,
-            DecoderError::RlpIsTooShort {
-                expected: 1,
-                got: 0
-            }
-        );
+        assert_eq!(dog_err, DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0
+        });
     }
 }
 
@@ -206,28 +200,22 @@ fn encode_str() {
         ETestPair("dog", vec![0x83, b'd', b'o', b'g']),
         ETestPair("Marek", vec![0x85, b'M', b'a', b'r', b'e', b'k']),
         ETestPair("", vec![0x80]),
-        ETestPair(
-            "Lorem ipsum dolor sit amet, consectetur adipisicing elit",
-            vec![
-                0xb8, 0x38, b'L', b'o', b'r', b'e', b'm', b' ', b'i', b'p', b's', b'u', b'm', b' ', b'd', b'o', b'l',
-                b'o', b'r', b' ', b's', b'i', b't', b' ', b'a', b'm', b'e', b't', b',', b' ', b'c', b'o', b'n', b's',
-                b'e', b'c', b't', b'e', b't', b'u', b'r', b' ', b'a', b'd', b'i', b'p', b'i', b's', b'i', b'c', b'i',
-                b'n', b'g', b' ', b'e', b'l', b'i', b't',
-            ],
-        ),
+        ETestPair("Lorem ipsum dolor sit amet, consectetur adipisicing elit", vec![
+            0xb8, 0x38, b'L', b'o', b'r', b'e', b'm', b' ', b'i', b'p', b's', b'u', b'm', b' ', b'd', b'o', b'l', b'o',
+            b'r', b' ', b's', b'i', b't', b' ', b'a', b'm', b'e', b't', b',', b' ', b'c', b'o', b'n', b's', b'e', b'c',
+            b't', b'e', b't', b'u', b'r', b' ', b'a', b'd', b'i', b'p', b'i', b's', b'i', b'c', b'i', b'n', b'g', b' ',
+            b'e', b'l', b'i', b't',
+        ]),
     ];
     run_encode_tests(tests);
 }
 
 #[test]
 fn encode_address() {
-    let tests = vec![ETestPair(
-        H160::from("ef2d6d194084c2de36e0dabfce45d046b37d1106"),
-        vec![
-            0x94, 0xef, 0x2d, 0x6d, 0x19, 0x40, 0x84, 0xc2, 0xde, 0x36, 0xe0, 0xda, 0xbf, 0xce, 0x45, 0xd0, 0x46, 0xb3,
-            0x7d, 0x11, 0x06,
-        ],
-    )];
+    let tests = vec![ETestPair(H160::from("ef2d6d194084c2de36e0dabfce45d046b37d1106"), vec![
+        0x94, 0xef, 0x2d, 0x6d, 0x19, 0x40, 0x84, 0xc2, 0xde, 0x36, 0xe0, 0xda, 0xbf, 0xce, 0x45, 0xd0, 0x46, 0xb3,
+        0x7d, 0x11, 0x06,
+    ])];
     run_encode_tests(tests);
 }
 
@@ -249,10 +237,9 @@ fn encode_vector_u64() {
         VETestPair(vec![], vec![0xc0]),
         VETestPair(vec![15u64], vec![0xc1, 0x0f]),
         VETestPair(vec![1, 2, 3, 7, 0xff], vec![0xc6, 1, 2, 3, 7, 0x81, 0xff]),
-        VETestPair(
-            vec![0xffff_ffff, 1, 2, 3, 7, 0xff],
-            vec![0xcb, 0x84, 0xff, 0xff, 0xff, 0xff, 1, 2, 3, 7, 0x81, 0xff],
-        ),
+        VETestPair(vec![0xffff_ffff, 1, 2, 3, 7, 0xff], vec![
+            0xcb, 0x84, 0xff, 0xff, 0xff, 0xff, 1, 2, 3, 7, 0x81, 0xff,
+        ]),
     ];
     run_encode_tests_list(tests);
 }
@@ -391,28 +378,22 @@ fn decode_untrusted_str() {
         DTestPair("dog".to_string(), vec![0x83, b'd', b'o', b'g']),
         DTestPair("Marek".to_string(), vec![0x85, b'M', b'a', b'r', b'e', b'k']),
         DTestPair("".to_string(), vec![0x80]),
-        DTestPair(
-            "Lorem ipsum dolor sit amet, consectetur adipisicing elit".to_string(),
-            vec![
-                0xb8, 0x38, b'L', b'o', b'r', b'e', b'm', b' ', b'i', b'p', b's', b'u', b'm', b' ', b'd', b'o', b'l',
-                b'o', b'r', b' ', b's', b'i', b't', b' ', b'a', b'm', b'e', b't', b',', b' ', b'c', b'o', b'n', b's',
-                b'e', b'c', b't', b'e', b't', b'u', b'r', b' ', b'a', b'd', b'i', b'p', b'i', b's', b'i', b'c', b'i',
-                b'n', b'g', b' ', b'e', b'l', b'i', b't',
-            ],
-        ),
+        DTestPair("Lorem ipsum dolor sit amet, consectetur adipisicing elit".to_string(), vec![
+            0xb8, 0x38, b'L', b'o', b'r', b'e', b'm', b' ', b'i', b'p', b's', b'u', b'm', b' ', b'd', b'o', b'l', b'o',
+            b'r', b' ', b's', b'i', b't', b' ', b'a', b'm', b'e', b't', b',', b' ', b'c', b'o', b'n', b's', b'e', b'c',
+            b't', b'e', b't', b'u', b'r', b' ', b'a', b'd', b'i', b'p', b'i', b's', b'i', b'c', b'i', b'n', b'g', b' ',
+            b'e', b'l', b'i', b't',
+        ]),
     ];
     run_decode_tests(tests);
 }
 
 #[test]
 fn decode_untrusted_address() {
-    let tests = vec![DTestPair(
-        H160::from("ef2d6d194084c2de36e0dabfce45d046b37d1106"),
-        vec![
-            0x94, 0xef, 0x2d, 0x6d, 0x19, 0x40, 0x84, 0xc2, 0xde, 0x36, 0xe0, 0xda, 0xbf, 0xce, 0x45, 0xd0, 0x46, 0xb3,
-            0x7d, 0x11, 0x06,
-        ],
-    )];
+    let tests = vec![DTestPair(H160::from("ef2d6d194084c2de36e0dabfce45d046b37d1106"), vec![
+        0x94, 0xef, 0x2d, 0x6d, 0x19, 0x40, 0x84, 0xc2, 0xde, 0x36, 0xe0, 0xda, 0xbf, 0xce, 0x45, 0xd0, 0x46, 0xb3,
+        0x7d, 0x11, 0x06,
+    ])];
     run_decode_tests(tests);
 }
 
@@ -422,20 +403,18 @@ fn decode_untrusted_vector_u64() {
         VDTestPair(vec![], vec![0xc0]),
         VDTestPair(vec![15u64], vec![0xc1, 0x0f]),
         VDTestPair(vec![1, 2, 3, 7, 0xff], vec![0xc6, 1, 2, 3, 7, 0x81, 0xff]),
-        VDTestPair(
-            vec![0xffff_ffff, 1, 2, 3, 7, 0xff],
-            vec![0xcb, 0x84, 0xff, 0xff, 0xff, 0xff, 1, 2, 3, 7, 0x81, 0xff],
-        ),
+        VDTestPair(vec![0xffff_ffff, 1, 2, 3, 7, 0xff], vec![
+            0xcb, 0x84, 0xff, 0xff, 0xff, 0xff, 1, 2, 3, 7, 0x81, 0xff,
+        ]),
     ];
     run_decode_tests_list(tests);
 }
 
 #[test]
 fn decode_untrusted_vector_str() {
-    let tests = vec![VDTestPair(
-        vec!["cat".to_string(), "dog".to_string()],
-        vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g'],
-    )];
+    let tests = vec![VDTestPair(vec!["cat".to_string(), "dog".to_string()], vec![
+        0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g',
+    ])];
     run_decode_tests_list(tests);
 }
 

--- a/util/secp256k1/src/key.rs
+++ b/util/secp256k1/src/key.rs
@@ -296,23 +296,17 @@ mod test {
         assert_eq!(PublicKey::from_slice(&s, &[]), Err(InvalidPublicKey));
         assert_eq!(PublicKey::from_slice(&s, &[1, 2, 3]), Err(InvalidPublicKey));
 
-        let uncompressed = PublicKey::from_slice(
-            &s,
-            &[
-                4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100,
-                57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72,
-                211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188,
-            ],
-        );
+        let uncompressed = PublicKey::from_slice(&s, &[
+            4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100, 57,
+            121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72, 211,
+            229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188,
+        ]);
         assert!(uncompressed.is_ok());
 
-        let compressed = PublicKey::from_slice(
-            &s,
-            &[
-                3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41, 111, 180, 110,
-                143, 114, 134, 88, 73, 198, 174, 52, 184, 78,
-            ],
-        );
+        let compressed = PublicKey::from_slice(&s, &[
+            3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41, 111, 180, 110, 143,
+            114, 134, 88, 73, 198, 174, 52, 184, 78,
+        ]);
         assert!(compressed.is_ok());
     }
 
@@ -334,22 +328,16 @@ mod test {
         // -1
         assert_eq!(SecretKey::from_slice(&s, &[0xff; 32]), Err(InvalidSecretKey));
         // Top of range
-        assert!(SecretKey::from_slice(
-            &s,
-            &[
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA,
-                0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40,
-            ]
-        )
+        assert!(SecretKey::from_slice(&s, &[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA, 0xAE,
+            0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40,
+        ])
         .is_ok());
         // One past top of range
-        assert!(SecretKey::from_slice(
-            &s,
-            &[
-                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA,
-                0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41,
-            ]
-        )
+        assert!(SecretKey::from_slice(&s, &[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA, 0xAE,
+            0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41,
+        ])
         .is_err());
     }
 


### PR DESCRIPTION
How about enabling [`overflow_delimited_expr`](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#overflow_delimited_expr) option?