### PR TITLE
Change setSigner to signer

### DIFF
--- a/test/src/e2e.dynval/setup.ts
+++ b/test/src/e2e.dynval/setup.ts
@@ -122,7 +122,7 @@ async function createNodes(options: {
             ],
             additionalKeysPath: `tendermint.dynval/${validator.platformAddress.value}/keys`
         });
-        nodes[i].setSigner(validator);
+        nodes[i].signer = validator;
     }
     let bootstrapFailed = false;
     try {

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -144,6 +144,10 @@ export default class CodeChain {
         return this._signer;
     }
 
+    public set signer(signer: Signer) {
+        this._signer = signer;
+    }
+
     constructor(
         options: {
             chain?: ChainType;
@@ -341,10 +345,6 @@ export default class CodeChain {
                 .on("exit", onExit);
             readline.on("line", onLine);
         });
-    }
-
-    public setSigner(signer: Signer) {
-        this._signer = signer;
     }
 
     public keepLogs() {


### PR DESCRIPTION
We already defined a getter accessor for signer, but defined a method
for setter instead of an accessor.
This patch changes the setSigner method to the signer accessor.