### PR TITLE
Increase the timeout of term change test

### DIFF
--- a/test/src/e2e/termChange.test.ts
+++ b/test/src/e2e/termChange.test.ts
@@ -30,7 +30,7 @@ import CodeChain from "../helper/spawn";
 
 const RLP = require("rlp");
 
-describe("ChangeParams", function() {
+describe("Term change", function() {
     const chain = `${__dirname}/../scheme/solo-block-reward-50.json`;
     let node: CodeChain;
 

--- a/test/src/e2e/termChange.test.ts
+++ b/test/src/e2e/termChange.test.ts
@@ -159,7 +159,7 @@ describe("Term change", function() {
             [blockNumber2]
         );
         expect(params2).to.be.deep.equals([blockNumber2, 2]);
-    });
+    }).timeout(10_000);
 
     afterEach(async function() {
         if (this.currentTest!.state === "failed") {


### PR DESCRIPTION
Because it waits term change, sometimes it takes longer than 5 seconds.