### PR TITLE
Refactor to introduce the snapshot sync

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -33,6 +33,7 @@ use crate::client::{EngineInfo, TermInfo};
 use crate::consensus::CodeChainEngine;
 use crate::error::{BlockError, Error};
 use crate::transaction::{SignedTransaction, UnverifiedTransaction};
+use crate::BlockId;
 
 /// A block, encoded as it is on the block chain.
 #[derive(Debug, Clone, PartialEq)]
@@ -493,16 +494,7 @@ pub fn enact<C: ChainTimeInfo + EngineInfo + FindActionHandler + TermInfo>(
     b.populate_from(header);
     b.push_transactions(transactions, client, parent.number(), parent.timestamp())?;
 
-    let term_common_params = {
-        let block_number = client
-            .last_term_finished_block_num((*header.parent_hash()).into())
-            .expect("The block of the parent hash should exist");
-        if block_number == 0 {
-            None
-        } else {
-            Some(client.common_params((block_number).into()).expect("Common params should exist"))
-        }
-    };
+    let term_common_params = client.term_common_params(BlockId::Hash(*header.parent_hash()));
     b.close_and_lock(parent, term_common_params.as_ref())
 }
 

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -813,6 +813,15 @@ impl TermInfo for Client {
             .map(|state| state.metadata().unwrap().expect("Metadata always exist"))
             .map(|metadata| metadata.current_term_id())
     }
+
+    fn term_common_params(&self, id: BlockId) -> Option<CommonParams> {
+        let block_number = self.last_term_finished_block_num(id).expect("The block of the parent hash should exist");
+        if block_number == 0 {
+            None
+        } else {
+            Some(self.common_params((block_number).into()).expect("Common params should exist"))
+        }
+    }
 }
 
 impl AccountData for Client {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -119,6 +119,7 @@ pub trait ConsensusClient: BlockChainClient + EngineClient + EngineInfo + TermIn
 pub trait TermInfo {
     fn last_term_finished_block_num(&self, id: BlockId) -> Option<BlockNumber>;
     fn current_term_id(&self, id: BlockId) -> Option<u64>;
+    fn term_common_params(&self, id: BlockId) -> Option<CommonParams>;
 }
 
 /// Provides methods to access account info

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -645,7 +645,7 @@ impl super::EngineClient for TestBlockChainClient {
 
 impl EngineInfo for TestBlockChainClient {
     fn common_params(&self, _block_id: BlockId) -> Option<CommonParams> {
-        unimplemented!()
+        Some(*self.scheme.engine.machine().genesis_common_params())
     }
 
     fn metadata_seq(&self, _block_id: BlockId) -> Option<u64> {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -679,6 +679,10 @@ impl TermInfo for TestBlockChainClient {
     fn current_term_id(&self, _id: BlockId) -> Option<u64> {
         self.term_id
     }
+
+    fn term_common_params(&self, _id: BlockId) -> Option<CommonParams> {
+        None
+    }
 }
 
 impl StateInfo for TestBlockChainClient {

--- a/core/src/consensus/blake_pow/mod.rs
+++ b/core/src/consensus/blake_pow/mod.rs
@@ -163,8 +163,6 @@ impl ConsensusEngine for BlakePoW {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
         _term_common_params: Option<&CommonParams>,
     ) -> Result<(), Error> {
         let author = *block.header().author();

--- a/core/src/consensus/cuckoo/mod.rs
+++ b/core/src/consensus/cuckoo/mod.rs
@@ -173,8 +173,6 @@ impl ConsensusEngine for Cuckoo {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
         _term_common_params: Option<&CommonParams>,
     ) -> Result<(), Error> {
         let author = *block.header().author();
@@ -261,21 +259,13 @@ mod tests {
     #[test]
     fn on_close_block() {
         let scheme = Scheme::new_test_cuckoo();
-        let genesis_header = scheme.genesis_header();
         let engine = &*scheme.engine;
         let db = scheme.ensure_genesis_state(get_temp_state_db()).unwrap();
         let header = Header::default();
         let block = OpenBlock::try_new(engine, db, &header, Default::default(), vec![]).unwrap();
         let mut executed_block = block.block().clone();
 
-        assert!(engine
-            .on_close_block(
-                &mut executed_block,
-                &genesis_header,
-                &CommonParams::default_for_test(),
-                Some(&CommonParams::default_for_test())
-            )
-            .is_ok());
+        assert!(engine.on_close_block(&mut executed_block, Some(&CommonParams::default_for_test())).is_ok());
         assert_eq!(0xd, engine.machine().balance(&executed_block, header.author()).unwrap());
     }
 

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -225,8 +225,6 @@ pub trait ConsensusEngine: Sync + Send {
     fn on_close_block(
         &self,
         _block: &mut ExecutedBlock,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
         _term_common_params: Option<&CommonParams>,
     ) -> Result<(), Error> {
         Ok(())

--- a/core/src/consensus/null_engine/mod.rs
+++ b/core/src/consensus/null_engine/mod.rs
@@ -17,7 +17,7 @@
 mod params;
 
 use ckey::Address;
-use ctypes::{CommonParams, Header};
+use ctypes::CommonParams;
 
 use self::params::NullEngineParams;
 use super::ConsensusEngine;
@@ -58,8 +58,6 @@ impl ConsensusEngine for NullEngine {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
         _term_common_params: Option<&CommonParams>,
     ) -> Result<(), Error> {
         let (author, total_reward) = {

--- a/core/src/consensus/simple_poa/mod.rs
+++ b/core/src/consensus/simple_poa/mod.rs
@@ -121,8 +121,6 @@ impl ConsensusEngine for SimplePoA {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
         _term_common_params: Option<&CommonParams>,
     ) -> Result<(), Error> {
         let author = *block.header().author();
@@ -186,9 +184,8 @@ mod tests {
         let db = scheme.ensure_genesis_state(get_temp_state_db()).unwrap();
         let genesis_header = scheme.genesis_header();
         let b = OpenBlock::try_new(engine, db, &genesis_header, Default::default(), vec![]).unwrap();
-        let parent_common_params = CommonParams::default_for_test();
         let term_common_params = CommonParams::default_for_test();
-        let b = b.close_and_lock(&genesis_header, &parent_common_params, Some(&term_common_params)).unwrap();
+        let b = b.close_and_lock(&genesis_header, Some(&term_common_params)).unwrap();
         if let Some(seal) = engine.generate_seal(Some(b.block()), &genesis_header).seal_fields() {
             assert!(b.try_seal(engine, seal).is_ok());
         }

--- a/core/src/consensus/stake/mod.rs
+++ b/core/src/consensus/stake/mod.rs
@@ -156,13 +156,7 @@ impl ActionHandler for Stake {
         action.verify(current_params, client, validators)
     }
 
-    fn on_close_block(
-        &self,
-        _state: &mut TopLevelState,
-        _header: &Header,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
-    ) -> StateResult<()> {
+    fn on_close_block(&self, _state: &mut TopLevelState, _header: &Header) -> StateResult<()> {
         Ok(())
     }
 }

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -173,8 +173,7 @@ impl ConsensusEngine for Tendermint {
             return Ok(())
         }
 
-        let block_author = *block.header().author();
-        stake::update_validator_weights(&mut block.state_mut(), &block_author)?;
+        stake::update_validator_weights(&mut block.state_mut(), &author)?;
 
         stake::add_intermediate_rewards(block.state_mut(), author, block_author_reward)?;
 

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -173,7 +173,7 @@ impl ConsensusEngine for Tendermint {
                 self.machine.add_balance(block, &author, block_author_reward)?;
             }
             _ => {
-                stake::update_validator_weights(&mut block.state_mut(), &author)?;
+                stake::update_validator_weights(block.state_mut(), &author)?;
                 stake::add_intermediate_rewards(block.state_mut(), author, block_author_reward)?;
             }
         }
@@ -185,7 +185,7 @@ impl ConsensusEngine for Tendermint {
         let inactive_validators = match term {
             0 => Vec::new(),
             _ => {
-                let rewards = stake::drain_previous_rewards(&mut block.state_mut())?;
+                let rewards = stake::drain_previous_rewards(block.state_mut())?;
                 let start_of_the_current_term = metadata.last_term_finished_block_num() + 1;
                 let client = self
                     .client
@@ -226,7 +226,7 @@ impl ConsensusEngine for Tendermint {
                     }
                 }
 
-                stake::move_current_to_previous_intermediate_rewards(&mut block.state_mut())?;
+                stake::move_current_to_previous_intermediate_rewards(block.state_mut())?;
 
                 let validators = stake::Validators::load_from_state(block.state())?
                     .into_iter()

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -115,6 +115,10 @@ impl Tendermint {
             has_signer: false.into(),
         })
     }
+
+    fn client(&self) -> Option<Arc<dyn ConsensusClient>> {
+        self.client.read().as_ref()?.upgrade()
+    }
 }
 
 const SEAL_FIELDS: usize = 4;

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -161,9 +161,8 @@ mod tests {
         let genesis_header = scheme.genesis_header();
         let b = OpenBlock::try_new(scheme.engine.as_ref(), db, &genesis_header, proposer, vec![]).unwrap();
         let seal = scheme.engine.generate_seal(None, &genesis_header).seal_fields().unwrap();
-        let common_params = CommonParams::default_for_test();
         let term_common_params = CommonParams::default_for_test();
-        let b = b.close(&genesis_header, &common_params, Some(&term_common_params)).unwrap();
+        let b = b.close(&genesis_header, Some(&term_common_params)).unwrap();
         (b, seal)
     }
 

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -603,7 +603,6 @@ impl Miner {
             let parent_header = chain.block_header(&parent_hash.into()).expect("Parent header MUST exist");
             (parent_header.decode(), parent_hash)
         };
-        let parent_common_params = chain.common_params(parent_hash.into()).unwrap();
         let term_common_params = {
             let block_number = chain
                 .last_term_finished_block_num(parent_hash.into())
@@ -614,7 +613,7 @@ impl Miner {
                 Some(chain.common_params((block_number).into()).expect("Common params should exist"))
             }
         };
-        let block = open_block.close(&parent_header, &parent_common_params, term_common_params.as_ref())?;
+        let block = open_block.close(&parent_header, term_common_params.as_ref())?;
 
         let fetch_seq = |p: &Public| {
             let address = public_to_address(p);

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -603,16 +603,7 @@ impl Miner {
             let parent_header = chain.block_header(&parent_hash.into()).expect("Parent header MUST exist");
             (parent_header.decode(), parent_hash)
         };
-        let term_common_params = {
-            let block_number = chain
-                .last_term_finished_block_num(parent_hash.into())
-                .expect("The block of the parent hash should exist");
-            if block_number == 0 {
-                None
-            } else {
-                Some(chain.common_params((block_number).into()).expect("Common params should exist"))
-            }
-        };
+        let term_common_params = chain.term_common_params(parent_hash.into());
         let block = open_block.close(&parent_header, term_common_params.as_ref())?;
 
         let fetch_seq = |p: &Public| {

--- a/core/src/miner/sealing_queue.rs
+++ b/core/src/miner/sealing_queue.rs
@@ -87,9 +87,8 @@ mod tests {
         let genesis_header = scheme.genesis_header();
         let db = scheme.ensure_genesis_state(get_temp_state_db()).unwrap();
         let b = OpenBlock::try_new(&*scheme.engine, db, &genesis_header, address, vec![]).unwrap();
-        let common_params = CommonParams::default_for_test();
         let term_common_params = CommonParams::default_for_test();
-        b.close(&genesis_header, &common_params, Some(&term_common_params)).unwrap()
+        b.close(&genesis_header, Some(&term_common_params)).unwrap()
     }
 
     #[test]

--- a/state/src/action_handler/hit.rs
+++ b/state/src/action_handler/hit.rs
@@ -86,13 +86,7 @@ impl ActionHandler for HitHandler {
         Ok(())
     }
 
-    fn on_close_block(
-        &self,
-        state: &mut TopLevelState,
-        _header: &Header,
-        _parent_header: &Header,
-        _parent_common_params: &CommonParams,
-    ) -> StateResult<()> {
+    fn on_close_block(&self, state: &mut TopLevelState, _header: &Header) -> StateResult<()> {
         let address = self.close_count();
         let action_data = state.action_data(&address)?.unwrap_or_default();
         let prev_counter: u32 = rlp::decode(&*action_data).unwrap();

--- a/state/src/action_handler/mod.rs
+++ b/state/src/action_handler/mod.rs
@@ -47,13 +47,7 @@ pub trait ActionHandler: Send + Sync {
         Ok(some_action_data)
     }
 
-    fn on_close_block(
-        &self,
-        state: &mut TopLevelState,
-        header: &Header,
-        parent_header: &Header,
-        parent_common_params: &CommonParams,
-    ) -> StateResult<()>;
+    fn on_close_block(&self, state: &mut TopLevelState, header: &Header) -> StateResult<()>;
 }
 
 pub trait FindActionHandler {


### PR DESCRIPTION
This is cherry-picked refactor commits while working on this PR https://github.com/CodeChain-io/codechain/pull/1910
You might have seen those changes before. This shouldn't change the behavior drastically.

* #1894 Refactor tendermint's on_close_block
* #1893 Add `era` to CommonParams
* #1896 Refactor `on_close_block`, take #2
* #1895 Read term_common_params from the snapshot