### PR TITLE
Change mergify not to check clahub

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - status-success=continuous-integration/travis-ci/pr
-      - status-success=clahub
       - base=master
       - label!=do-not-merge
       - "- title~=\\b(wip|WIP)\\b"


### PR DESCRIPTION
Because mergify itself didn't sign the clahub, the merge commit that
mergify creates fail to pass clahub check. This makes mergify check only
Travis and approved reviews.
It is the task of the reviewers to make the author sign to clahub.