### PR TITLE
Do not request older headers if re-organization is not occurred

### DIFF
--- a/sync/src/block/downloader/header.rs
+++ b/sync/src/block/downloader/header.rs
@@ -142,7 +142,10 @@ impl HeaderDownloader {
     /// Imports headers and mark success
     /// Expects importing headers matches requested header
     pub fn import_headers(&mut self, headers: &[Header]) {
-        let first_header_hash = headers.first().expect("First header must exist").hash();
+        let first_header = headers.first().expect("First header must exist");
+        let first_header_hash = first_header.hash();
+        let first_header_number = first_header.number();
+        let pivot_header = self.pivot_header();
 
         // This happens when best_hash is imported by other peer.
         if self.best_hash == self.pivot.hash {
@@ -158,14 +161,26 @@ impl HeaderDownloader {
                 hash: headers.last().expect("Last downloaded header must exist").hash(),
                 total_score: self.pivot.total_score + new_scores,
             }
-        } else {
-            let pivot_header = self.pivot_header();
+        } else if first_header_number < pivot_header.number() {
+            ctrace!(
+                SYNC,
+                "Ignore received headers, pivot is already updated since headers are imported by other peers"
+            );
+        } else if first_header_number == pivot_header.number() {
             if pivot_header.number() != 0 {
                 self.pivot = Pivot {
                     hash: pivot_header.parent_hash(),
                     total_score: self.pivot.total_score - pivot_header.score(),
                 }
             }
+        } else {
+            cerror!(
+                SYNC,
+                "Invalid header update state. best_hash: {}, self.pivot.hash: {}, first_header_hash: {}",
+                self.best_hash,
+                self.pivot.hash,
+                first_header_hash
+            );
         }
 
         self.request_time = None;


### PR DESCRIPTION
Header downloader has "best_hash," which is peer's best hash, and
"pivot," which is the best hash of received headers from a peer.

When header downloader receives headers from a peer, it checks the
first header's hash and the pivot's hash. If they are not the same,
the downloader concludes that there is a reorganization and request
older headers.

However, if the pivot is changed between header request and response,
the header downloader requests older hashes even though there is no
re-organization. This commit changes the header downloader check
re-organization more concisely.