### PR TITLE
Remove the duration argument from ChainNotify

### DIFF
--- a/core/src/client/chain_notify.rs
+++ b/core/src/client/chain_notify.rs
@@ -27,7 +27,6 @@ pub trait ChainNotify: Send + Sync {
         _enacted: Vec<BlockHash>,
         _retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
         _new_best_proposal: Option<BlockHash>,
     ) {
         // does nothing by default
@@ -41,7 +40,6 @@ pub trait ChainNotify: Send + Sync {
         _enacted: Vec<BlockHash>,
         _retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
     ) {
         // does nothing by default
     }

--- a/core/src/consensus/tendermint/chain_notify.rs
+++ b/core/src/consensus/tendermint/chain_notify.rs
@@ -41,7 +41,6 @@ impl ChainNotify for TendermintChainNotify {
         enacted: Vec<BlockHash>,
         _retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
     ) {
         self.inner
             .send(worker::Event::NewBlocks {

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -775,7 +775,6 @@ impl ChainNotify for BlockSyncSender {
         enacted: Vec<BlockHash>,
         retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
         _new_best_proposal: Option<BlockHash>,
     ) {
         self.0
@@ -794,7 +793,6 @@ impl ChainNotify for BlockSyncSender {
         _enacted: Vec<BlockHash>,
         _retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
     ) {
         self.0
             .send(Event::NewBlocks {

--- a/sync/src/snapshot/service.rs
+++ b/sync/src/snapshot/service.rs
@@ -52,7 +52,6 @@ impl ChainNotify for Service {
         enacted: Vec<BlockHash>,
         _retracted: Vec<BlockHash>,
         _sealed: Vec<BlockHash>,
-        _duration: u64,
     ) {
         let best_number = self.client.chain_info().best_block_number;
         let is_checkpoint = enacted


### PR DESCRIPTION
I don't know why we have this argument in the first place, but we don't use it now.