### PR TITLE
Do not stop nodes while changing a term in the partial shutdown test

### DIFF
--- a/test/src/e2e.dynval/2/dv.shutdown.test.ts
+++ b/test/src/e2e.dynval/2/dv.shutdown.test.ts
@@ -65,12 +65,7 @@ describe("Shutdown test", function() {
                 { signer: validators[4], delegation: 1, deposit: 100000 },
                 { signer: validators[5], delegation: 1, deposit: 100000 },
                 { signer: validators[6], delegation: 1, deposit: 100000 }
-            ],
-            async onBeforeEnable(allNodes) {
-                for (const node of getBetas(allNodes).nodes) {
-                    await node.clean();
-                }
-            }
+            ]
         });
 
         beforeEach(async function() {


### PR DESCRIPTION
Because of the same reason as the total shutdown test, it reduces the failure rate.