### PR TITLE
Do not call verify_block_external in the header verification

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -805,12 +805,14 @@ impl BlockChainClient for Client {
 impl TermInfo for Client {
     fn last_term_finished_block_num(&self, id: BlockId) -> Option<BlockNumber> {
         self.state_at(id)
-            .and_then(|state| state.metadata().unwrap())
+            .map(|state| state.metadata().unwrap().expect("Meatadata always exist"))
             .map(|metadata| metadata.last_term_finished_block_num())
     }
 
     fn current_term_id(&self, id: BlockId) -> Option<u64> {
-        self.state_at(id).and_then(|state| state.metadata().unwrap()).map(|metadata| metadata.current_term_id())
+        self.state_at(id)
+            .map(|state| state.metadata().unwrap().expect("Metadata always exist"))
+            .map(|metadata| metadata.current_term_id())
     }
 }
 

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -384,19 +384,6 @@ impl Importer {
             );
             return false
         };
-
-        // "external" verification.
-        if let Err(e) = self.engine.verify_block_external(&header) {
-            cwarn!(
-                CLIENT,
-                "Stage 4 block verification failed for #{} ({})\nError: {:?}",
-                header.number(),
-                header.hash(),
-                e
-            );
-            return false
-        };
-
         true
     }
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -100,6 +100,8 @@ pub struct TestBlockChainClient {
     pub latest_block_timestamp: RwLock<u64>,
     /// Pruning history size to report.
     pub history: RwLock<Option<u64>>,
+    /// Term ID
+    pub term_id: Option<u64>,
 }
 
 impl Default for TestBlockChainClient {
@@ -151,6 +153,7 @@ impl TestBlockChainClient {
             scheme,
             latest_block_timestamp: RwLock::new(10_000_000),
             history: RwLock::new(None),
+            term_id: None,
         };
 
         // insert genesis hash.
@@ -618,7 +621,7 @@ impl TermInfo for TestBlockChainClient {
     }
 
     fn current_term_id(&self, _id: BlockId) -> Option<u64> {
-        None
+        self.term_id
     }
 }
 

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -376,7 +376,14 @@ impl Worker {
     fn block_proposer_idx(&self, block_hash: H256) -> Option<usize> {
         self.client().block_header(&BlockId::Hash(block_hash)).map(|header| {
             let proposer = header.author();
-            let parent = header.parent_hash();
+            let parent = if header.number() == 0 {
+                // Genesis block's parent is not exist
+                // FIXME: The DynamicValidator should handle the Genesis block correctly.
+                block_hash
+            } else {
+                header.parent_hash()
+            };
+
             self.validators.get_index_by_address(&parent, &proposer).expect("The proposer must be in the validator set")
         })
     }

--- a/core/src/consensus/validator_set/dynamic_validator.rs
+++ b/core/src/consensus/validator_set/dynamic_validator.rs
@@ -193,17 +193,26 @@ impl ValidatorSet for DynamicValidator {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use ckey::Public;
 
     use super::super::ValidatorSet;
     use super::DynamicValidator;
+    use crate::client::TestBlockChainClient;
+    use client::ConsensusClient;
 
     #[test]
     fn validator_set() {
         let a1 = Public::from_str("34959b60d54703e9dfe36afb1e9950a4abe34d666cbb64c92969013bc9cc74063f9e4680d9d48c4597ee623bd4b507a1b2f43a9c5766a06463f85b73a94c51d1").unwrap();
         let a2 = Public::from_str("8c5a25bfafceea03073e2775cfb233a46648a088c12a1ca18a5865534887ccf60e1670be65b5f8e29643f463fdf84b1cbadd6027e71d8d04496570cb6b04885d").unwrap();
         let set = DynamicValidator::new(vec![a1, a2]);
+        let test_client: Arc<ConsensusClient> = Arc::new({
+            let mut client = TestBlockChainClient::new();
+            client.term_id = Some(1);
+            client
+        });
+        set.register_client(Arc::downgrade(&test_client));
         assert!(set.contains(&Default::default(), &a1));
         assert_eq!(set.get(&Default::default(), 0), a1);
         assert_eq!(set.get(&Default::default(), 1), a2);

--- a/core/src/consensus/validator_set/dynamic_validator.rs
+++ b/core/src/consensus/validator_set/dynamic_validator.rs
@@ -42,9 +42,15 @@ impl DynamicValidator {
     }
 
     fn validators(&self, parent: H256) -> Option<Vec<Validator>> {
-        let client: Arc<ConsensusClient> = self.client.read().as_ref().and_then(Weak::upgrade)?;
+        let client: Arc<ConsensusClient> =
+            self.client.read().as_ref().and_then(Weak::upgrade).expect("Client is not initialized");
         let block_id = parent.into();
-        if client.current_term_id(block_id)? == 0 {
+        let term_id = client.current_term_id(block_id).expect(
+            "valdators() is called when creating a block or verifying a block.
+            Minor creates a block only when the parent block is imported.
+            The n'th block is verified only when the parent block is imported.",
+        );
+        if term_id == 0 {
             return None
         }
         let state = client.state_at(block_id)?;


### PR DESCRIPTION
`verify_block_external` could use the parent block's state. In the
Tendermint consensus, `verify_block_external` uses the parent block's
state to calculate the current validator set.