### PR TITLE
Automatically create a ReportDoubleVote transaction

### DIFF
--- a/codechain/rpc_apis.rs
+++ b/codechain/rpc_apis.rs
@@ -34,7 +34,7 @@ impl ApiDependencies {
     pub fn extend_api(&self, enable_devel_api: bool, handler: &mut MetaIoHandler<(), impl Middleware<()>>) {
         use crpc::v1::*;
         handler.extend_with(ChainClient::new(Arc::clone(&self.client)).to_delegate());
-        handler.extend_with(MempoolClient::new(Arc::clone(&self.client), Arc::clone(&self.miner)).to_delegate());
+        handler.extend_with(MempoolClient::new(Arc::clone(&self.client)).to_delegate());
         if enable_devel_api {
             handler.extend_with(
                 DevelClient::new(Arc::clone(&self.client), Arc::clone(&self.miner), self.block_sync.clone())

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -52,7 +52,7 @@ use crate::error::{BlockImportError, Error, ImportError, SchemeError};
 use crate::miner::{Miner, MinerService};
 use crate::scheme::Scheme;
 use crate::service::ClientIoMessage;
-use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, UnverifiedTransaction};
+use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction, UnverifiedTransaction};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 
 const MAX_MEM_POOL_SIZE: usize = 4096;
@@ -718,6 +718,12 @@ impl ImportBlock for Client {
 impl BlockChainClient for Client {
     fn queue_info(&self) -> BlockQueueInfo {
         self.importer.block_queue.queue_info()
+    }
+
+    /// Import own transaction
+    fn queue_own_transaction(&self, transaction: SignedTransaction) -> Result<(), Error> {
+        self.importer.miner.import_own_transaction(self, transaction)?;
+        Ok(())
     }
 
     fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: NodeId) {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -114,7 +114,7 @@ pub trait EngineClient: Sync + Send + BlockChainTrait + ImportBlock {
     fn get_kvdb(&self) -> Arc<KeyValueDB>;
 }
 
-pub trait ConsensusClient: BlockChainTrait + EngineClient + EngineInfo + TermInfo + StateInfo {}
+pub trait ConsensusClient: BlockChainClient + EngineClient + EngineInfo + TermInfo + StateInfo {}
 
 pub trait TermInfo {
     fn last_term_finished_block_num(&self, id: BlockId) -> Option<BlockNumber>;

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -46,8 +46,8 @@ use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
 use crate::consensus::EngineError;
 use crate::encoded;
-use crate::error::BlockImportError;
-use crate::transaction::{LocalizedTransaction, PendingSignedTransactions};
+use crate::error::{BlockImportError, Error as GenericError};
+use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 
 /// Provides various blockchain information, like block header, chain state etc.
@@ -213,6 +213,9 @@ pub trait ImportBlock {
 pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + ImportBlock + ChainTimeInfo {
     /// Get block queue information.
     fn queue_info(&self) -> BlockQueueInfo;
+
+    /// Queue own transaction for importing
+    fn queue_own_transaction(&self, transaction: SignedTransaction) -> Result<(), GenericError>;
 
     /// Queue transactions for importing.
     fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: NodeId);

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -63,7 +63,7 @@ use crate::consensus::stake::{Validator, Validators};
 use crate::consensus::EngineError;
 use crate::db::{COL_STATE, NUM_COLUMNS};
 use crate::encoded;
-use crate::error::BlockImportError;
+use crate::error::{BlockImportError, Error as GenericError};
 use crate::miner::{Miner, MinerService, TransactionImportResult};
 use crate::scheme::Scheme;
 use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
@@ -505,6 +505,11 @@ impl BlockChainClient for TestBlockChainClient {
             max_mem_use: 0,
             mem_used: 0,
         }
+    }
+
+    fn queue_own_transaction(&self, transaction: SignedTransaction) -> Result<(), GenericError> {
+        self.miner.import_own_transaction(self, transaction)?;
+        Ok(())
     }
 
     fn queue_transactions(&self, transactions: Vec<Bytes>, _peer_id: NodeId) {

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -24,7 +24,7 @@ mod solo;
 pub mod stake;
 mod tendermint;
 mod validator_set;
-mod vote_collector;
+pub mod vote_collector;
 
 pub use self::blake_pow::BlakePoW;
 pub use self::cuckoo::Cuckoo;

--- a/core/src/consensus/stake/mod.rs
+++ b/core/src/consensus/stake/mod.rs
@@ -37,11 +37,11 @@ use rlp::{Decodable, UntrustedRlp};
 
 pub use self::action_data::{Banned, Validator, Validators};
 use self::action_data::{Candidates, Delegation, IntermediateRewards, Jail, ReleaseResult, StakeAccount, Stakeholders};
-use self::actions::Action;
+pub use self::actions::Action;
 pub use self::distribute::fee_distribute;
 use super::ValidatorSet;
 
-const CUSTOM_ACTION_HANDLER_ID: u64 = 2;
+pub const CUSTOM_ACTION_HANDLER_ID: u64 = 2;
 
 pub struct Stake<M> {
     genesis_stakes: HashMap<Address, u64>,

--- a/core/src/consensus/vote_collector.rs
+++ b/core/src/consensus/vote_collector.rs
@@ -24,6 +24,7 @@ use parking_lot::RwLock;
 use primitives::H256;
 use rlp::{Decodable, Encodable, RlpStream};
 
+use super::stake::Action;
 use super::BitSet;
 
 pub trait Message: Clone + PartialEq + Eq + Hash + Encodable + Decodable + Debug + Sync + Send {
@@ -62,6 +63,15 @@ pub struct DoubleVote<M: Message> {
     author_index: usize,
     vote_one: M,
     vote_two: M,
+}
+
+impl<M: Message> DoubleVote<M> {
+    pub fn to_action(&self) -> Action<M> {
+        Action::ReportDoubleVote {
+            message1: self.vote_one.clone(),
+            message2: self.vote_two.clone(),
+        }
+    }
 }
 
 impl<M: Message> Encodable for DoubleVote<M> {

--- a/test/src/e2e.dynval/doubleVote.test.ts
+++ b/test/src/e2e.dynval/doubleVote.test.ts
@@ -1,0 +1,75 @@
+// Copyright 2019 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import * as chai from "chai";
+import { expect } from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as stake from "codechain-stakeholder-sdk";
+import "mocha";
+
+import { Mock } from "../helper/mock";
+import { validators } from "../../tendermint.dynval/constants";
+import { PromiseExpect } from "../helper/promise";
+import { setTermTestTimeout, withNodes } from "./setup";
+
+chai.use(chaiAsPromised);
+
+describe("Double vote detection", function() {
+    const promiseExpect = new PromiseExpect();
+
+    const [alice, betty, charlie] = validators;
+
+    const { nodes } = withNodes(this, {
+        promiseExpect,
+        validators: [
+            { signer: alice, delegation: 5000, deposit: 10_000_000 - 0 },
+            { signer: betty, delegation: 5000, deposit: 10_000_000 - 1 },
+            { signer: charlie, delegation: 5000, deposit: 10_000_000 - 2 }
+        ],
+        overrideParams: {
+            termSeconds: 20,
+            minNumOfValidators: 3
+        }
+    });
+
+    let mock: Mock;
+
+    beforeEach(async function() {
+        const aliceNode = nodes[0];
+        mock = new Mock("0.0.0.0", aliceNode.port, aliceNode.sdk.networkId);
+    });
+
+    it("Should create ReportDoubleVote transaction if double vote is detected", async function() {
+        const termWaiter = setTermTestTimeout(this, { terms: 1 });
+
+        const aliceNode = nodes[0];
+        await mock.establishWithoutSync();
+        mock.startDoubleVote(alice.privateKey);
+        await termWaiter.waitNodeUntilTerm(aliceNode, {
+            target: 2,
+            termPeriods: 1
+        });
+        const banned = await stake.getBanned(aliceNode.sdk);
+        expect(banned.map(b => b.toString())).to.include(
+            alice.platformAddress.toString()
+        );
+    });
+
+    afterEach(async function() {
+        await mock.end();
+        promiseExpect.checkFulfilled();
+    });
+});

--- a/test/src/e2e.dynval/setup.ts
+++ b/test/src/e2e.dynval/setup.ts
@@ -326,7 +326,7 @@ export const defaultParams = {
     minSetShardOwnersCost: 10,
     minSetShardUsersCost: 10,
     minWrapCccCost: 10,
-    minCustomCost: 10,
+    minCustomCost: 0,
     minStoreCost: 10,
     minRemoveCost: 10,
     minMintAssetCost: 10,

--- a/test/src/helper/mock/index.ts
+++ b/test/src/helper/mock/index.ts
@@ -18,6 +18,7 @@ import { SignedTransaction } from "codechain-sdk/lib/core/SignedTransaction";
 import { BlockSyncMessage, Emitter, IBodiesq, IHeadersq, MessageType, ResponseMessage } from "./blockSyncMessage";
 import { Header } from "./cHeader";
 import { P2pLayer } from "./p2pLayer";
+import { TendermintMessage } from "./tendermintMessage";
 import { TransactionSyncMessage } from "./transactionSyncMessage";
 
 type EncodedHeaders = Array<Array<Buffer>>;
@@ -63,6 +64,12 @@ export class Mock {
         this.sendStatus(score, best, genesis);
 
         await this.waitHeaderRequest();
+
+        if (this.log) { console.log("Connected\n"); }
+    }
+
+    public async establishWithoutSync() {
+        await this.p2psocket.connect();
 
         if (this.log) { console.log("Connected\n"); }
     }
@@ -174,6 +181,10 @@ export class Mock {
             data: transactions
         });
         await this.p2psocket.sendExtensionMessage("transaction-propagation", message.rlpBytes(), false);
+    }
+
+    public async sendTendermintMessage(message: TendermintMessage) {
+        await this.p2psocket.sendExtensionMessage("tendermint", message.rlpBytes(), false);
     }
 
     public async sendEncodedBlock(header: EncodedHeaders, body: EncodedBodies, bestBlockHash: H256, bestBlockScore: U256) {

--- a/test/src/helper/mock/p2pLayer.ts
+++ b/test/src/helper/mock/p2pLayer.ts
@@ -41,6 +41,7 @@ export class P2pLayer {
 
     constructor(ip: string, port: number, networkId: string) {
         this.socket = new Socket();
+        this.socket.setMaxListeners(0);
         this.ip = ip;
         this.port = port;
         this.arrivedExtensionMessage = [];

--- a/test/src/helper/mock/tendermintMessage.ts
+++ b/test/src/helper/mock/tendermintMessage.ts
@@ -1,0 +1,257 @@
+// Copyright 2018-2019 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+import { H256, U64 } from "codechain-primitives";
+import { EventEmitter } from "events";
+import { compressSync, uncompressSync } from "snappy";
+
+const RLP = require("rlp");
+
+export const Emitter = new EventEmitter();
+
+enum MessageType {
+    MESSAGE_ID_CONSENSUS_MESSAGE = 0x01,
+    MESSAGE_ID_PROPOSAL_BLOCK = 0x02,
+    MESSAGE_ID_STEP_STATE = 0x03,
+    MESSAGE_ID_REQUEST_MESSAGE = 0x04,
+    MESSAGE_ID_REQUEST_PROPOSAL = 0x05,
+}
+
+export enum Step {
+    Propose = 0,
+    Prevote = 1,
+    Precommit = 2,
+    Commit = 3,
+}
+
+interface VoteStep {
+    height: number,
+    view: number,
+    step: Step,
+}
+
+export interface ConsensusMessage {
+    type: "consensusmessage",
+    messages: Array<{
+        on: {
+            step: VoteStep,
+            blockHash: H256 | null,
+        },
+        signature: string,
+        signerIndex: number,
+    }>;
+}
+
+export interface ProposalBlock {
+    type: "proposalblock",
+    signature: string,
+    view: number,
+    message: Buffer,
+}
+
+export interface StepState {
+    type: "stepstate",
+    voteStep: VoteStep,
+    proposal: H256 | null,
+    lockView: number | null,
+    knownVotes: Buffer
+}
+
+export interface RequestMessage {
+    type: "requestmessage",
+    voteStep: VoteStep,
+    requestedVotes: Buffer,
+}
+
+export interface RequestProposal {
+    type: "requestproposal",
+    height: number,
+    view: number,
+}
+
+type MessageBody = ConsensusMessage | ProposalBlock | StepState | RequestMessage | RequestProposal;
+
+function readOptionalRlp<T>(bytes: [] | [Buffer], decoder: (b: Buffer) => T) {
+    if (bytes.length === 0) {
+        return null;
+    } else {
+        return decoder(bytes[0]);
+    }
+}
+
+function readUIntRLP(bytes: Buffer) {
+    if (bytes.length === 0) {
+        return 0;
+    } else {
+        return bytes.readUIntBE(0, bytes.length);
+    }
+}
+
+export class TendermintMessage {
+
+    public static fromBytes(bytes: Buffer): TendermintMessage {
+        const decoded = RLP.decode(bytes);
+        const id = readUIntRLP(decoded[0]);
+        let message: MessageBody;
+        switch (id) {
+            case MessageType.MESSAGE_ID_CONSENSUS_MESSAGE: {
+                message = {
+                    type: "consensusmessage",
+                    messages: decoded[1].map((d: any) => {
+                        const inner = RLP.decode(d);
+                        return ({
+                            on: {
+                                step: {
+                                    height: readUIntRLP(inner[0][0][0]),
+                                    view: readUIntRLP(inner[0][0][1]),
+                                    step: readUIntRLP(inner[0][0][2]) as Step,
+                                },
+                                blockHash: readOptionalRlp(
+                                    inner[0][1],
+                                    (buffer) => new H256(buffer.toString("hex"))
+                                ),
+                            },
+                            signature: inner[1].toString("hex"),
+                            signerIndex: readUIntRLP(inner[2]),
+                        })
+                    }),
+                };
+                break;
+            }
+            case MessageType.MESSAGE_ID_PROPOSAL_BLOCK: {
+                message = {
+                    type: "proposalblock",
+                    signature: decoded[1].toString("hex"),
+                    view: readUIntRLP(decoded[2]),
+                    message: uncompressSync(decoded[3]),
+                };
+                break;
+            }
+            case MessageType.MESSAGE_ID_STEP_STATE: {
+                message = {
+                    type: "stepstate",
+                    voteStep: {
+                        height: readUIntRLP(decoded[1][0]),
+                        view: readUIntRLP(decoded[1][1]),
+                        step: readUIntRLP(decoded[1][2]) as Step,
+                    },
+                    proposal: readOptionalRlp(decoded[2], (buffer) =>  new H256(buffer.toString("hex"))),
+                    lockView: readOptionalRlp(decoded[3], readUIntRLP),
+                    knownVotes: decoded[4],
+                };
+                break;
+            }
+            case MessageType.MESSAGE_ID_REQUEST_MESSAGE: {
+                message = {
+                    type: "requestmessage",
+                    voteStep: {
+                        height: readUIntRLP(decoded[1][0]),
+                        view: readUIntRLP(decoded[1][1]),
+                        step: readUIntRLP(decoded[1][2]) as Step,
+                    },
+                    requestedVotes: decoded[2],
+                };
+                break;
+            }
+            case MessageType.MESSAGE_ID_REQUEST_PROPOSAL: {
+                message = {
+                    type: "requestproposal",
+                    height: readUIntRLP(decoded[1]),
+                    view: readUIntRLP(decoded[2]),
+                };
+                break;
+            }
+            default: {
+                throw new Error(`Unexpected message id ${id}`);
+            }
+        }
+        Emitter.emit(message.type, message);
+        return new TendermintMessage(message);
+    }
+    private body: MessageBody;
+
+    constructor(body: MessageBody) {
+        this.body = body;
+    }
+
+    public getBody(): MessageBody {
+        return this.body;
+    }
+
+    public toEncodeObject() {
+        switch (this.body.type) {
+            case "consensusmessage": {
+                return [
+                    MessageType.MESSAGE_ID_CONSENSUS_MESSAGE,
+                    this.body.messages.map((m) => RLP.encode([
+                        [
+                            [
+                                new U64(m.on.step.height).toEncodeObject(),
+                                new U64(m.on.step.view).toEncodeObject(),
+                                new U64(m.on.step.step).toEncodeObject(),
+                            ],
+                            m.on.blockHash == null ? [] : [m.on.blockHash.toEncodeObject()],
+                        ],
+                        Buffer.from(m.signature, "hex"),
+                        new U64(m.signerIndex).toEncodeObject(),
+                    ])),
+                ];
+            }
+            case "proposalblock": {
+                return [
+                    MessageType.MESSAGE_ID_PROPOSAL_BLOCK,
+                    Buffer.from(this.body.signature, "hex"),
+                    new U64(this.body.view).toEncodeObject(),
+                    compressSync(this.body.message),
+                ];
+            }
+            case "stepstate": {
+                return [
+                    MessageType.MESSAGE_ID_STEP_STATE,
+                    [
+                        new U64(this.body.voteStep.height).toEncodeObject(),
+                        new U64(this.body.voteStep.view).toEncodeObject(),
+                        new U64(this.body.voteStep.step).toEncodeObject(),
+                    ],
+                    this.body.proposal == null ? [] : [this.body.proposal.toEncodeObject()],
+                    this.body.lockView == null ? [] : [new U64(this.body.lockView).toEncodeObject()],
+                    this.body.knownVotes,
+                ];
+            }
+            case "requestmessage": {
+                return [
+                    MessageType.MESSAGE_ID_REQUEST_MESSAGE,
+                    [
+                        new U64(this.body.voteStep.height).toEncodeObject(),
+                        new U64(this.body.voteStep.view).toEncodeObject(),
+                        new U64(this.body.voteStep.step).toEncodeObject(),
+                    ],
+                    this.body.requestedVotes,
+                ];
+            }
+            case "requestproposal": {
+                return [
+                    MessageType.MESSAGE_ID_REQUEST_PROPOSAL,
+                    new U64(this.body.height).toEncodeObject(),
+                    new U64(this.body.view).toEncodeObject(),
+                ];
+            }
+        }
+    }
+
+    public rlpBytes(): Buffer {
+        return RLP.encode(this.toEncodeObject());
+    }
+}


### PR DESCRIPTION
This patch only covers double votes for precommit and prevote messages. 