### PR TITLE
Break a tie on the validator election

### DIFF
--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -284,7 +284,7 @@ impl Validators {
         assert!(max_num_of_validators > min_num_of_validators);
 
         let delegatees = Stakeholders::delegatees(&state)?;
-        // Step 1
+        // Step 1 & 2.
         let mut validators = Candidates::prepare_validators(&state, min_deposit, &delegatees)?;
         // validators are now sorted in descending order of (delegation, deposit, priority)
         validators.reverse();
@@ -295,16 +295,8 @@ impl Validators {
             assert!(!banned.is_banned(&address), "{} is banned address", address);
         }
 
-        let the_highest_score_dropout =
-            validators.get(max_num_of_validators).map(|&validator| (validator.delegation, validator.deposit));
-
-        // step 2
+        // Step 3
         validators.truncate(max_num_of_validators);
-
-        // step 3
-        if let Some(the_highest_score_dropout) = the_highest_score_dropout {
-            validators.retain(|&validator| (validator.delegation, validator.deposit) > the_highest_score_dropout);
-        }
 
         if validators.len() < min_num_of_validators {
             cerror!(
@@ -315,7 +307,7 @@ impl Validators {
                 min_num_of_validators
             );
         }
-
+        // Step 4 & 5
         let (minimum, rest) = validators.split_at(min_num_of_validators.min(validators.len()));
         let over_threshold = rest.iter().filter(|c| c.delegation >= delegation_threshold);
 

--- a/spec/Dynamic-Validator.md
+++ b/spec/Dynamic-Validator.md
@@ -65,10 +65,12 @@ The delegated stakes are returned when the account becomes an eligible account o
 ## Election
 The election is a process that elects validators of a term according to the following rule:
 
-1. Select the candidates who deposited **MIN_DEPOSIT** or more.
-2. Pick **MAX_NUM_OF_VALIDATORS** candidates in order of the amount of received delegations and the amount of deposit that the candidate made.
-3. If there are candidates who have tied delegation scores with the dropouts, drop those candidates as well.
-4. Select **MIN_NUM_OF_VALIDATORS** accounts; they become validators.
+1. Calculate the rankings of candidates.
+   * Candidates who receive the most delegation will have the highest ranking.
+   * If there is a tie between them, candidates with the higher index in the `candidates` list will have the higher ranking.
+2. Select the candidates who deposited **MIN_DEPOSIT** or more.
+3. Pick the top **MAX_NUM_OF_VALIDATORS** candidates.
+4. Select the top **MIN_NUM_OF_VALIDATORS** accounts; they become validators.
 5. Among the rest of them, drop the accounts that received less than **DELEGATION_THRESHOLD**; the remaining accounts become validators.
 
 This process guarantees two things:
@@ -97,7 +99,7 @@ for (&mut delegation, _, pubkey) in validators[(author_index + 1)..] {
 	delegation -= min_delegation * 2;
 }
 // Deprioritize author
-validators[author_index].2 -= min_delegation;
+validators[author_index].0 -= min_delegation;
 
 validators.sort();
 


### PR DESCRIPTION
This changes `candadates` state sort ordering. 
To break a tie on `(delegation, deposit)`, we introduce a candidate priority. Candidate have highest priority when it has responded most recently. We give them a highest index in `candidate` list on the state.