### PR TITLE
Remove a redundant logging on the jsonrpc server

### DIFF
--- a/codechain/rpc.rs
+++ b/codechain/rpc.rs
@@ -149,14 +149,6 @@ impl<M: jsonrpc_core::Metadata> jsonrpc_core::Middleware<M> for LogMiddleware {
         }
         Either::B(next(request, meta))
     }
-
-    fn on_call<F, X>(&self, call: jsonrpc_core::Call, meta: M, next: F) -> Either<Self::CallFuture, X>
-    where
-        F: FnOnce(jsonrpc_core::Call, M) -> X + Send,
-        X: futures::Future<Item = Option<jsonrpc_core::Output>, Error = ()> + Send + 'static, {
-        Self::print_call(&call);
-        Either::B(next(call, meta))
-    }
 }
 
 impl LogMiddleware {


### PR DESCRIPTION
I thought `on_call` and `on_request` are mutually exclusive functions. It was not. For every request, the `on_call` is called after the `on_request` is called.