### PR TITLE
Fix the bug that calculates the number of signatures wrongly

### DIFF
--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -205,7 +205,7 @@ impl ConsensusEngine for Tendermint {
         } else {
             let start_of_the_previous_term = {
                 let end_of_the_two_level_previous_term =
-                    client.last_term_finished_block_num(metadata.last_term_finished_block_num().into()).unwrap();
+                    client.last_term_finished_block_num((metadata.last_term_finished_block_num() - 1).into()).unwrap();
 
                 end_of_the_two_level_previous_term + 1
             };


### PR DESCRIPTION
```client.last_term_finished_block_num(metadata.last_term_finished_block_num().into())``` returns the last block number of the previous term; so 1 block after it is the start of the current term, not the start of the previous term.