### PR TITLE
Move VoteCollector into Tendermint

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -24,7 +24,6 @@ mod solo;
 pub mod stake;
 mod tendermint;
 mod validator_set;
-pub mod vote_collector;
 
 pub use self::blake_pow::BlakePoW;
 pub use self::cuckoo::Cuckoo;

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -37,7 +37,6 @@ pub use self::tendermint::{
 };
 pub use self::validator_set::validator_list::RoundRobinValidator;
 pub use self::validator_set::{DynamicValidator, ValidatorSet};
-pub use self::vote_collector::Message;
 
 use std::fmt;
 use std::sync::{Arc, Weak};

--- a/core/src/consensus/stake/actions.rs
+++ b/core/src/consensus/stake/actions.rs
@@ -64,8 +64,8 @@ pub enum Action {
     },
     // TODO: ConsensusMessage is tied to the Tendermint
     ReportDoubleVote {
-        message1: ConsensusMessage,
-        message2: ConsensusMessage,
+        message1: Box<ConsensusMessage>,
+        message2: Box<ConsensusMessage>,
     },
 }
 
@@ -239,7 +239,10 @@ impl Encodable for Action {
                 message1,
                 message2,
             } => {
-                s.begin_list(3).append(&ACTION_TAG_REPORT_DOUBLE_VOTE).append(message1).append(message2);
+                s.begin_list(3)
+                    .append(&ACTION_TAG_REPORT_DOUBLE_VOTE)
+                    .append(message1.as_ref())
+                    .append(message2.as_ref());
             }
         };
     }
@@ -340,8 +343,8 @@ impl Decodable for Action {
                         got: item_count,
                     })
                 }
-                let message1 = rlp.val_at(1)?;
-                let message2 = rlp.val_at(2)?;
+                let message1 = Box::new(rlp.val_at(1)?);
+                let message2 = Box::new(rlp.val_at(2)?);
                 Ok(Action::ReportDoubleVote {
                     message1,
                     message2,
@@ -449,8 +452,8 @@ mod tests {
         let consensus_message2 =
             create_consensus_message(message_info2, &test_client, vote_step_twister, block_hash_twister);
         let action = Action::ReportDoubleVote {
-            message1: consensus_message1,
-            message2: consensus_message2,
+            message1: Box::new(consensus_message1),
+            message2: Box::new(consensus_message2),
         };
         let arced_client: Arc<ConsensusClient> = Arc::new(test_client);
         validator_set.register_client(Arc::downgrade(&arced_client));

--- a/core/src/consensus/tendermint/message.rs
+++ b/core/src/consensus/tendermint/message.rs
@@ -24,7 +24,6 @@ use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 use snap;
 
 use super::super::validator_set::DynamicValidator;
-use super::super::vote_collector::Message;
 use super::super::BitSet;
 use super::{BlockHash, Height, Step, View};
 
@@ -347,36 +346,28 @@ impl ConsensusMessage {
             },
         })
     }
-}
 
-impl Message for ConsensusMessage {
-    type Round = VoteStep;
-
-    fn signature(&self) -> SchnorrSignature {
+    pub fn signature(&self) -> SchnorrSignature {
         self.signature
     }
 
-    fn signer_index(&self) -> usize {
+    pub fn signer_index(&self) -> usize {
         self.signer_index
     }
 
-    fn block_hash(&self) -> Option<H256> {
+    pub fn block_hash(&self) -> Option<H256> {
         self.on.block_hash
     }
 
-    fn round(&self) -> &VoteStep {
+    pub fn round(&self) -> &VoteStep {
         &self.on.step
     }
 
-    fn height(&self) -> u64 {
+    pub fn height(&self) -> u64 {
         self.on.step.height
     }
 
-    fn is_broadcastable(&self) -> bool {
-        self.on.step.step.is_pre()
-    }
-
-    fn verify(&self, signer_public: &Public) -> Result<bool, KeyError> {
+    pub fn verify(&self, signer_public: &Public) -> Result<bool, KeyError> {
         let vote_info = message_info_rlp(self.on.step, self.on.block_hash);
         verify_schnorr(signer_public, &self.signature, &blake256(vote_info))
     }

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -71,7 +71,7 @@ pub struct Tendermint {
     /// Action handlers for this consensus method
     action_handlers: Vec<Arc<ActionHandler>>,
     /// stake object to register client data later
-    stake: Arc<stake::Stake<ConsensusMessage>>,
+    stake: Arc<stake::Stake>,
     /// Chain notify
     chain_notify: Arc<TendermintChainNotify>,
     has_signer: AtomicBool,
@@ -90,7 +90,7 @@ impl Tendermint {
     /// Create a new instance of Tendermint engine
     pub fn new(our_params: TendermintParams, machine: CodeChainMachine) -> Arc<Self> {
         let validators = Arc::clone(&our_params.validators);
-        let stake = Arc::new(stake::Stake::<ConsensusMessage>::new(our_params.genesis_stakes));
+        let stake = Arc::new(stake::Stake::new(our_params.genesis_stakes));
         let timeouts = our_params.timeouts;
         let machine = Arc::new(machine);
 

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -21,6 +21,7 @@ mod message;
 mod network;
 mod params;
 pub mod types;
+pub mod vote_collector;
 mod worker;
 
 use std::sync::atomic::AtomicBool;

--- a/core/src/consensus/tendermint/types.rs
+++ b/core/src/consensus/tendermint/types.rs
@@ -159,13 +159,6 @@ pub enum Step {
 }
 
 impl Step {
-    pub fn is_pre(self) -> bool {
-        match self {
-            Step::Prevote | Step::Precommit => true,
-            _ => false,
-        }
-    }
-
     pub fn number(self) -> u8 {
         match self {
             Step::Propose => 0,

--- a/core/src/consensus/tendermint/vote_collector.rs
+++ b/core/src/consensus/tendermint/vote_collector.rs
@@ -23,8 +23,8 @@ use primitives::H256;
 use rlp::{Encodable, RlpStream};
 
 use super::stake::Action;
-use super::BitSet;
 use super::{ConsensusMessage, VoteStep};
+use crate::consensus::BitSet;
 
 /// Storing all Proposals, Prevotes and Precommits.
 #[derive(Debug)]

--- a/core/src/consensus/tendermint/vote_collector.rs
+++ b/core/src/consensus/tendermint/vote_collector.rs
@@ -49,8 +49,8 @@ pub struct DoubleVote {
 impl DoubleVote {
     pub fn to_action(&self) -> Action {
         Action::ReportDoubleVote {
-            message1: self.vote_one.clone(),
-            message2: self.vote_two.clone(),
+            message1: Box::new(self.vote_one.clone()),
+            message2: Box::new(self.vote_two.clone()),
         }
     }
 }

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -37,6 +37,7 @@ use super::network;
 use super::params::TimeGapParams;
 use super::stake::CUSTOM_ACTION_HANDLER_ID;
 use super::types::{Height, Proposal, Step, TendermintSealView, TendermintState, TwoThirdsMajority, View};
+use super::vote_collector::{DoubleVote, VoteCollector};
 use super::{
     BlockHash, ENGINE_TIMEOUT_BROADCAST_STEP_STATE, ENGINE_TIMEOUT_EMPTY_PROPOSAL, ENGINE_TIMEOUT_TOKEN_NONCE_BASE,
     SEAL_FIELDS,
@@ -46,7 +47,6 @@ use crate::block::*;
 use crate::client::ConsensusClient;
 use crate::consensus::signer::EngineSigner;
 use crate::consensus::validator_set::{DynamicValidator, ValidatorSet};
-use crate::consensus::vote_collector::{DoubleVote, VoteCollector};
 use crate::consensus::{EngineError, Seal};
 use crate::encoded;
 use crate::error::{BlockError, Error};

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -30,7 +30,6 @@ use ctypes::{BlockNumber, Header};
 use primitives::{u256_from_u128, Bytes, H256, U256};
 use rlp::{Encodable, UntrustedRlp};
 
-use super::super::vote_collector::DoubleVote;
 use super::super::BitSet;
 use super::backup::{backup, restore, BackupView};
 use super::message::*;
@@ -47,7 +46,7 @@ use crate::block::*;
 use crate::client::ConsensusClient;
 use crate::consensus::signer::EngineSigner;
 use crate::consensus::validator_set::{DynamicValidator, ValidatorSet};
-use crate::consensus::vote_collector::{Message, VoteCollector};
+use crate::consensus::vote_collector::{DoubleVote, VoteCollector};
 use crate::consensus::{EngineError, Seal};
 use crate::encoded;
 use crate::error::{BlockError, Error};
@@ -80,7 +79,7 @@ struct Worker {
     /// The votes_received field is changed after last state broadcast.
     votes_received_changed: bool,
     /// Vote accumulator.
-    votes: VoteCollector<ConsensusMessage>,
+    votes: VoteCollector,
     /// Used to sign messages and proposals.
     signer: EngineSigner,
     /// Last majority
@@ -1409,7 +1408,7 @@ impl Worker {
         Ok(())
     }
 
-    fn report_double_vote(&self, double: &DoubleVote<ConsensusMessage>) {
+    fn report_double_vote(&self, double: &DoubleVote) {
         let network_id = self.client().common_params(BlockId::Latest).unwrap().network_id();
         let seq = match self.signer.address() {
             Some(address) => self.client().latest_seq(address),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -89,7 +89,7 @@ pub use crate::client::{
     EngineClient, EngineInfo, ExecuteClient, ImportBlock, MiningBlockChainClient, Shard, StateInfo, TermInfo,
     TestBlockChainClient, TextClient,
 };
-pub use crate::consensus::{EngineType, Message, TimeGapParams};
+pub use crate::consensus::{EngineType, TimeGapParams};
 pub use crate::db::{COL_STATE, NUM_COLUMNS};
 pub use crate::error::{BlockImportError, Error, ImportError};
 pub use crate::miner::{Miner, MinerOptions, MinerService, Stratum, StratumConfig, StratumError};


### PR DESCRIPTION
`VoteCollector` doesn't have to be generic since it is only used in `tendermint`. So I've removed `trait Message`, and `SoloMessage` which is its dummy implementation.