### PR TITLE
Remove the cli optional argument "no-miner"

### DIFF
--- a/codechain/codechain.yml
+++ b/codechain/codechain.yml
@@ -155,14 +155,10 @@ args:
         long: author
         help: Specify the block author (aka "coinbase") address for sending block rewards from sealed blocks.
         takes_value: true
-        conflicts_with:
-            - no-miner
     - engine-signer:
         long: engine-signer
         help: Specify the address which should be used to sign consensus messages and issue blocks.
         takes_value: true
-        conflicts_with:
-            -  no-miner
     - password-path:
         long: password-path
         help: Specify the password file path.

--- a/codechain/config/mod.rs
+++ b/codechain/config/mod.rs
@@ -215,7 +215,6 @@ pub struct Operating {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Mining {
-    pub disable: Option<bool>,
     pub author: Option<PlatformAddress>,
     pub engine_signer: Option<PlatformAddress>,
     pub mem_pool_size: Option<usize>,
@@ -374,9 +373,6 @@ impl Operating {
 
 impl Mining {
     pub fn merge(&mut self, other: &Mining) {
-        if other.disable.is_some() {
-            self.disable = other.disable;
-        }
         if other.author.is_some() {
             self.author = other.author;
         }
@@ -416,15 +412,16 @@ impl Mining {
     }
 
     pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
-        if matches.is_present("no-miner") {
-            self.disable = Some(true);
-        }
-
         if let Some(author) = matches.value_of("author") {
             self.author = Some(author.parse().map_err(|_| "Invalid address format")?);
         }
         if let Some(engine_signer) = matches.value_of("engine-signer") {
             self.engine_signer = Some(engine_signer.parse().map_err(|_| "Invalid address format")?);
+        }
+        if matches.is_present("no-miner") {
+            self.author = None;
+            self.engine_signer = None;
+            println!("This option was deprecated. PoW type engine with no engine signer and PBFT or PoA type engine with no author implicitly means no-miner.");
         }
         if let Some(mem_pool_fee_bump_shift) = matches.value_of("mem-pool-fee-bump-shift") {
             self.mem_pool_mem_limit =

--- a/codechain/config/presets/config.dev.toml
+++ b/codechain/config/presets/config.dev.toml
@@ -4,7 +4,6 @@ base_path = "."
 chain = "solo"
 
 [mining]
-disable = false
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
 mem_pool_fee_bump_shift = 3 # 12.5%

--- a/codechain/config/presets/config.prod.toml
+++ b/codechain/config/presets/config.prod.toml
@@ -4,7 +4,6 @@ base_path = "."
 chain = "mainnet"
 
 [mining]
-disable = false
 mem_pool_mem_limit = 512 # MB
 mem_pool_size = 524288
 mem_pool_fee_bump_shift = 3 # 12.5%


### PR DESCRIPTION
Now the default value of mining.disable is true and could be set to false not through the no-miner option but through not giving both author and engine signer options.
It closes #1492 

As the `no-miner` option disappears, previous `no-miner` behavior is mimicked implicitly. If one wants to execute the codechain with PoW type engine but doesn't specify the author then it implicitly indicates `no-miner`. This is same for PBFT or PoA type engine if one doesn't specify the engine signer.
In addition, the error message has changed. If one wants PoW type engine but specified engine singer, it can be speculated that he/she wants mining. Then the proper guide would be given to make him/her correctly designate the author. This is same for the PBFT or PoA type.
Now the solo type engine but `no-miner` is impossible. It is weird in some sense.