### PR TITLE
Add RPC snapshot_getList

### DIFF
--- a/codechain/rpc_apis.rs
+++ b/codechain/rpc_apis.rs
@@ -37,6 +37,7 @@ impl ApiDependencies {
         use crpc::v1::*;
         handler.extend_with(ChainClient::new(Arc::clone(&self.client)).to_delegate());
         handler.extend_with(MempoolClient::new(Arc::clone(&self.client)).to_delegate());
+        handler.extend_with(SnapshotClient::new(Arc::clone(&self.client), config.snapshot.path.clone()).to_delegate());
         if config.rpc.enable_devel_api {
             handler.extend_with(
                 DevelClient::new(Arc::clone(&self.client), Arc::clone(&self.miner), self.block_sync.clone())

--- a/codechain/rpc_apis.rs
+++ b/codechain/rpc_apis.rs
@@ -22,6 +22,8 @@ use cnetwork::{EventSender, NetworkControl};
 use crpc::{MetaIoHandler, Middleware, Params, Value};
 use csync::BlockSyncEvent;
 
+use crate::config::Config;
+
 pub struct ApiDependencies {
     pub client: Arc<Client>,
     pub miner: Arc<Miner>,
@@ -31,11 +33,11 @@ pub struct ApiDependencies {
 }
 
 impl ApiDependencies {
-    pub fn extend_api(&self, enable_devel_api: bool, handler: &mut MetaIoHandler<(), impl Middleware<()>>) {
+    pub fn extend_api(&self, config: &Config, handler: &mut MetaIoHandler<(), impl Middleware<()>>) {
         use crpc::v1::*;
         handler.extend_with(ChainClient::new(Arc::clone(&self.client)).to_delegate());
         handler.extend_with(MempoolClient::new(Arc::clone(&self.client)).to_delegate());
-        if enable_devel_api {
+        if config.rpc.enable_devel_api {
             handler.extend_with(
                 DevelClient::new(Arc::clone(&self.client), Arc::clone(&self.miner), self.block_sync.clone())
                     .to_delegate(),

--- a/rpc/src/v1/errors.rs
+++ b/rpc/src/v1/errors.rs
@@ -304,6 +304,14 @@ pub fn invalid_custom_action(err: String) -> Error {
     }
 }
 
+pub fn io(error: std::io::Error) -> Error {
+    Error {
+        code: ErrorCode::InternalError,
+        message: format!("{}", error),
+        data: None,
+    }
+}
+
 /// Internal error signifying a logic error in code.
 /// Should not be used when function can just fail
 /// because of invalid parameters or incomplete node state.

--- a/rpc/src/v1/impls/snapshot.rs
+++ b/rpc/src/v1/impls/snapshot.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2019 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::fs;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ccore::{BlockChainClient, BlockId};
+use ctypes::BlockHash;
+use primitives::H256;
+
+use jsonrpc_core::Result;
+
+use super::super::errors;
+use super::super::traits::Snapshot;
+use super::super::types::BlockNumberAndHash;
+
+pub struct SnapshotClient<C>
+where
+    C: BlockChainClient, {
+    client: Arc<C>,
+    snapshot_path: Option<String>,
+}
+
+impl<C> SnapshotClient<C>
+where
+    C: BlockChainClient,
+{
+    pub fn new(client: Arc<C>, snapshot_path: Option<String>) -> Self {
+        SnapshotClient {
+            client,
+            snapshot_path,
+        }
+    }
+}
+
+impl<C> Snapshot for SnapshotClient<C>
+where
+    C: BlockChainClient + 'static,
+{
+    fn get_snapshot_list(&self) -> Result<Vec<BlockNumberAndHash>> {
+        if let Some(snapshot_path) = &self.snapshot_path {
+            let mut result = Vec::new();
+            for entry in fs::read_dir(snapshot_path).map_err(errors::io)? {
+                let entry = entry.map_err(errors::io)?;
+
+                // Check if the entry is a directory
+                let file_type = entry.file_type().map_err(errors::io)?;
+                if !file_type.is_dir() {
+                    continue
+                }
+
+                let path = entry.path();
+                let name = match path.file_name().expect("Directories always have file name").to_str() {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let hash = match H256::from_str(name) {
+                    Ok(h) => BlockHash::from(h),
+                    Err(_) => continue,
+                };
+                if let Some(number) = self.client.block_number(&BlockId::Hash(hash)) {
+                    result.push(BlockNumberAndHash {
+                        number,
+                        hash,
+                    });
+                }
+            }
+            result.sort_unstable_by(|a, b| b.number.cmp(&a.number));
+            Ok(result)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+}

--- a/rpc/src/v1/traits/mod.rs
+++ b/rpc/src/v1/traits/mod.rs
@@ -21,6 +21,7 @@ mod engine;
 mod mempool;
 mod miner;
 mod net;
+mod snapshot;
 
 pub use self::account::Account;
 pub use self::chain::Chain;
@@ -29,3 +30,4 @@ pub use self::engine::Engine;
 pub use self::mempool::Mempool;
 pub use self::miner::Miner;
 pub use self::net::Net;
+pub use self::snapshot::Snapshot;

--- a/rpc/src/v1/traits/snapshot.rs
+++ b/rpc/src/v1/traits/snapshot.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Kodebox, Inc.
+// Copyright 2018-2019 Kodebox, Inc.
 // This file is part of CodeChain.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,20 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod account;
-mod chain;
-mod devel;
-mod engine;
-mod mempool;
-mod miner;
-mod net;
-mod snapshot;
+use jsonrpc_core::Result;
 
-pub use self::account::AccountClient;
-pub use self::chain::ChainClient;
-pub use self::devel::DevelClient;
-pub use self::engine::EngineClient;
-pub use self::mempool::MempoolClient;
-pub use self::miner::MinerClient;
-pub use self::net::NetClient;
-pub use self::snapshot::SnapshotClient;
+use super::super::types::BlockNumberAndHash;
+
+#[rpc(server)]
+pub trait Snapshot {
+    /// Gets list of block numbers and block hashes of the snapshots.
+    #[rpc(name = "snapshot_getList")]
+    fn get_snapshot_list(&self) -> Result<Vec<BlockNumberAndHash>>;
+}


### PR DESCRIPTION
`snapshot_getList` RPC is introduced by this PR.
The RPC checks the `snapshot_dir` directory provided by the config and inspects its entries.
An entry is recognized as a snapshot if it satisfies the following rules:
* Is a directory
* Directory name is a valid 256bit hex string
* There exists a block which has a hash same as the directory name