### PR TITLE
Make additional reward to be added to pending_reward

### DIFF
--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -424,7 +424,8 @@ fn calculate_pending_rewards_of_the_previous_term(
 
     // Give additional rewards
     give_additional_rewards(reduced_rewards, missed_signatures, |address, reward| {
-        pending_rewards.insert(*address, reward);
+        let prev = pending_rewards.entry(*address).or_default();
+        *prev += reward;
         Ok(())
     })?;
 


### PR DESCRIPTION
Previous implementation will overwrite a pending reward with an additional reward. That does not fit with the original intention. Now an additional reward becomes to be added.