### PR TITLE
The latest ubuntu has yarn by default

### DIFF
--- a/.github/workflows/yarn-lint.yml
+++ b/.github/workflows/yarn-lint.yml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - run: npm install yarn
       - working-directory: ./test
         run: yarn
       - working-directory: ./test


### PR DESCRIPTION
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#ubuntu-1804-lts It has yarn 1.19.1 by default.