### PR TITLE
Import following downloaded blocks if the preceding block is already queued

### DIFF
--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -728,6 +728,9 @@ impl Extension {
                     Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
                         cwarn!(SYNC, "Downloaded already existing block({})", hash)
                     }
+                    Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {
+                        cwarn!(SYNC, "Downloaded already queued in the verification queue({})", hash)
+                    }
                     Err(err) => {
                         // FIXME: handle import errors
                         cwarn!(SYNC, "Cannot import block({}): {:?}", hash, err);


### PR DESCRIPTION
Before this commit, following blocks were dropped and this behavior
was causing "parent not found" errors in Block Sync.