### PR TITLE
Enable all grandchild of the best block to become a best proposal block

### DIFF
--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -184,11 +184,16 @@ impl BlockChain {
         let new_header = new_block.header_view();
         let parent_hash_of_new_block = new_header.parent_hash();
         let parent_details_of_new_block = self.block_details(&parent_hash_of_new_block).expect("Invalid parent hash");
-        let prev_best_proposal_hash = self.best_proposal_block_hash();
+        let grandparent_hash_of_new_block = parent_details_of_new_block.parent;
         let prev_best_hash = self.best_block_hash();
 
         if parent_details_of_new_block.total_score + new_header.score() > self.best_proposal_block_detail().total_score
-            && engine.can_change_canon_chain(&new_header, prev_best_hash, prev_best_proposal_hash)
+            && engine.can_change_canon_chain(
+                new_header.hash(),
+                parent_hash_of_new_block,
+                grandparent_hash_of_new_block,
+                prev_best_hash,
+            )
         {
             cinfo!(
                 BLOCKCHAIN,

--- a/core/src/blockchain/headerchain.rs
+++ b/core/src/blockchain/headerchain.rs
@@ -242,11 +242,16 @@ impl HeaderChain {
     fn best_header_changed(&self, new_header: &HeaderView, engine: &dyn CodeChainEngine) -> BestHeaderChanged {
         let parent_hash_of_new_header = new_header.parent_hash();
         let parent_details_of_new_header = self.block_details(&parent_hash_of_new_header).expect("Invalid parent hash");
-        let prev_best_proposal_hash = self.best_proposal_header_hash();
+        let grandparent_hash_of_new_header = parent_details_of_new_header.parent;
         let prev_best_hash = self.best_header_hash();
         let is_new_best = parent_details_of_new_header.total_score + new_header.score()
             > self.best_proposal_header_detail().total_score
-            && engine.can_change_canon_chain(&new_header, prev_best_hash, prev_best_proposal_hash);
+            && engine.can_change_canon_chain(
+                new_header.hash(),
+                parent_hash_of_new_header,
+                grandparent_hash_of_new_header,
+                prev_best_hash,
+            );
 
         if is_new_best {
             ctrace!(

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -271,9 +271,10 @@ pub trait ConsensusEngine: Sync + Send {
     /// Only the descendant of the current best block could be the next best block in Tendermint consensus.
     fn can_change_canon_chain(
         &self,
-        _new_header: &HeaderView,
+        _new_block_hash: H256,
+        _parent_hash_of_new_header: H256,
+        _grandparent_hash_of_new_header: H256,
         _previous_best_hash: H256,
-        _previous_best_proposal_hash: H256,
     ) -> bool {
         true
     }

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -311,11 +311,12 @@ impl ConsensusEngine for Tendermint {
 
     fn can_change_canon_chain(
         &self,
-        new_header: &HeaderView,
+        _new_header_hash: H256,
+        parent_hash_of_new_header: H256,
+        grandparent_hash_of_new_header: H256,
         prev_best_hash: H256,
-        prev_best_proposal_hash: H256,
     ) -> bool {
-        new_header.parent_hash() == prev_best_hash || new_header.parent_hash() == prev_best_proposal_hash
+        parent_hash_of_new_header == prev_best_hash || grandparent_hash_of_new_header == prev_best_hash
     }
 
     fn action_handlers(&self) -> &[Arc<dyn ActionHandler>] {


### PR DESCRIPTION
Before this commit, only the child of the best block and the child of the best proposal block could be a new best proposal block. A block that is a grandchild of the best block but not the child of the best proposal block should be able to become a best proposal block.

After this commit, CodeChain checks whether a new block is the best block's child or grandchild.