### PR TITLE
[rc-1.4.x] Install libssl-dev in the docker image

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -43,6 +43,7 @@ FROM ubuntu:18.04
 WORKDIR /app/codechain
 COPY --from=builder /build/codechain/target/release/codechain ./target/release/codechain
 COPY --from=builder /build/codechain/codechain/config/presets/ ./codechain/config/presets
+RUN apt-get update && apt-get install -y libssl-dev
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -41,9 +41,9 @@ RUN file /build/codechain/target/release/codechain
 
 FROM ubuntu:18.04
 WORKDIR /app/codechain
+RUN apt-get update && apt-get install -y libssl-dev
 COPY --from=builder /build/codechain/target/release/codechain ./target/release/codechain
 COPY --from=builder /build/codechain/codechain/config/presets/ ./codechain/config/presets
-RUN apt-get update && apt-get install -y libssl-dev
 
 # show backtraces
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
Ubuntu 14.04 doesn't need the libssl-dev. However, 18.04 needs it.