### PR TITLE
Handle multiple proposals in a view correctly in Tendermint

### DIFF
--- a/core/src/consensus/tendermint/vote_collector.rs
+++ b/core/src/consensus/tendermint/vote_collector.rs
@@ -207,6 +207,15 @@ impl VoteCollector {
             .unwrap_or_else(Vec::new)
     }
 
+    pub fn has_votes_for(&self, round: &VoteStep, block_hash: H256) -> bool {
+        let votes = self
+            .votes
+            .get(round)
+            .map(|c| c.block_votes.keys().cloned().filter_map(|x| x).collect())
+            .unwrap_or_else(Vec::new);
+        votes.into_iter().any(|vote_block_hash| vote_block_hash == block_hash)
+    }
+
     pub fn get_all(&self) -> Vec<ConsensusMessage> {
         self.votes.iter().flat_map(|(_round, collector)| collector.messages.iter()).cloned().collect()
     }


### PR DESCRIPTION
The previous code assumes that there is only one proposal in a
view. Tendermint was always using the first proposal even though there
are many proposals in a view. This commit makes Tendermint find the
proper proposal for that situation.

Fixes https://github.com/CodeChain-io/codechain/issues/1773