### PR TITLE
Fix .dockerignore file to get commit hash successfully from docker image clients.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/.git/
 /.idea/
 /target/
 /keys/

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 /keys/
 /db/
 /docker/
+/keystore.db
+/test/


### PR DESCRIPTION
It closes #1443 