### PR TITLE
Increase the number of blocks and headers to import in a round

### DIFF
--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -90,14 +90,14 @@ impl Importer {
 
     /// This is triggered by a message coming from a block queue when the block is ready for insertion
     pub fn import_verified_blocks(&self, client: &Client) -> usize {
-        let max_blocks_to_import = 4;
         let (imported_blocks, import_results, invalid_blocks, imported, duration, is_empty) = {
-            let mut imported_blocks = Vec::with_capacity(max_blocks_to_import);
+            const MAX_BLOCKS_TO_IMPORT: usize = 1_000;
+            let mut imported_blocks = Vec::with_capacity(MAX_BLOCKS_TO_IMPORT);
             let mut invalid_blocks = HashSet::new();
-            let mut import_results = Vec::with_capacity(max_blocks_to_import);
+            let mut import_results = Vec::with_capacity(MAX_BLOCKS_TO_IMPORT);
 
             let import_lock = self.import_lock.lock();
-            let blocks = self.block_queue.drain(max_blocks_to_import);
+            let blocks = self.block_queue.drain(MAX_BLOCKS_TO_IMPORT);
             if blocks.is_empty() {
                 return 0
             }
@@ -327,9 +327,9 @@ impl Importer {
 
     /// This is triggered by a message coming from a header queue when the header is ready for insertion
     pub fn import_verified_headers(&self, client: &Client) -> usize {
-        let max_headers_to_import = 256;
+        const MAX_HEADERS_TO_IMPORT: usize = 10_000;
         let lock = self.import_lock.lock();
-        let headers = self.header_queue.drain(max_headers_to_import);
+        let headers = self.header_queue.drain(MAX_HEADERS_TO_IMPORT);
         self.import_headers(&headers, client, &lock)
     }
 


### PR DESCRIPTION
Currently, the client imports only four blocks per signal.
Increasing it makes the synchronization fast.
It fixes https://github.com/CodeChain-io/codechain/issues/1511