### PR TITLE
Enable IPC in production build

### DIFF
--- a/codechain/config/presets/config.prod.toml
+++ b/codechain/config/presets/config.prod.toml
@@ -40,7 +40,7 @@ interface = "127.0.0.1"
 port = 8080
 
 [ipc]
-disable = true
+disable = false
 path = "/tmp/jsonrpc.ipc"
 
 [ws]


### PR DESCRIPTION
IPC is enabled in the development binary and disabled in the production binary.
HTTP RPC is enabled in the development and production binary.
If a user can access the 8080 port, generally she/he can access the IPC file.

Enabling in the production binary is a good default value.