### PR TITLE
Precalculate the fee at on_term_open

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -313,6 +313,10 @@ impl<'x> OpenBlock<'x> {
         self.block.header.set_seal(seal);
         Ok(())
     }
+
+    pub fn inner_mut(&mut self) -> &mut ExecutedBlock {
+        &mut self.block
+    }
 }
 
 /// Just like `OpenBlock`, except that we've applied `Engine::on_close_block`, finished up the non-seal header fields.
@@ -492,6 +496,7 @@ pub fn enact<C: ChainTimeInfo + EngineInfo + FindActionHandler + TermInfo>(
     let mut b = OpenBlock::try_new(engine, db, parent, Address::default(), vec![])?;
 
     b.populate_from(header);
+    engine.on_open_block(b.inner_mut())?;
     b.push_transactions(transactions, client, parent.number(), parent.timestamp())?;
 
     let term_common_params = client.term_common_params(BlockId::Hash(*header.parent_hash()));

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -221,6 +221,11 @@ pub trait ConsensusEngine: Sync + Send {
     /// Stops any services that the may hold the Engine and makes it safe to drop.
     fn stop(&self) {}
 
+    /// Block transformation functions, before the transactions.
+    fn on_open_block(&self, _block: &mut ExecutedBlock) -> Result<(), Error> {
+        Ok(())
+    }
+
     /// Block transformation functions, after the transactions.
     fn on_close_block(
         &self,

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -118,7 +118,7 @@ impl ConsensusEngine for Solo {
             self.machine.add_balance(block, &author, block_author_reward)?;
             return Ok(())
         }
-        stake::add_intermediate_rewards(block.state_mut(), author, block_author_reward)?;
+        stake::v0::add_intermediate_rewards(block.state_mut(), author, block_author_reward)?;
         let last_term_finished_block_num = {
             let header = block.header();
             let current_term_period = header.timestamp() / term_seconds;
@@ -128,8 +128,8 @@ impl ConsensusEngine for Solo {
             }
             header.number()
         };
-        stake::move_current_to_previous_intermediate_rewards(&mut block.state_mut())?;
-        let rewards = stake::drain_previous_rewards(&mut block.state_mut())?;
+        stake::v0::move_current_to_previous_intermediate_rewards(&mut block.state_mut())?;
+        let rewards = stake::v0::drain_previous_rewards(&mut block.state_mut())?;
         for (address, reward) in rewards {
             self.machine.add_balance(block, &address, reward)?;
         }

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -298,7 +298,7 @@ impl ConsensusEngine for Tendermint {
 
         match term {
             0 => {}
-            _ => match era {
+            _ => match metadata.params().map_or(0, |p| p.era()) {
                 0 => {}
                 1 => block.state_mut().snapshot_term_params()?,
                 _ => unimplemented!("It is not decided how we handle this"),

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -134,6 +134,15 @@ impl ConsensusEngine for Tendermint {
 
     fn stop(&self) {}
 
+    /// Block transformation functions, before the transactions.
+    fn on_open_block(&self, block: &mut ExecutedBlock) -> Result<(), Error> {
+        let metadata = block.state().metadata()?.expect("Metadata must exist");
+        if block.header().number() == metadata.last_term_finished_block_num() + 1 {
+            // FIXME: on_term_open
+        }
+        Ok(())
+    }
+
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -527,6 +527,7 @@ impl Miner {
                 return Ok(None)
             }
         }
+        self.engine.on_open_block(open_block.inner_mut())?;
 
         let mut invalid_transactions = Vec::new();
 


### PR DESCRIPTION
Depends on https://github.com/CodeChain-io/codechain/pull/1895

This PR introduces `on_term_open`, and calculates the final fee distribution there.
The detailed design is as follows:
### 1. State structure
State leaf at `makeKey("IntermediateRewards")` contains `[previous, current]` value, and they mean the previous and current intermediate reward that the validators collected.

In era=1, it now contains `[current, calculated]`, and they mean the _current intermediate reward_, and the _calculated result of (reward - penalty)_.

### 2. `on_term_open`
`on_term_open` is called at the first block of the term, and before any of the transactions in the block is processed.
The term start is detected by the following condition:
`block_number == metadata.last_term_finished_block_num() + 1`

When the era is zero, it does nothing.
When the era is 1, it calculates the penalty that each validator should take, and substracts it from the _current_ reward in the state, and saves the result in _calculated_ part.
After that, it clears the _current_ reward.

### 3. `on_term_close`
When the era is 1, the _calculated_ fee is read from the state and CCC is distributed according to that value.
Note that although it is not strictly required to do this, the _calculated_ part is cleared to empty map here. 