### PR TITLE
Use the genesis network id at the email title

### DIFF
--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -240,7 +240,11 @@ pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
     );
     let email_alarm = if !config.email_alarm.disable.unwrap() {
         let config = match (&config.email_alarm.to, &config.email_alarm.sendgrid_key) {
-            (Some(to), Some(sendgrid_key)) => Some(EmailAlarmConfig::new(to.to_string(), sendgrid_key.to_string())),
+            (Some(to), Some(sendgrid_key)) => Some(EmailAlarmConfig::new(
+                to.to_string(),
+                sendgrid_key.to_string(),
+                scheme.genesis_params().network_id().to_string(),
+            )),
             (None, _) => return Err("email-alarm-to is not specified".to_string()),
             (_, None) => return Err("email-alarm-sendgrid-key is not specified".to_string()),
         };

--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -248,7 +248,7 @@ pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
             (None, _) => return Err("email-alarm-to is not specified".to_string()),
             (_, None) => return Err("email-alarm-sendgrid-key is not specified".to_string()),
         };
-        config.as_ref().map(EmailAlarm::new)
+        config.map(EmailAlarm::new)
     } else {
         None
     };

--- a/util/logger/src/email.rs
+++ b/util/logger/src/email.rs
@@ -3,13 +3,15 @@ use sendgrid::v3 as sendgrid;
 pub struct EmailAlarmConfig {
     pub to: String,
     pub sendgrid_key: String,
+    pub network_id: String,
 }
 
 impl EmailAlarmConfig {
-    pub fn new(to: String, sendgrid_key: String) -> Self {
+    pub fn new(to: String, sendgrid_key: String, network_id: String) -> Self {
         Self {
             to,
             sendgrid_key,
+            network_id,
         }
     }
 }
@@ -18,6 +20,7 @@ impl EmailAlarmConfig {
 pub struct EmailAlarm {
     pub to: String,
     pub sendgrid_key: String,
+    pub network_id: String,
 }
 
 impl EmailAlarm {
@@ -25,6 +28,7 @@ impl EmailAlarm {
         Self {
             to: config.to.clone(),
             sendgrid_key: config.sendgrid_key.clone(),
+            network_id: config.network_id.clone(),
         }
     }
 
@@ -34,8 +38,7 @@ impl EmailAlarm {
         let now = now.rfc3339();
         let m = sendgrid::Message::new()
             .set_from(sendgrid::Email::new().set_email("no-reply@codechain.io"))
-            // FIXME: fill the network id
-            .set_subject(&format!("[error][?c][codechain] Error from CodeChain-{}", now))
+            .set_subject(&format!("[error][{}][codechain] Error from CodeChain-{}", self.network_id, now))
             .add_content(sendgrid::Content::new().set_content_type("text/html").set_value(log))
             .add_personalization(p);
         let sender = sendgrid::Sender::new(self.sendgrid_key.clone());

--- a/util/logger/src/email.rs
+++ b/util/logger/src/email.rs
@@ -24,11 +24,11 @@ pub struct EmailAlarm {
 }
 
 impl EmailAlarm {
-    pub fn new(config: &EmailAlarmConfig) -> Self {
+    pub fn new(config: EmailAlarmConfig) -> Self {
         Self {
-            to: config.to.clone(),
-            sendgrid_key: config.sendgrid_key.clone(),
-            network_id: config.network_id.clone(),
+            to: config.to,
+            sendgrid_key: config.sendgrid_key,
+            network_id: config.network_id,
         }
     }
 

--- a/util/logger/src/email.rs
+++ b/util/logger/src/email.rs
@@ -1,9 +1,9 @@
 use sendgrid::v3 as sendgrid;
 
 pub struct EmailAlarmConfig {
-    pub to: String,
-    pub sendgrid_key: String,
-    pub network_id: String,
+    to: String,
+    sendgrid_key: String,
+    network_id: String,
 }
 
 impl EmailAlarmConfig {
@@ -18,9 +18,9 @@ impl EmailAlarmConfig {
 
 #[derive(Clone)]
 pub struct EmailAlarm {
-    pub to: String,
-    pub sendgrid_key: String,
-    pub network_id: String,
+    to: String,
+    sendgrid_key: String,
+    network_id: String,
 }
 
 impl EmailAlarm {


### PR DESCRIPTION
The best way is using the current network id, but CodeChain cannot know
the current network id when creating an email alarm.
Instead of the current network id, it can get the genesis network id
easily. Because there is no use case to change the network id yet, it
would be a fine solution for now.

And this PR also does some trivial refactoring.