### PR TITLE
Fix a memory leak in header downloader's downloaded

### DIFF
--- a/sync/src/block/downloader/header.rs
+++ b/sync/src/block/downloader/header.rs
@@ -179,6 +179,7 @@ impl HeaderDownloader {
     pub fn mark_as_imported(&mut self, hashes: Vec<H256>) {
         for hash in hashes {
             self.queued.remove(&hash);
+            self.downloaded.remove(&hash);
 
             if self.best_hash == hash {
                 self.pivot = Pivot {
@@ -188,6 +189,7 @@ impl HeaderDownloader {
             }
         }
         self.queued.shrink_to_fit();
+        self.downloaded.shrink_to_fit();
     }
 
     pub fn mark_as_queued(&mut self, hashes: Vec<H256>) {


### PR DESCRIPTION
The header downloader has two queues. The first one is the downloaded
queue, and the second one is the "queued" queue. If a header is
downloaded, downloader enqueues the header to the downloaded
queue. When starting to import the header, the downloader removes the
header from the downloaded queue and enqueues the header to the
"queued" queue. When the importing is done, the downloader removes the
header from the "queued" queue.

However, if a header(let's call it A) is downloaded and is imported
already, A is not removed from the downloaded queue forever. This
commit removes A from the downloaded header.