### PR TITLE
Reduce the failure rate of testing total shutdown

### DIFF
--- a/test/src/e2e.dynval/2/dv.shutdown.test.ts
+++ b/test/src/e2e.dynval/2/dv.shutdown.test.ts
@@ -216,12 +216,7 @@ describe("Shutdown test", function() {
                     delegation: 1000,
                     deposit: 100000 - i // tie-breaker
                 }))
-            ],
-            async onBeforeEnable(allNodes) {
-                for (const node of getValidators(allNodes).nodes) {
-                    await node.clean();
-                }
-            }
+            ]
         });
 
         it("only a term closer should be a validator after a complete shutdown", async function() {


### PR DESCRIPTION
Currently, the test frequently failed.
This test changes the validator set to the nodes which are not started
yet and starts all new validators when the term changed.

What I found is they are far behind than the best chain, and they cannot
create a block until timeout because they are synchronizing.

I think it's because of the slow synchronization, but fast
synchronization is hard to achieve in the near future. So this patch
made the new validator nodes keep alive while creating the blocks that
set initial states.

It may not be a perfect solution, but it reduces the test failure rates
dramatically.