### PR TITLE
Do not assert the finalized_view while restoring

### DIFF
--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -612,8 +612,11 @@ impl Worker {
     }
 
     /// Do we need this function?
-    fn set_finalized_view_in_current_height(&mut self, view: View) {
-        assert_eq!(self.finalized_view_of_current_block, None);
+    fn set_finalized_view_in_current_height(&mut self, view: View, is_restoring: bool) {
+        if !is_restoring {
+            assert_eq!(self.finalized_view_of_current_block, None);
+        }
+
         self.finalized_view_of_current_block = Some(view);
     }
 
@@ -774,7 +777,7 @@ impl Worker {
             Step::Commit => {
                 cinfo!(ENGINE, "move_to_step: Commit.");
                 let (view, block_hash) = state.committed().expect("commit always has committed_view");
-                self.set_finalized_view_in_current_height(view);
+                self.set_finalized_view_in_current_height(view, is_restoring);
 
                 let proposal_received = self.is_proposal_received(self.height, view, block_hash);
                 let proposal_imported = self.client().block(&block_hash.into()).is_some();


### PR DESCRIPTION
In the Tendermint restoring process, if the step variable is backed up by the Commit value, CodeChain sets the step to the Precommit step and handles the votes. The purpose of this behavior is to call functions that are called when the node enters the Commit state.

Changing the "step" in the restoring process is fragile. It is easy to miss setting some variables. The `finalized_view_of_current_block` variable should be changed when the step is changed. Until now, it was forgotten due to human error.

This commit fixes the problem by ignoring the assertion check in the restore process. Although it is not a perfect solution, it is consistent. There is some code already that does different things in the restore process, depending on whether the code is called or not.