### PR TITLE
Add benchmark tests for TrieDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,10 +414,14 @@ dependencies = [
  "codechain-crypto 0.1.0 (git+https://github.com/CodeChain-io/rust-codechain-crypto.git)",
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashdb 0.1.1",
+ "journaldb 0.1.0",
+ "kvdb 0.1.0",
+ "kvdb-rocksdb 0.1.0",
  "memorydb 0.1.1",
  "primitives 0.4.0 (git+https://github.com/CodeChain-io/rust-codechain-primitives.git)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-standardmap 0.1.0",
 ]
 
@@ -550,7 +554,7 @@ dependencies = [
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "snap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "token-generator 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-standardmap 0.1.0",
@@ -1604,7 +1608,7 @@ dependencies = [
  "schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2592,12 +2596,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3416,7 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/util/merkle/Cargo.toml
+++ b/util/merkle/Cargo.toml
@@ -12,5 +12,9 @@ primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.
 rlp = {path = "../rlp" }
 
 [dev-dependencies]
+journaldb = { path = "../journaldb" }
+kvdb = { path = "../kvdb" }
+kvdb-rocksdb = { path = "../kvdb-rocksdb" }
+tempfile = "3.1.0"
 trie-standardmap = { path = "../trie-standardmap" }
 memorydb = {path = "../memorydb" }

--- a/util/merkle/benches/triedb.rs
+++ b/util/merkle/benches/triedb.rs
@@ -1,0 +1,161 @@
+// Copyright 2019 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate codechain_merkle as cmerkle;
+extern crate hashdb;
+extern crate journaldb;
+extern crate kvdb;
+extern crate kvdb_rocksdb as rocksdb;
+extern crate primitives;
+extern crate rand;
+extern crate tempfile;
+extern crate test;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cmerkle::{Trie, TrieDB, TrieDBMut, TrieMut};
+use kvdb::DBTransaction;
+use primitives::H256;
+use rand::random;
+use rocksdb::{CompactionProfile, Database, DatabaseConfig};
+use tempfile::{tempdir, TempDir};
+use test::Bencher;
+
+struct TestDB {
+    _dir: TempDir,
+    db: Arc<Database>,
+    journal: Box<dyn journaldb::JournalDB>,
+    root: H256,
+}
+
+impl TestDB {
+    // Replicate CodeChain's db config
+    fn config(path: &Path) -> DatabaseConfig {
+        let mut config = DatabaseConfig::with_columns(Some(1));
+        config.memory_budget = Default::default();
+        config.compaction = CompactionProfile::auto(path);
+        config.wal = true;
+        config
+    }
+
+    fn populate(path: &Path, size: usize) -> H256 {
+        // Create database
+        let config = Self::config(path);
+        let db = Arc::new(Database::open(&config, path.to_str().unwrap()).unwrap());
+        let mut journal = journaldb::new(db.clone(), journaldb::Algorithm::Archive, Some(0));
+        let mut root = H256::new();
+        {
+            let hashdb = journal.as_hashdb_mut();
+            let mut trie = TrieDBMut::new(hashdb, &mut root);
+            for i in 0..size {
+                trie.insert(&i.to_be_bytes(), &i.to_be_bytes()).unwrap();
+            }
+        }
+        let mut batch = DBTransaction::new();
+        journal.journal_under(&mut batch, 0, &H256::new()).unwrap();
+        db.write_buffered(batch);
+        db.flush().unwrap();
+
+        root
+    }
+
+    fn new(size: usize) -> Self {
+        // Create temporary directory
+        let dir = tempdir().unwrap();
+        let root = Self::populate(dir.path(), size);
+
+        // Create database
+        let config = Self::config(dir.path());
+        let db = Arc::new(Database::open(&config, dir.path().to_str().unwrap()).unwrap());
+        let journal = journaldb::new(db.clone(), journaldb::Algorithm::Archive, Some(0));
+
+        Self {
+            _dir: dir,
+            db,
+            journal,
+            root,
+        }
+    }
+
+    fn trie(&self) -> TrieDB {
+        let hashdb = self.journal.as_hashdb();
+        TrieDB::try_new(hashdb, &self.root).unwrap()
+    }
+
+    fn trie_mut(&mut self) -> TrieDBMut {
+        let hashdb = self.journal.as_hashdb_mut();
+        TrieDBMut::new(hashdb, &mut self.root)
+    }
+
+    fn flush(&mut self) {
+        let mut batch = DBTransaction::new();
+        self.journal.journal_under(&mut batch, 0, &H256::new()).unwrap();
+        self.db.write_buffered(batch);
+        self.db.flush().unwrap();
+    }
+}
+
+const DB_SIZE: usize = 10000;
+const BATCH: usize = 10000;
+
+#[bench]
+fn bench_read_single(b: &mut Bencher) {
+    let db = TestDB::new(DB_SIZE);
+    b.iter(|| {
+        let trie = db.trie();
+        let item = random::<usize>() % DB_SIZE;
+        let _ = trie.get(&item.to_be_bytes()).unwrap().unwrap();
+    });
+}
+
+#[bench]
+fn bench_read_multiple(b: &mut Bencher) {
+    let db = TestDB::new(DB_SIZE);
+    b.iter(|| {
+        let trie = db.trie();
+        for _ in 0..BATCH {
+            let item = random::<usize>() % DB_SIZE;
+            let _ = trie.get(&item.to_be_bytes()).unwrap().unwrap();
+        }
+    });
+}
+
+#[bench]
+fn bench_write_single(b: &mut Bencher) {
+    let mut db = TestDB::new(DB_SIZE);
+    b.iter(|| {
+        let mut trie = db.trie_mut();
+        let item = random::<usize>() % DB_SIZE + DB_SIZE;
+        let _ = trie.insert(&item.to_be_bytes(), &item.to_be_bytes()).unwrap();
+        db.flush();
+    });
+}
+
+#[bench]
+fn bench_write_multiple(b: &mut Bencher) {
+    let mut db = TestDB::new(DB_SIZE);
+    b.iter(|| {
+        let mut trie = db.trie_mut();
+        for _ in 0..BATCH {
+            let item = random::<usize>() % DB_SIZE + DB_SIZE;
+            let _ = trie.insert(&item.to_be_bytes(), &item.to_be_bytes()).unwrap();
+        }
+        db.flush();
+    });
+}


### PR DESCRIPTION
Resolve https://github.com/CodeChain-io/codechain/issues/1502

You can run the benches by running following commands under `util/merkle` directory:
```
cargo +nightly bench
```

~Here's the actual benchmark statistics I got from the real machines.~
See https://github.com/CodeChain-io/codechain/pull/1828#issuecomment-546818670 for the new result.

~with SSD:~
```
test bench_read_multiple  ... bench: 239,979,231 ns/iter (+/- 98,801,879)
test bench_read_single    ... bench:      31,041 ns/iter (+/- 2,420)
test bench_write_multiple ... bench: 219,346,906 ns/iter (+/- 123,023,116)
test bench_write_single   ... bench:       6,788 ns/iter (+/- 1,069)
```

~with HDD:~
```
test bench_read_multiple  ... bench: 228,591,915 ns/iter (+/- 1,163,440)
test bench_read_single    ... bench:      67,821 ns/iter (+/- 1,498)
test bench_write_multiple ... bench: 534,238,617 ns/iter (+/- 2,717,086,442)
test bench_write_single   ... bench:      43,088 ns/iter (+/- 5,151)
```

~Write is faster(!) than read in SSD. I'm checking if something went wrong now.~