### PR TITLE
Change the spec to store the public key of candidate instead of the address

### DIFF
--- a/spec/Dynamic-Validator.md
+++ b/spec/Dynamic-Validator.md
@@ -218,7 +218,7 @@ In other words, the *DELEGATE* transaction to the banned account and the *SELF_N
 stakeholders = [ address+ ], address asc
 balance(address) = quantity
 delegation(delegator) = [ [delegatee, quantity]+ ], delegatee asc
-candidates = [ [address, deposits, nominate_end_at]+ ], address asc
+candidates = [ [pubkey, deposits, nominate_end_at]+ ], pubkey asc
 pending_rewards = [ [withdraw_at, address, quantity]+ ], [withdraw_at, address] asc
 banned = [ address+ ], address asc
 jailed = [ [address, deposits, custody_until, kicked_at]+ ], address asc


### PR DESCRIPTION
Because the recovering key is an expensive operation, it's good to know the public key of the validators.