### PR TITLE
Recover TendermintState when empty the proposal timer is fired in a wrong time

### DIFF
--- a/core/src/consensus/tendermint/types.rs
+++ b/core/src/consensus/tendermint/types.rs
@@ -76,6 +76,15 @@ impl TendermintState {
         }
     }
 
+    pub fn is_propose_wait_empty_block_timer(&self) -> bool {
+        match self {
+            TendermintState::ProposeWaitEmptyBlockTimer {
+                ..
+            } => true,
+            _ => false,
+        }
+    }
+
     pub fn is_commit(&self) -> bool {
         match self {
             TendermintState::Commit {


### PR DESCRIPTION
The Tendermint module was changing its step to 'Propose' when the "engine timeout empty proposal" timer is fired. If the timer is called in the wrong time, the step should not be changed. This commit makes the step change when it is needed.
