### PR TITLE
Fix the test case to test invalid signature of store transaction

### DIFF
--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -2221,10 +2221,10 @@ mod tests_tx {
 
         let tx = transaction!(fee: 10, store!(content.clone(), sender, signature));
 
-        assert_eq!(
-            Err(RuntimeError::TextVerificationFail("Invalid Signature".to_string()).into()),
-            state.apply(&tx, &H256::random(), &sender_public, &get_test_client(), 0, 0, 0)
-        );
+        match state.apply(&tx, &H256::random(), &sender_public, &get_test_client(), 0, 0, 0) {
+            Err(StateError::Runtime(RuntimeError::TextVerificationFail(_))) => {}
+            err => panic!("The transaction must fail with text verification failure, but {:?}", err),
+        }
 
         check_top_level_state!(state, [
             (account: sender => (seq: 0, balance: 20)),


### PR DESCRIPTION
Random strings are very likely not to be a signature. However, a random
string can be a signature of some private key which we don't know.

That's the reason that the test has failed flaky.