### PR TITLE
Assert that transaction is executed in the expected term

### DIFF
--- a/test/src/e2e.dynval/1/dv.m-m'.test.ts
+++ b/test/src/e2e.dynval/1/dv.m-m'.test.ts
@@ -24,7 +24,11 @@ import "mocha";
 import { validators } from "../../../tendermint.dynval/constants";
 import { faucetAddress, faucetSecret } from "../../helper/constants";
 import { PromiseExpect } from "../../helper/promise";
-import { setTermTestTimeout, withNodes } from "../setup";
+import {
+    setTermTestTimeout,
+    withNodes,
+    termThatIncludeTransaction
+} from "../setup";
 
 chai.use(chaiAsPromised);
 
@@ -147,6 +151,9 @@ describe("Dynamic Validator M -> M' (Changed the subset, M, M’ = maximum numbe
                     })
             );
             await nodes[0].waitForTx(delegateToCharlie);
+            await expect(
+                termThatIncludeTransaction(nodes[0].sdk, delegateToCharlie)
+            ).eventually.equal(1);
             await termWaiter.waitNodeUntilTerm(nodes[0], {
                 target: 2,
                 termPeriods: 1

--- a/test/src/e2e.dynval/setup.ts
+++ b/test/src/e2e.dynval/setup.ts
@@ -464,3 +464,22 @@ export function setTermTestTimeout(
         }
     };
 }
+
+export async function termThatIncludeTransaction(
+    sdk: SDK,
+    txHash: H256
+): Promise<number> {
+    const transaction = await sdk.rpc.chain.getTransaction(txHash);
+    const minedBlock = transaction!.blockNumber!;
+    const termMetadata = await stake.getTermMetadata(sdk, minedBlock);
+
+    if (minedBlock > termMetadata!.lastTermFinishedBlockNumber) {
+        return termMetadata!.currentTermId;
+    } else if (minedBlock === termMetadata!.lastTermFinishedBlockNumber) {
+        return termMetadata!.currentTermId - 1;
+    } else {
+        throw new Error(
+            "Invalid state. minedBlock should be the same or greater than lastTermFinishedBlockNumber"
+        );
+    }
+}


### PR DESCRIPTION
Currently, some tests are sometiles failed. I suspect that term is
changed unintentionally. This error log will help to find the code
that needs more timeout.