### PR TITLE
Change the versions of master branch to 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "codechain"
-version = "1.3.0"
+version = "0.0.0"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cidr 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codechain"
-version = "1.3.0"
+version = "0.0.0"
 license = "AGPL-3.0"
 authors = ["CodeChain Team <hi@codechain.io>"]
 exclude = [


### PR DESCRIPTION
The version of the master branch doesn't make sense because we use the release branch.
I suggest fixing the master branch version to 0.0.0.