### PR TITLE
Do not generate a seal if the block is generated from a past view

### DIFF
--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -1044,7 +1044,13 @@ impl Worker {
             return Seal::None
         }
 
-        assert!(self.is_signer_proposer(&parent_hash));
+        // We don't know at which view the node starts generating a block.
+        // If this node's signer is not proposer at the current view, return none.
+        if !self.is_signer_proposer(&parent_hash) {
+            cwarn!(ENGINE, "Seal request for an old view");
+            return Seal::None
+        }
+
         assert_eq!(Proposal::None, self.proposal);
         assert_eq!(height, self.height);
 


### PR DESCRIPTION
If generating a block takes too much time, the view could be changed
before the miner module requests the signature. If the Tendermint
module receives a signature request of an old view, it should ignore
the message. Before this commit, the Tendermint module was
crashing when it gets a signature request from an old view.

It fixes https://github.com/CodeChain-io/codechain/issues/1805.