### PR TITLE
Make the term id sequential

### DIFF
--- a/core/src/codechain_machine.rs
+++ b/core/src/codechain_machine.rs
@@ -251,13 +251,8 @@ impl CodeChainMachine {
         Ok(())
     }
 
-    pub fn change_term_id(
-        &self,
-        live: &mut ExecutedBlock,
-        last_term_finished_block_num: u64,
-        current_term_id: u64,
-    ) -> Result<(), Error> {
-        live.state_mut().change_term_id(last_term_finished_block_num, current_term_id)?;
+    pub fn increase_term_id(&self, live: &mut ExecutedBlock, last_term_finished_block_num: u64) -> Result<(), Error> {
+        live.state_mut().increase_term_id(last_term_finished_block_num)?;
         Ok(())
     }
 }

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -164,14 +164,14 @@ impl ConsensusEngine for Tendermint {
             return Ok(())
         }
         stake::add_intermediate_rewards(block.state_mut(), author, block_author_reward)?;
-        let (last_term_finished_block_num, current_term_id) = {
+        let last_term_finished_block_num = {
             let header = block.header();
-            let term_id = header.timestamp() / term_seconds;
-            let parent_term_id = parent_header.timestamp() / term_seconds;
-            if term_id == parent_term_id {
+            let current_term_period = header.timestamp() / term_seconds;
+            let parent_term_period = parent_header.timestamp() / term_seconds;
+            if current_term_period == parent_term_period {
                 return Ok(())
             }
-            (header.number(), term_id)
+            header.number()
         };
         let rewards = stake::drain_previous_rewards(&mut block.state_mut())?;
         let client = self
@@ -202,7 +202,7 @@ impl ConsensusEngine for Tendermint {
             self.machine.add_balance(block, &address, reward)?;
         }
 
-        self.machine.change_term_id(block, last_term_finished_block_num, current_term_id)?;
+        self.machine.increase_term_id(block, last_term_finished_block_num)?;
         stake::move_current_to_previous_intermediate_rewards(&mut block.state_mut())?;
         Ok(())
     }

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -974,9 +974,9 @@ impl TopState for TopLevelState {
         Ok(())
     }
 
-    fn change_term_id(&mut self, last_term_finished_block_num: u64, current_term_id: u64) -> StateResult<()> {
+    fn increase_term_id(&mut self, last_term_finished_block_num: u64) -> StateResult<()> {
         let mut metadata = self.get_metadata_mut()?;
-        metadata.change_term(last_term_finished_block_num, current_term_id);
+        metadata.increase_term_id(last_term_finished_block_num);
         Ok(())
     }
 

--- a/state/src/item/metadata.rs
+++ b/state/src/item/metadata.rs
@@ -93,11 +93,10 @@ impl Metadata {
         self.params = Some(params);
     }
 
-    pub fn change_term(&mut self, last_term_finished_block_num: u64, current_term_id: u64) {
+    pub fn increase_term_id(&mut self, last_term_finished_block_num: u64) {
         assert!(self.term.last_term_finished_block_num < last_term_finished_block_num);
-        assert!(self.term.current_term_id < current_term_id);
         self.term.last_term_finished_block_num = last_term_finished_block_num;
-        self.term.current_term_id = current_term_id;
+        self.term.current_term_id += 1;
     }
 
     pub fn last_term_finished_block_num(&self) -> u64 {

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -177,7 +177,7 @@ pub trait TopState {
     fn store_text(&mut self, key: &H256, text: Text, sig: &Signature) -> StateResult<()>;
     fn remove_text(&mut self, key: &H256, sig: &Signature) -> StateResult<()>;
 
-    fn change_term_id(&mut self, last_term_finished_block_num: u64, current_term_id: u64) -> StateResult<()>;
+    fn increase_term_id(&mut self, last_term_finished_block_num: u64) -> StateResult<()>;
 
     fn update_action_data(&mut self, key: &H256, data: Bytes) -> StateResult<()>;
     fn remove_action_data(&mut self, key: &H256);


### PR DESCRIPTION
Currently, the `block.timestamp()/term_seconds` is term id. This patch
makes the term id sequential. This guarantees there are no missing term
id.