### PR TITLE
Don't panic if the max_num is equal to the min_num for validators

### DIFF
--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -281,7 +281,7 @@ impl Validators {
                 common_params.min_deposit(),
             )
         };
-        assert!(max_num_of_validators > min_num_of_validators);
+        assert!(max_num_of_validators >= min_num_of_validators);
 
         let delegatees = Stakeholders::delegatees(&state)?;
         // Step 1 & 2.


### PR DESCRIPTION
https://github.com/CodeChain-io/codechain/blob/4e0238689331d61e733db342d49af77d1791743d/types/src/common_params.rs#L192 and https://github.com/CodeChain-io/codechain/blob/4e0238689331d61e733db342d49af77d1791743d/core/src/consensus/stake/action_data.rs#L284 have different criteria for common parameters.
This patch fixes latter to allow situations where the `max_num_of_validators` are equal to the `min_num_of_validators`.