### PR TITLE
Fix slow sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memorydb 0.1.1",
  "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.4.0 (git+https://github.com/CodeChain-io/rust-codechain-primitives.git)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,6 @@ hyper = { git = "https://github.com/paritytech/hyper", default-features = false 
 journaldb = { path = "../util/journaldb" }
 linked-hash-map = "0.5"
 log = "0.4.6"
-num_cpus = "1.8"
 kvdb = { path = "../util/kvdb" }
 kvdb-rocksdb = { path = "../util/kvdb-rocksdb" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -305,7 +305,7 @@ impl Importer {
 
     /// This is triggered by a message coming from a header queue when the header is ready for insertion
     pub fn import_verified_headers(&self, client: &Client) -> usize {
-        const MAX_HEADERS_TO_IMPORT: usize = 10_000;
+        const MAX_HEADERS_TO_IMPORT: usize = 1_000;
         let lock = self.import_lock.lock();
         let headers = self.header_queue.drain(MAX_HEADERS_TO_IMPORT);
         self.import_headers(&headers, client, &lock)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,7 +39,6 @@ extern crate kvdb_memorydb;
 extern crate kvdb_rocksdb;
 extern crate linked_hash_map;
 extern crate memorydb;
-extern crate num_cpus;
 extern crate num_rational;
 extern crate primitives;
 extern crate rand;

--- a/core/src/verification/queue/mod.rs
+++ b/core/src/verification/queue/mod.rs
@@ -23,7 +23,6 @@ use std::sync::{Arc, Condvar as SCondvar, Mutex as SMutex};
 use std::thread::{self, JoinHandle};
 
 use cio::IoChannel;
-use num_cpus;
 use parking_lot::{Mutex, RwLock};
 use primitives::{H256, U256};
 
@@ -36,8 +35,8 @@ use crate::types::{BlockStatus as Status, VerificationQueueInfo as QueueInfo};
 const MIN_MEM_LIMIT: usize = 16384;
 const MIN_QUEUE_LIMIT: usize = 512;
 
-// maximum possible number of verification threads.
-const MAX_VERIFIERS: usize = 8;
+// number of verification threads.
+const NUM_VERIFIERS: usize = 2;
 
 /// Type alias for block queue convenience.
 pub type BlockQueue = VerificationQueue<kind::Blocks>;
@@ -150,10 +149,9 @@ impl<K: Kind> VerificationQueue<K> {
         let empty = Arc::new(SCondvar::new());
         let more_to_verify = Arc::new(SCondvar::new());
 
-        let num_verifiers = cmp::min(num_cpus::get(), MAX_VERIFIERS);
-        let mut verifier_handles = Vec::with_capacity(num_verifiers);
+        let mut verifier_handles = Vec::with_capacity(NUM_VERIFIERS);
 
-        for i in 0..num_verifiers {
+        for i in 0..NUM_VERIFIERS {
             let engine = engine.clone();
             let verification = verification.clone();
             let more_to_verify = more_to_verify.clone();

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -680,9 +680,13 @@ impl Extension {
         completed.sort_unstable_by_key(EncodedHeader::number);
 
         let mut exists = Vec::new();
+        let mut queued = Vec::new();
+
         for header in completed {
+            let hash = header.hash();
             match self.client.import_header(header.clone().into_inner()) {
-                Err(BlockImportError::Import(ImportError::AlreadyInChain)) => exists.push(header.hash()),
+                Err(BlockImportError::Import(ImportError::AlreadyInChain)) => exists.push(hash),
+                Err(BlockImportError::Import(ImportError::AlreadyQueued)) => queued.push(hash),
                 // FIXME: handle import errors
                 Err(err) => {
                     cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
@@ -693,6 +697,7 @@ impl Extension {
         }
 
         let request = self.header_downloaders.get_mut(from).and_then(|peer| {
+            peer.mark_as_queued(queued);
             peer.mark_as_imported(exists);
             peer.create_request()
         });


### PR DESCRIPTION
Now the total time taken for a node to synchronize with the corgi blocks is about 145 minutes.
Queued cache has introduced distinct from the downloaded cache in `HeaderDownloader`.
I failed to analyze the correct reason but decreasing `MAX_HEADERS_TO_IMPORT` down to 1,000 helps reducing sync time.
And lastly, in the current structure it doesn't help to spawn many threads because the cpu intensive jobs should be sequential. So I decreased it down to `2`.

The following image shows the cpu time spent during 50,000 block synchronization.
![with_queued_cache](https://user-images.githubusercontent.com/20704471/58540408-4770dd00-8234-11e9-87d7-68187799ee6d.png)

Now the main cpu intensive jobs are all related to EC calculation for verification.