### PR TITLE
Adjust the log level to avoid spam alarms

### DIFF
--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -980,7 +980,7 @@ impl MinerService for Miner {
                 };
                 get_next_seq(self.future_transactions(), &addresses)
                     .map(|seq| {
-                        cerror!(RPC, "There are future transactions for {}", platform_address);
+                        cwarn!(RPC, "There are future transactions for {}", platform_address);
                         seq
                     })
                     .unwrap_or_else(|| {

--- a/network/src/stream.rs
+++ b/network/src/stream.rs
@@ -142,7 +142,7 @@ impl<Stream: TryRead + TryWrite + PeerAddr + Shutdown> TryStream<Stream> {
                 return Ok(Some(bytes))
             }
             let from_socket = self.peer_addr()?;
-            cerror!(NETWORK, "Invalid messages({:?}) from {}", bytes, from_socket);
+            cwarn!(NETWORK, "Invalid messages({:?}) from {}", bytes, from_socket);
             self.shutdown()?;
             Ok(None)
         } else {

--- a/util/io/src/service.rs
+++ b/util/io/src/service.rs
@@ -469,7 +469,7 @@ where
         self.host_channel
             .lock()
             .send(IoMessage::Shutdown)
-            .unwrap_or_else(|e| cwarn!(IO, "Error on IO service shutdown: {:?}", e));
+            .unwrap_or_else(|e| cerror!(IO, "Error on IO service shutdown: {:?}", e));
         if let Some(thread) = self.thread.lock().take() {
             thread.join().unwrap_or_else(|e| {
                 cdebug!(SHUTDOWN, "Error joining IO service event loop thread: {:?}", e);


### PR DESCRIPTION
Because CodeChain sends error log to email, this patch adjusted the log
level to warning when it doesn't harm the system.