### PR TITLE
Set finalized_view to None when restoring in the Commit step

### DIFF
--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -1033,6 +1033,11 @@ impl Worker {
         let client = self.client();
         let backup = restore(client.get_kvdb().as_ref());
         if let Some(backup) = backup {
+            if backup.step == Step::Commit {
+                self.finalized_view_of_current_block = None;
+            } else {
+                self.finalized_view_of_current_block = backup.finalized_view_of_current_block;
+            }
             let backup_step = match backup.step {
                 Step::Propose => TendermintState::Propose,
                 Step::Prevote => TendermintState::Prevote,
@@ -1046,7 +1051,6 @@ impl Worker {
             self.height = backup.height;
             self.view = backup.view;
             self.finalized_view_of_previous_block = backup.finalized_view_of_previous_block;
-            self.finalized_view_of_current_block = backup.finalized_view_of_current_block;
 
             if let Some(proposal) = backup.proposal {
                 if client.block(&BlockId::Hash(proposal)).is_some() {


### PR DESCRIPTION
In the Tendermint restoring process, if the backup state is the Commit
step, CodeChain set the step to the Precommit step and handles the
votes. The purpose of the behavior is that calling functions that are
called when enters the Commit state.

After we introduce the `finalized_view_of_current_block` variable, the
variable should be changed to `None` when CodeChain sets the state to
Precommit in the restoring process.