### PR TITLE
Specify test timeout and slowness.

### DIFF
--- a/test/src/e2e.dynval/dv.n'.test.ts
+++ b/test/src/e2e.dynval/dv.n'.test.ts
@@ -50,10 +50,9 @@ const [alice, betty, notUsed, ...otherDynValidators] = originalDynValidators;
 const allDynValidators = [alice, betty, ...otherDynValidators];
 
 describe("Dynamic Validator N -> N'", function() {
-    this.timeout(0);
-
     const promiseExpect = new PromiseExpect();
     const TERM_SECONDS = 30;
+    const margin = 1.2;
 
     describe("1. Jail one of the validator + increase the delegation of a candidate who doesn’t have enough delegation", async function() {
         const allDynNodes = withNodes(this, {
@@ -78,7 +77,9 @@ describe("Dynamic Validator N -> N'", function() {
         });
 
         it("Alice should get out of the committee and Betty should be included in the committee", async function() {
-            const margin = 1.1;
+            this.slow(TERM_SECONDS * margin * 1000); // All tests waits at most 1 terms.
+            this.timeout(TERM_SECONDS * 2 * 1000);
+
             const [_aliceNode, _bettyNode, ...otherDynNodes] = allDynNodes;
             {
                 const authors = (await stake.getPossibleAuthors(

--- a/test/src/e2e.dynval/dv.n.test.ts
+++ b/test/src/e2e.dynval/dv.n.test.ts
@@ -28,8 +28,6 @@ import { withNodes } from "./setup";
 chai.use(chaiAsPromised);
 
 describe("Dynamic Validator N -> N", function() {
-    this.timeout(0);
-
     const promiseExpect = new PromiseExpect();
     const termSeconds = 20;
     const margin = 1.2;
@@ -58,6 +56,9 @@ describe("Dynamic Validator N -> N", function() {
         });
 
         it("should keep possible authors after a term change", async function() {
+            this.slow(termSeconds * margin * 1000);
+            this.timeout(termSeconds * 2 * 1000);
+
             await nodes[0].waitForTermChange(2, termSeconds * margin);
             const blockNumber = await nodes[0].sdk.rpc.chain.getBestBlockNumber();
             const termMetadata = await stake.getTermMetadata(
@@ -115,6 +116,9 @@ describe("Dynamic Validator N -> N", function() {
         });
 
         it("should keep possible authors after a term change", async function() {
+            this.slow(termSeconds * margin * 1000);
+            this.timeout(termSeconds * 2 * 1000);
+
             const insufficientDelegationTx = await nodes[0].sdk.rpc.chain.sendSignedTransaction(
                 stake
                     .createDelegateCCSTransaction(
@@ -187,6 +191,9 @@ describe("Dynamic Validator N -> N", function() {
         });
 
         it("should keep possible authors after a term change", async function() {
+            this.slow(termSeconds * margin * 1000);
+            this.timeout(termSeconds * 2 * 1000);
+
             const insufficientDelegationTx = await nodes[0].sdk.rpc.chain.sendSignedTransaction(
                 stake
                     .createDelegateCCSTransaction(
@@ -259,6 +266,9 @@ describe("Dynamic Validator N -> N", function() {
         });
 
         it("should keep possible authors after a term change", async function() {
+            this.slow(termSeconds * margin * 1000);
+            this.timeout(termSeconds * 2 * 1000);
+
             const insufficientDelegationTx = await nodes[0].sdk.rpc.chain.sendSignedTransaction(
                 stake
                     .createRevokeTransaction(
@@ -331,6 +341,9 @@ describe("Dynamic Validator N -> N", function() {
         });
 
         it("should keep possible authors after a term change", async function() {
+            this.slow(termSeconds * margin * 1000);
+            this.timeout(termSeconds * 2 * 1000);
+
             const insufficientDelegationTx = await nodes[0].sdk.rpc.chain.sendSignedTransaction(
                 stake
                     .createDelegateCCSTransaction(
@@ -425,6 +438,9 @@ describe("Dynamic Validator N -> N", function() {
         ].forEach(({ description, deposit, delegation }) => {
             describe(description, async function() {
                 it("should keep possible authors after a term change", async function() {
+                    this.slow(termSeconds * margin * 1000);
+                    this.timeout(termSeconds * 2 * 1000);
+
                     const nominationTx = await nodes[4].sdk.rpc.chain.sendSignedTransaction(
                         stake
                             .createSelfNominateTransaction(

--- a/test/src/e2e.dynval/setup.ts
+++ b/test/src/e2e.dynval/setup.ts
@@ -45,6 +45,14 @@ export function withNodes(
 ): CodeChain[] {
     const result: CodeChain[] = [];
     suite.beforeEach(async function() {
+        const termSeconds =
+            (options &&
+                options.overrideParams &&
+                options.overrideParams.termSeconds) ||
+            defaultParams.termSeconds;
+        const secsPerBlock = 5;
+        this.slow((secsPerBlock * 3 + termSeconds) * 1000); // createNodes will wait for 3 blocks + at most 1 terms
+        this.timeout((secsPerBlock * 3 + termSeconds) * 2 * 1000);
         result.length = 0;
         const nodes = await createNodes(options);
         result.push(...nodes);


### PR DESCRIPTION
According to the mochaJS document (https://mochajs.org/#test-duration)
```
|--FAST--|--NORMAL--|--------SLOW--------|
0      slow/2      slow               timeout
```
NORMAL tasks will report the test duration of it by yellow, and SLOW tasks
will report the test duration of it by red color.

Most of the dynamic validator tests should be HERE
```
                  v-- HERE
|--FAST--|--NORMAL--|--------SLOW--------|
0      slow/2      slow               timeout
```

Note: 
I've set the parameter with following formula.
> slow: expected time * margin (1.1~1.5)
> timeout: expected time * 2

I've set per-hook timeout, and per-suite timeout. You can also set per-test timeout.
A test can take several more times than you've set to. Timeout is reset on each event.
```typescript
describe("It took much longer than the timeout!", function() {
    this.timeout(1000);
	beforeEach(function() { sleep(900); });
	beforeEach(function() { sleep(800); });
	it("doesn't finish with timeout", function() { sleep(900); });
	afterEach(function() { sleep(700); });
});
```
will prints
```
  It took much longer than the timeout!
    ✓ doesn't finish with timeout (903ms)


  1 passing (3s)

✨  Done in 5.24s.
```

Refer: https://github.com/CodeChain-io/codechain/issues/1705