### PR TITLE
Download the full snapshot target block

### DIFF
--- a/codechain/run_node.rs
+++ b/codechain/run_node.rs
@@ -35,6 +35,7 @@ use csync::snapshot::Service as SnapshotService;
 use csync::{BlockSyncExtension, BlockSyncSender, TransactionSyncExtension};
 use ctimer::TimerLoop;
 use ctrlc::CtrlC;
+use ctypes::BlockHash;
 use fdlimit::raise_fd_limit;
 use kvdb::KeyValueDB;
 use kvdb_rocksdb::{Database, DatabaseConfig};
@@ -303,7 +304,7 @@ pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
                 let sync_sender = {
                     let client = client.client();
                     let snapshot_target = match (config.network.snapshot_hash, config.network.snapshot_number) {
-                        (Some(hash), Some(num)) => Some((hash, num)),
+                        (Some(hash), Some(num)) => Some((BlockHash::from(hash), num)),
                         _ => None,
                     };
                     let snapshot_dir = config.snapshot.path.clone();

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -28,7 +28,7 @@ use cstate::{
 };
 use ctimer::{TimeoutHandler, TimerApi, TimerScheduleError, TimerToken};
 use ctypes::transaction::{AssetTransferInput, PartialHashing, ShardTransaction};
-use ctypes::{BlockHash, BlockNumber, CommonParams, Header, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, Tracker, TxHash};
 use cvm::{decode, execute, ChainTimeInfo, ScriptResult, VMConfig};
 use hashdb::AsHashDB;
 use journaldb;
@@ -43,7 +43,7 @@ use super::{
     ClientConfig, DatabaseClient, EngineClient, EngineInfo, Error as ClientError, ExecuteClient, ImportBlock,
     ImportResult, MiningBlockChainClient, Shard, StateInfo, StateOrBlock, TextClient,
 };
-use crate::block::{ClosedBlock, IsBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, ClosedBlock, IsBlock, OpenBlock, SealedBlock};
 use crate::blockchain::{BlockChain, BlockProvider, BodyProvider, HeaderProvider, InvoiceProvider, TransactionAddress};
 use crate::client::{ConsensusClient, SnapshotClient, TermInfo};
 use crate::consensus::{CodeChainEngine, EngineError};
@@ -664,13 +664,13 @@ impl ImportBlock for Client {
         Ok(self.importer.header_queue.import(unverified)?)
     }
 
-    fn import_bootstrap_header(&self, header: &Header) -> Result<BlockHash, BlockImportError> {
-        if self.block_chain().is_known_header(&header.hash()) {
+    fn import_bootstrap_block(&self, block: &Block) -> Result<BlockHash, BlockImportError> {
+        if self.block_chain().is_known(&block.header.hash()) {
             return Err(BlockImportError::Import(ImportError::AlreadyInChain))
         }
         let import_lock = self.importer.import_lock.lock();
-        self.importer.import_bootstrap_header(header, self, &import_lock);
-        Ok(header.hash())
+        self.importer.import_bootstrap_block(block, self, &import_lock);
+        Ok(block.header.hash())
     }
 
     fn import_sealed_block(&self, block: &SealedBlock) -> ImportResult {

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -20,14 +20,14 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use cio::IoChannel;
-use ctypes::header::Header;
+use ctypes::header::{Header, Seal};
 use ctypes::BlockHash;
 use kvdb::DBTransaction;
 use parking_lot::{Mutex, MutexGuard};
 use rlp::Encodable;
 
 use super::{BlockChainTrait, Client, ClientConfig};
-use crate::block::{enact, IsBlock, LockedBlock};
+use crate::block::{enact, Block, IsBlock, LockedBlock};
 use crate::blockchain::{BodyProvider, HeaderProvider, ImportRoute};
 use crate::consensus::CodeChainEngine;
 use crate::error::Error;
@@ -371,19 +371,26 @@ impl Importer {
         imported.len()
     }
 
-    pub fn import_bootstrap_header<'a>(&'a self, header: &'a Header, client: &Client, _importer_lock: &MutexGuard<()>) {
+    pub fn import_bootstrap_block<'a>(&'a self, block: &'a Block, client: &Client, _importer_lock: &MutexGuard<()>) {
+        let header = &block.header;
         let hash = header.hash();
-        ctrace!(CLIENT, "Importing bootstrap header {}-{:?}", header.number(), hash);
+        ctrace!(CLIENT, "Importing bootstrap block #{}-{:?}", header.number(), hash);
 
+        let start = Instant::now();
         {
             let chain = client.block_chain();
             let mut batch = DBTransaction::new();
-            chain.insert_bootstrap_header(&mut batch, &HeaderView::new(&header.rlp_bytes()));
+            chain.insert_bootstrap_block(&mut batch, &block.rlp_bytes(&Seal::With));
             client.db().write_buffered(batch);
             chain.commit();
         }
-
+        let duration = {
+            let elapsed = start.elapsed();
+            elapsed.as_secs() * 1_000_000_000 + u64::from(elapsed.subsec_nanos())
+        };
         client.new_headers(&[hash], &[], &[hash], &[], &[], 0, Some(hash));
+        self.miner.chain_new_blocks(client, &[hash], &[], &[hash], &[]);
+        client.new_blocks(&[hash], &[], &[hash], &[], &[], duration);
 
         client.db().flush().expect("DB flush failed.");
     }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -37,6 +37,7 @@ use ckey::{Address, NetworkId, PlatformAddress, Public};
 use cmerkle::Result as TrieResult;
 use cnetwork::NodeId;
 use cstate::{AssetScheme, FindActionHandler, OwnedAsset, StateResult, Text, TopLevelState, TopStateView};
+use ctypes::header::Header;
 use ctypes::transaction::{AssetTransferInput, PartialHashing, ShardTransaction};
 use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, Tracker, TxHash};
 use cvm::ChainTimeInfo;
@@ -201,9 +202,16 @@ pub trait ImportBlock {
     /// Import a header into the blockchain
     fn import_header(&self, bytes: Bytes) -> Result<BlockHash, BlockImportError>;
 
-    /// Import a trusted bootstrap header into the blockchain
-    /// Bootstrap headers don't execute any verifications
-    fn import_bootstrap_block(&self, bytes: &Block) -> Result<BlockHash, BlockImportError>;
+    /// Import a trusted header into the blockchain
+    /// Trusted header doesn't go through any verifications and doesn't update the best header
+    fn import_trusted_header(&self, header: &Header) -> Result<BlockHash, BlockImportError>;
+
+    /// Import a trusted block into the blockchain
+    /// Trusted block doesn't go through any verifications and doesn't update the best block
+    fn import_trusted_block(&self, block: &Block) -> Result<BlockHash, BlockImportError>;
+
+    /// Forcefully update the best block
+    fn force_update_best_block(&self, hash: &BlockHash);
 
     /// Import sealed block. Skips all verifications.
     fn import_sealed_block(&self, block: &SealedBlock) -> ImportResult;

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -38,12 +38,12 @@ use cmerkle::Result as TrieResult;
 use cnetwork::NodeId;
 use cstate::{AssetScheme, FindActionHandler, OwnedAsset, StateResult, Text, TopLevelState, TopStateView};
 use ctypes::transaction::{AssetTransferInput, PartialHashing, ShardTransaction};
-use ctypes::{BlockHash, BlockNumber, CommonParams, Header, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, Tracker, TxHash};
 use cvm::ChainTimeInfo;
 use kvdb::KeyValueDB;
 use primitives::{Bytes, H160, H256, U256};
 
-use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, ClosedBlock, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
 use crate::consensus::EngineError;
 use crate::encoded;
@@ -203,7 +203,7 @@ pub trait ImportBlock {
 
     /// Import a trusted bootstrap header into the blockchain
     /// Bootstrap headers don't execute any verifications
-    fn import_bootstrap_header(&self, bytes: &Header) -> Result<BlockHash, BlockImportError>;
+    fn import_bootstrap_block(&self, bytes: &Block) -> Result<BlockHash, BlockImportError>;
 
     /// Import sealed block. Skips all verifications.
     fn import_sealed_block(&self, block: &SealedBlock) -> ImportResult;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -52,7 +52,7 @@ use parking_lot::RwLock;
 use primitives::{Bytes, H256, U256};
 use rlp::*;
 
-use crate::block::{ClosedBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, ClosedBlock, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
 use crate::client::ImportResult;
 use crate::client::{
@@ -510,7 +510,7 @@ impl ImportBlock for TestBlockChainClient {
         unimplemented!()
     }
 
-    fn import_bootstrap_header(&self, _header: &BlockHeader) -> Result<BlockHash, BlockImportError> {
+    fn import_bootstrap_block(&self, _header: &Block) -> Result<BlockHash, BlockImportError> {
         unimplemented!()
     }
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -42,6 +42,7 @@ use cnetwork::NodeId;
 use cstate::tests::helpers::empty_top_state;
 use cstate::{FindActionHandler, StateDB, TopLevelState};
 use ctimer::{TimeoutHandler, TimerToken};
+use ctypes::header::Header;
 use ctypes::transaction::{Action, Transaction};
 use ctypes::{BlockHash, BlockNumber, CommonParams, Header as BlockHeader, Tracker, TxHash};
 use cvm::ChainTimeInfo;
@@ -510,7 +511,15 @@ impl ImportBlock for TestBlockChainClient {
         unimplemented!()
     }
 
-    fn import_bootstrap_block(&self, _header: &Block) -> Result<BlockHash, BlockImportError> {
+    fn import_trusted_header(&self, _header: &Header) -> Result<BlockHash, BlockImportError> {
+        unimplemented!()
+    }
+
+    fn import_trusted_block(&self, _block: &Block) -> Result<BlockHash, BlockImportError> {
+        unimplemented!()
+    }
+
+    fn force_update_best_block(&self, _hash: &BlockHash) {
         unimplemented!()
     }
 

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -27,7 +27,7 @@ use ccore::{
 };
 use cmerkle::snapshot::ChunkDecompressor;
 use cmerkle::snapshot::Restore as SnapshotRestore;
-use cmerkle::TrieFactory;
+use cmerkle::{skewed_merkle_root, TrieFactory};
 use cnetwork::{Api, EventSender, NetworkExtension, NodeId};
 use cstate::FindActionHandler;
 use ctimer::TimerToken;
@@ -64,7 +64,7 @@ pub struct TokenInfo {
 enum State {
     SnapshotHeader(BlockHash, u64),
     SnapshotBody {
-        block: BlockHash,
+        header: EncodedHeader,
         prev_root: H256,
     },
     SnapshotChunk {
@@ -150,7 +150,7 @@ impl Extension {
             let parent =
                 client.block_header(&parent_hash.into()).expect("Parent header of the snapshot header must exist");
             return State::SnapshotBody {
-                block: hash,
+                header,
                 prev_root: parent.transactions_root(),
             }
         }
@@ -414,8 +414,30 @@ impl NetworkExtension<Event> for Extension {
                         }
                     }
                     State::SnapshotBody {
+                        ref header,
                         ..
-                    } => unimplemented!(),
+                    } => {
+                        for id in &peer_ids {
+                            if let Some(requests) = self.requests.get_mut(id) {
+                                ctrace!(SYNC, "Send snapshot body request to {}", id);
+                                let request = RequestMessage::Bodies(vec![header.hash()]);
+                                let request_id = self.last_request;
+                                self.last_request += 1;
+                                requests.push((request_id, request.clone()));
+                                self.api
+                                    .send(id, Arc::new(Message::Request(request_id, request).rlp_bytes().into_vec()));
+
+                                let token = &self.tokens[id];
+                                let token_info = self.tokens_info.get_mut(token).unwrap();
+
+                                let _ = self.api.clear_timer(*token);
+                                self.api
+                                    .set_timer_once(*token, Duration::from_millis(SYNC_EXPIRE_REQUEST_INTERVAL))
+                                    .expect("Timer set succeeds");
+                                token_info.request_id = Some(request_id);
+                            }
+                        }
+                    }
                     State::SnapshotChunk {
                         block,
                         ref mut restore,
@@ -811,20 +833,11 @@ impl Extension {
         match self.state {
             State::SnapshotHeader(hash, _) => match headers {
                 [parent, header] if header.hash() == hash => {
-                    match self.client.import_bootstrap_header(&header) {
-                        Ok(_) | Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
-                            self.state = State::SnapshotBody {
-                                block: hash,
-                                prev_root: *parent.transactions_root(),
-                            };
-                            cdebug!(SYNC, "Transitioning state to {:?}", self.state);
-                        }
-                        Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
-                        // FIXME: handle import errors
-                        Err(err) => {
-                            cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
-                        }
-                    }
+                    self.state = State::SnapshotBody {
+                        header: EncodedHeader::new(header.rlp_bytes().to_vec()),
+                        prev_root: *parent.transactions_root(),
+                    };
+                    cdebug!(SYNC, "Transitioning state to {:?}", self.state);
                 }
                 _ => cdebug!(
                     SYNC,
@@ -883,42 +896,75 @@ impl Extension {
 
     fn on_body_response(&mut self, hashes: Vec<BlockHash>, bodies: Vec<Vec<UnverifiedTransaction>>) {
         ctrace!(SYNC, "Received body response with lenth({}) {:?}", hashes.len(), hashes);
-        {
-            self.body_downloader.import_bodies(hashes, bodies);
-            let completed = self.body_downloader.drain();
-            for (hash, transactions) in completed {
-                let header = self
-                    .client
-                    .block_header(&BlockId::Hash(hash))
-                    .expect("Downloaded body's header must exist")
-                    .decode();
-                let block = Block {
-                    header,
-                    transactions,
-                };
-                cdebug!(SYNC, "Body download completed for #{}({})", block.header.number(), hash);
-                match self.client.import_block(block.rlp_bytes(&Seal::With)) {
-                    Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
-                        cwarn!(SYNC, "Downloaded already existing block({})", hash)
-                    }
-                    Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {
-                        cwarn!(SYNC, "Downloaded already queued in the verification queue({})", hash)
-                    }
-                    Err(err) => {
+
+        match self.state {
+            State::SnapshotBody {
+                ref header,
+                prev_root,
+            } => {
+                let body = bodies.first().expect("Body response in SnapshotBody state has only one body");
+                let new_root = skewed_merkle_root(prev_root, body.iter().map(Encodable::rlp_bytes));
+                if header.transactions_root() == new_root {
+                    let block = Block {
+                        header: header.decode(),
+                        transactions: body.clone(),
+                    };
+                    match self.client.import_bootstrap_block(&block) {
+                        Ok(_) | Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
+                            self.state = State::SnapshotChunk {
+                                block: header.hash(),
+                                restore: SnapshotRestore::new(header.state_root()),
+                            };
+                            cdebug!(SYNC, "Transitioning state to {:?}", self.state);
+                        }
+                        Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
                         // FIXME: handle import errors
-                        cwarn!(SYNC, "Cannot import block({}): {:?}", hash, err);
-                        break
+                        Err(err) => {
+                            cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
+                        }
                     }
-                    _ => {}
                 }
             }
-        }
+            State::Full => {
+                {
+                    self.body_downloader.import_bodies(hashes, bodies);
+                    let completed = self.body_downloader.drain();
+                    for (hash, transactions) in completed {
+                        let header = self
+                            .client
+                            .block_header(&BlockId::Hash(hash))
+                            .expect("Downloaded body's header must exist")
+                            .decode();
+                        let block = Block {
+                            header,
+                            transactions,
+                        };
+                        cdebug!(SYNC, "Body download completed for #{}({})", block.header.number(), hash);
+                        match self.client.import_block(block.rlp_bytes(&Seal::With)) {
+                            Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
+                                cwarn!(SYNC, "Downloaded already existing block({})", hash)
+                            }
+                            Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {
+                                cwarn!(SYNC, "Downloaded already queued in the verification queue({})", hash)
+                            }
+                            Err(err) => {
+                                // FIXME: handle import errors
+                                cwarn!(SYNC, "Cannot import block({}): {:?}", hash, err);
+                                break
+                            }
+                            _ => {}
+                        }
+                    }
+                }
 
-        let mut peer_ids: Vec<_> = self.header_downloaders.keys().cloned().collect();
-        peer_ids.shuffle(&mut thread_rng());
+                let mut peer_ids: Vec<_> = self.header_downloaders.keys().cloned().collect();
+                peer_ids.shuffle(&mut thread_rng());
 
-        for id in peer_ids {
-            self.send_body_request(&id);
+                for id in peer_ids {
+                    self.send_body_request(&id);
+                }
+            }
+            _ => {}
         }
     }
 

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -63,6 +63,10 @@ pub struct TokenInfo {
 #[derive(Debug)]
 enum State {
     SnapshotHeader(BlockHash, u64),
+    SnapshotBody {
+        block: BlockHash,
+        prev_root: H256,
+    },
     SnapshotChunk {
         block: BlockHash,
         restore: SnapshotRestore,
@@ -90,28 +94,12 @@ impl Extension {
     pub fn new(
         client: Arc<Client>,
         api: Box<dyn Api>,
-        snapshot_target: Option<(H256, u64)>,
+        snapshot_target: Option<(BlockHash, u64)>,
         snapshot_dir: Option<String>,
     ) -> Extension {
         api.set_timer(SYNC_TIMER_TOKEN, Duration::from_millis(SYNC_TIMER_INTERVAL)).expect("Timer set succeeds");
 
-        let state = match snapshot_target {
-            Some((hash, num)) => match client.block_header(&BlockId::Number(num)) {
-                Some(ref header) if *header.hash() == hash => {
-                    let state_db = client.state_db().read();
-                    let state_root = header.state_root();
-                    match TrieFactory::readonly(state_db.as_hashdb(), &state_root) {
-                        Ok(ref trie) if trie.is_complete() => State::Full,
-                        _ => State::SnapshotChunk {
-                            block: hash.into(),
-                            restore: SnapshotRestore::new(state_root),
-                        },
-                    }
-                }
-                _ => State::SnapshotHeader(hash.into(), num),
-            },
-            None => State::Full,
-        };
+        let state = Extension::initial_state(client.clone(), snapshot_target);
         cdebug!(SYNC, "Initial state is {:?}", state);
         let mut header = client.best_header();
         let mut hollow_headers = vec![header.decode()];
@@ -145,6 +133,36 @@ impl Extension {
             last_request: Default::default(),
             nonce: Default::default(),
             snapshot_dir,
+        }
+    }
+
+    fn initial_state(client: Arc<Client>, snapshot_target: Option<(BlockHash, u64)>) -> State {
+        let (hash, num) = match snapshot_target {
+            Some(target) => target,
+            None => return State::Full,
+        };
+        let header = match client.block_header(&num.into()) {
+            Some(ref h) if h.hash() == hash => h.clone(),
+            _ => return State::SnapshotHeader(hash, num),
+        };
+        if client.block_body(&hash.into()).is_none() {
+            let parent_hash = header.parent_hash();
+            let parent =
+                client.block_header(&parent_hash.into()).expect("Parent header of the snapshot header must exist");
+            return State::SnapshotBody {
+                block: hash,
+                prev_root: parent.state_root(),
+            }
+        }
+
+        let state_db = client.state_db().read();
+        let state_root = header.state_root();
+        match TrieFactory::readonly(state_db.as_hashdb(), &state_root) {
+            Ok(ref trie) if trie.is_complete() => State::Full,
+            _ => State::SnapshotChunk {
+                block: hash,
+                restore: SnapshotRestore::new(state_root),
+            },
         }
     }
 
@@ -395,6 +413,9 @@ impl NetworkExtension<Event> for Extension {
                             });
                         }
                     }
+                    State::SnapshotBody {
+                        ..
+                    } => unimplemented!(),
                     State::SnapshotChunk {
                         block,
                         ref mut restore,
@@ -509,6 +530,9 @@ impl Extension {
                     None
                 }
             }
+            State::SnapshotBody {
+                ..
+            } => None,
             State::SnapshotChunk {
                 ..
             } => None,
@@ -561,6 +585,9 @@ impl Extension {
                     None
                 }
             }
+            State::SnapshotBody {
+                ..
+            } => unimplemented!(),
             State::SnapshotChunk {
                 ..
             } => None,
@@ -855,6 +882,9 @@ impl Extension {
                     headers.len()
                 ),
             },
+            State::SnapshotBody {
+                ..
+            } => {}
             State::SnapshotChunk {
                 ..
             } => {}

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -151,7 +151,7 @@ impl Extension {
                 client.block_header(&parent_hash.into()).expect("Parent header of the snapshot header must exist");
             return State::SnapshotBody {
                 block: hash,
-                prev_root: parent.state_root(),
+                prev_root: parent.transactions_root(),
             }
         }
 
@@ -408,8 +408,8 @@ impl NetworkExtension<Event> for Extension {
                     State::SnapshotHeader(_, num) => {
                         for id in &peer_ids {
                             self.send_header_request(id, RequestMessage::Headers {
-                                start_number: num,
-                                max_count: 1,
+                                start_number: num - 1,
+                                max_count: 2,
                             });
                         }
                     }
@@ -518,88 +518,40 @@ pub enum Event {
 
 impl Extension {
     fn new_headers(&mut self, imported: Vec<BlockHash>, enacted: Vec<BlockHash>, retracted: Vec<BlockHash>) {
-        if let Some(next_state) = match self.state {
-            State::SnapshotHeader(hash, ..) => {
-                if imported.contains(&hash) {
-                    let header = self.client.block_header(&BlockId::Hash(hash)).expect("Imported header must exist");
-                    Some(State::SnapshotChunk {
-                        block: hash,
-                        restore: SnapshotRestore::new(header.state_root()),
-                    })
-                } else {
-                    None
+        if let State::Full = self.state {
+            let peer_ids: Vec<_> = self.header_downloaders.keys().cloned().collect();
+            for id in peer_ids {
+                if let Some(peer) = self.header_downloaders.get_mut(&id) {
+                    peer.mark_as_imported(imported.clone());
                 }
             }
-            State::SnapshotBody {
-                ..
-            } => None,
-            State::SnapshotChunk {
-                ..
-            } => None,
-            State::Full => {
-                let peer_ids: Vec<_> = self.header_downloaders.keys().cloned().collect();
-                for id in peer_ids {
-                    if let Some(peer) = self.header_downloaders.get_mut(&id) {
-                        peer.mark_as_imported(imported.clone());
-                    }
-                }
-                let mut headers_to_download: Vec<_> = enacted
-                    .into_iter()
-                    .map(|hash| self.client.block_header(&BlockId::Hash(hash)).expect("Enacted header must exist"))
-                    .collect();
-                headers_to_download.sort_unstable_by_key(EncodedHeader::number);
-                #[allow(clippy::redundant_closure)]
-                // False alarm. https://github.com/rust-lang/rust-clippy/issues/1439
-                headers_to_download.dedup_by_key(|h| h.hash());
+            let mut headers_to_download: Vec<_> = enacted
+                .into_iter()
+                .map(|hash| self.client.block_header(&BlockId::Hash(hash)).expect("Enacted header must exist"))
+                .collect();
+            headers_to_download.sort_unstable_by_key(EncodedHeader::number);
+            #[allow(clippy::redundant_closure)]
+            // False alarm. https://github.com/rust-lang/rust-clippy/issues/1439
+            headers_to_download.dedup_by_key(|h| h.hash());
 
-                let headers: Vec<_> = headers_to_download
-                    .into_iter()
-                    .filter(|header| self.client.block_body(&BlockId::Hash(header.hash())).is_none())
-                    .collect(); // FIXME: No need to collect here if self is not borrowed.
-                for header in headers {
-                    let parent = self
-                        .client
-                        .block_header(&BlockId::Hash(header.parent_hash()))
-                        .expect("Enacted header must have parent");
-                    self.body_downloader.add_target(&header.decode(), &parent.decode());
-                }
-                self.body_downloader.remove_target(&retracted);
-                None
+            let headers: Vec<_> = headers_to_download
+                .into_iter()
+                .filter(|header| self.client.block_body(&BlockId::Hash(header.hash())).is_none())
+                .collect(); // FIXME: No need to collect here if self is not borrowed.
+            for header in headers {
+                let parent = self
+                    .client
+                    .block_header(&BlockId::Hash(header.parent_hash()))
+                    .expect("Enacted header must have parent");
+                self.body_downloader.add_target(&header.decode(), &parent.decode());
             }
-        } {
-            cdebug!(SYNC, "Transitioning state to {:?}", next_state);
-            self.state = next_state;
+            self.body_downloader.remove_target(&retracted);
         }
     }
 
     fn new_blocks(&mut self, imported: Vec<BlockHash>, invalid: Vec<BlockHash>) {
-        if let Some(next_state) = match self.state {
-            State::SnapshotHeader(hash, ..) => {
-                if imported.contains(&hash) {
-                    let header = self.client.block_header(&BlockId::Hash(hash)).expect("Imported header must exist");
-                    Some(State::SnapshotChunk {
-                        block: hash,
-                        restore: SnapshotRestore::new(header.state_root()),
-                    })
-                } else {
-                    None
-                }
-            }
-            State::SnapshotBody {
-                ..
-            } => unimplemented!(),
-            State::SnapshotChunk {
-                ..
-            } => None,
-            State::Full => {
-                self.body_downloader.remove_target(&imported);
-                self.body_downloader.remove_target(&invalid);
-                None
-            }
-        } {
-            cdebug!(SYNC, "Transitioning state to {:?}", next_state);
-            self.state = next_state;
-        }
+        self.body_downloader.remove_target(&imported);
+        self.body_downloader.remove_target(&invalid);
 
         let chain_info = self.client.chain_info();
 
@@ -858,20 +810,20 @@ impl Extension {
         ctrace!(SYNC, "Received header response from({}) with length({})", from, headers.len());
         match self.state {
             State::SnapshotHeader(hash, _) => match headers {
-                [header] if header.hash() == hash => {
+                [parent, header] if header.hash() == hash => {
                     match self.client.import_bootstrap_header(&header) {
-                        Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
-                            self.state = State::SnapshotChunk {
+                        Ok(_) | Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
+                            self.state = State::SnapshotBody {
                                 block: hash,
-                                restore: SnapshotRestore::new(*header.state_root()),
+                                prev_root: *parent.transactions_root(),
                             };
+                            cdebug!(SYNC, "Transitioning state to {:?}", self.state);
                         }
                         Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
                         // FIXME: handle import errors
                         Err(err) => {
                             cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
                         }
-                        _ => {}
                     }
                 }
                 _ => cdebug!(

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -446,6 +446,7 @@ impl NetworkExtension<Event> for Extension {
                             self.send_chunk_request(&block, &root);
                         } else {
                             cdebug!(SYNC, "Transitioning state to {:?}", State::Full);
+                            self.client.force_update_best_block(&block);
                             self.state = State::Full;
                         }
                     }
@@ -833,6 +834,24 @@ impl Extension {
         match self.state {
             State::SnapshotHeader(hash, _) => match headers {
                 [parent, header] if header.hash() == hash => {
+                    match self.client.import_trusted_header(parent) {
+                        Ok(_)
+                        | Err(BlockImportError::Import(ImportError::AlreadyInChain))
+                        | Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
+                        Err(err) => {
+                            cwarn!(SYNC, "Cannot import header({}): {:?}", parent.hash(), err);
+                            return
+                        }
+                    }
+                    match self.client.import_trusted_header(header) {
+                        Ok(_)
+                        | Err(BlockImportError::Import(ImportError::AlreadyInChain))
+                        | Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
+                        Err(err) => {
+                            cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
+                            return
+                        }
+                    }
                     self.state = State::SnapshotBody {
                         header: EncodedHeader::new(header.rlp_bytes().to_vec()),
                         prev_root: *parent.transactions_root(),
@@ -909,7 +928,7 @@ impl Extension {
                         header: header.decode(),
                         transactions: body.clone(),
                     };
-                    match self.client.import_bootstrap_block(&block) {
+                    match self.client.import_trusted_block(&block) {
                         Ok(_) | Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
                             self.state = State::SnapshotChunk {
                                 block: header.hash(),
@@ -920,7 +939,7 @@ impl Extension {
                         Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {}
                         // FIXME: handle import errors
                         Err(err) => {
-                            cwarn!(SYNC, "Cannot import header({}): {:?}", header.hash(), err);
+                            cwarn!(SYNC, "Cannot import block({}): {:?}", header.hash(), err);
                         }
                     }
                 }
@@ -1020,6 +1039,7 @@ impl Extension {
                 self.send_chunk_request(&block, &root);
             } else {
                 cdebug!(SYNC, "Transitioning state to {:?}", State::Full);
+                self.client.force_update_best_block(&block);
                 self.state = State::Full;
             }
         }


### PR DESCRIPTION
Original snapshot sync implementation downloaded only the header of the snapshot target.
It introduced lots of problems, so I and @foriequal0 decided to download the body of the snapshot target too.

`SnapshotBody` state is added to the `State` enum in sync extension.
Also, `import_bootstrap_header` in `Client` is changed to `import_trusted_header`, `import_trusted_block` and `force_update_best_block`.