### PR TITLE
Save current block's validator in the state

### DIFF
--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -59,7 +59,7 @@ use crate::client::{
     AccountData, BlockChainClient, BlockChainTrait, BlockProducer, BlockStatus, ConsensusClient, EngineInfo,
     ImportBlock, ImportResult, MiningBlockChainClient, StateInfo, StateOrBlock, TermInfo,
 };
-use crate::consensus::stake::{Validator, Validators};
+use crate::consensus::stake::{NextValidators, Validator};
 use crate::consensus::EngineError;
 use crate::db::{COL_STATE, NUM_COLUMNS};
 use crate::encoded;
@@ -106,7 +106,7 @@ pub struct TestBlockChainClient {
     /// Fixed validator keys
     pub validator_keys: RwLock<HashMap<Public, Private>>,
     /// Fixed validators
-    pub validators: Validators,
+    pub validators: NextValidators,
 }
 
 impl Default for TestBlockChainClient {
@@ -160,7 +160,7 @@ impl TestBlockChainClient {
             history: RwLock::new(None),
             term_id: Some(1),
             validator_keys: RwLock::new(HashMap::new()),
-            validators: Validators::from_vector_to_test(vec![]),
+            validators: NextValidators::from_vector_to_test(vec![]),
         };
 
         // insert genesis hash.
@@ -325,14 +325,14 @@ impl TestBlockChainClient {
             self.validator_keys.write().insert(*key_pair.public(), *key_pair.private());
             pubkeys.push(*key_pair.public());
         }
-        let fixed_validators: Validators = Validators::from_vector_to_test(
+        let fixed_validators: NextValidators = NextValidators::from_vector_to_test(
             pubkeys.into_iter().map(|pubkey| Validator::new_for_test(0, 0, pubkey)).collect(),
         );
 
         self.validators = fixed_validators;
     }
 
-    pub fn get_validators(&self) -> &Validators {
+    pub fn get_validators(&self) -> &NextValidators {
         &self.validators
     }
 }

--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -432,6 +432,16 @@ impl CurrentValidators {
     pub fn update(&mut self, validators: Vec<Validator>) {
         self.0 = validators;
     }
+
+    pub fn addresses(&self) -> Vec<Address> {
+        self.0.iter().rev().map(|v| public_to_address(&v.pubkey)).collect()
+    }
+
+    pub fn get_validator(&self, index: usize) -> &Validator {
+        let len = self.0.len();
+        // NOTE: validator list is reversed when reading a validator by index
+        self.0.iter().nth_back(index % len).unwrap()
+    }
 }
 
 impl Deref for CurrentValidators {

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -35,7 +35,7 @@ use super::backup::{backup, restore, BackupView};
 use super::message::*;
 use super::network;
 use super::params::TimeGapParams;
-use super::stake::CUSTOM_ACTION_HANDLER_ID;
+use super::stake::{CurrentValidators, CUSTOM_ACTION_HANDLER_ID};
 use super::types::{Height, Proposal, Step, TendermintSealView, TendermintState, TwoThirdsMajority, View};
 use super::vote_collector::{DoubleVote, VoteCollector};
 use super::vote_regression_checker::VoteRegressionChecker;
@@ -1244,13 +1244,19 @@ impl Worker {
         };
 
         let mut voted_validators = BitSet::new();
-        let grand_parent_hash = self
-            .client()
-            .block_header(&(*header.parent_hash()).into())
-            .expect("The parent block must exist")
-            .parent_hash();
+        let parent = self.client().block_header(&(*header.parent_hash()).into()).expect("The parent block must exist");
+        let grand_parent_hash = parent.parent_hash();
         for (bitset_index, signature) in seal_view.signatures()? {
-            let public = self.validators.get(&grand_parent_hash, bitset_index);
+            let public = {
+                let state = self.client().state_at(parent.hash().into()).expect("The parent state must exist");
+                let validators = CurrentValidators::load_from_state(&state)?;
+                // This happens when era == 0
+                if validators.is_empty() {
+                    self.validators.get(&grand_parent_hash, bitset_index)
+                } else {
+                    *validators.get_validator(bitset_index).pubkey()
+                }
+            };
             if !verify_schnorr(&public, &signature, &precommit_vote_on.hash())? {
                 let address = public_to_address(&public);
                 return Err(EngineError::BlockNotAuthorized(address.to_owned()).into())
@@ -1263,7 +1269,7 @@ impl Worker {
         if header.number() == 1 {
             return Ok(())
         }
-        self.validators.check_enough_votes(&grand_parent_hash, &voted_validators)?;
+        self.validators.check_enough_votes_with_header(&parent.decode(), &voted_validators)?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR introduces the `CurrentValidator` state value, which represents the set of validators for this block.
It allows the tendermint consensus module to verify blocks without reading their parents.
`CurrentValidator` is updated at `on_open_block` for every block that is in the 1st era.