### PR TITLE
Do not export TrieDB and TrieDBMut

### DIFF
--- a/core/src/scheme/scheme.rs
+++ b/core/src/scheme/scheme.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use ccrypto::{blake256, BLAKE_NULL_RLP};
 use cjson;
 use ckey::Address;
-use cmerkle::TrieFactory;
+use cmerkle::{TrieFactory, TrieMut};
 use cstate::{Metadata, MetadataAddress, Shard, ShardAddress, StateDB, StateResult, StateWithCache, TopLevelState};
 use ctypes::errors::SyntaxError;
 use ctypes::{BlockHash, CommonParams, Header, ShardId};

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -670,7 +670,7 @@ impl<'db> ShardLevelState<'db> {
     fn get_asset_scheme_mut(&self, shard_id: ShardId, asset_type: H160) -> cmerkle::Result<RefMut<AssetScheme>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.cache.asset_scheme_mut(&AssetSchemeAddress::new(asset_type, shard_id), &*trie)
+        self.cache.asset_scheme_mut(&AssetSchemeAddress::new(asset_type, shard_id), &trie)
     }
 
     pub fn create_asset(
@@ -697,13 +697,13 @@ impl<'db> ShardStateView for ShardLevelState<'db> {
     fn asset_scheme(&self, asset_type: H160) -> cmerkle::Result<Option<AssetScheme>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.cache.asset_scheme(&AssetSchemeAddress::new(asset_type, self.shard_id), &*trie)
+        self.cache.asset_scheme(&AssetSchemeAddress::new(asset_type, self.shard_id), &trie)
     }
 
     fn asset(&self, tracker: Tracker, index: usize) -> Result<Option<OwnedAsset>, TrieError> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.cache.asset(&OwnedAssetAddress::new(tracker, index, self.shard_id), &*trie)
+        self.cache.asset(&OwnedAssetAddress::new(tracker, index, self.shard_id), &trie)
     }
 }
 
@@ -780,13 +780,13 @@ impl<'db> ShardStateView for ReadOnlyShardLevelState<'db> {
     fn asset_scheme(&self, asset_type: H160) -> cmerkle::Result<Option<AssetScheme>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.cache.asset_scheme(&AssetSchemeAddress::new(asset_type, self.shard_id), &*trie)
+        self.cache.asset_scheme(&AssetSchemeAddress::new(asset_type, self.shard_id), &trie)
     }
 
     fn asset(&self, tracker: Tracker, index: usize) -> Result<Option<OwnedAsset>, TrieError> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.cache.asset(&OwnedAssetAddress::new(tracker, index, self.shard_id), &*trie)
+        self.cache.asset(&OwnedAssetAddress::new(tracker, index, self.shard_id), &trie)
     }
 }
 

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -105,28 +105,28 @@ impl TopStateView for TopLevelState {
     fn account(&self, a: &Address) -> TrieResult<Option<Account>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.account(&a, &*trie)
+        self.top_cache.account(&a, &trie)
     }
 
     fn regular_account_by_address(&self, a: &Address) -> TrieResult<Option<RegularAccount>> {
         let a = RegularAccountAddress::from_address(a);
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        Ok(self.top_cache.regular_account(&a, &*trie)?)
+        Ok(self.top_cache.regular_account(&a, &trie)?)
     }
 
     fn metadata(&self) -> TrieResult<Option<Metadata>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let address = MetadataAddress::new();
-        self.top_cache.metadata(&address, &*trie)
+        self.top_cache.metadata(&address, &trie)
     }
 
     fn shard(&self, shard_id: ShardId) -> TrieResult<Option<Shard>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let shard_address = ShardAddress::new(shard_id);
-        self.top_cache.shard(&shard_address, &*trie)
+        self.top_cache.shard(&shard_address, &trie)
     }
 
     fn shard_state<'db>(&'db self, shard_id: ShardId) -> TrieResult<Option<Box<dyn ShardStateView + 'db>>> {
@@ -143,13 +143,13 @@ impl TopStateView for TopLevelState {
     fn text(&self, key: &H256) -> TrieResult<Option<Text>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        Ok(self.top_cache.text(key, &*trie)?.map(Into::into))
+        Ok(self.top_cache.text(key, &trie)?.map(Into::into))
     }
 
     fn action_data(&self, key: &H256) -> TrieResult<Option<ActionData>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        Ok(self.top_cache.action_data(key, &*trie)?.map(Into::into))
+        Ok(self.top_cache.action_data(key, &trie)?.map(Into::into))
     }
 }
 
@@ -173,14 +173,14 @@ impl StateWithCache for TopLevelState {
 
                 let shard_cache = self.shard_caches.get_mut(&shard_id).expect("Shard must exist");
 
-                shard_cache.commit(&mut *trie)?;
+                shard_cache.commit(&mut trie)?;
             }
             self.set_shard_root(shard_id, shard_root)?;
         }
         {
             let mut db = self.db.borrow_mut();
             let mut trie = TrieFactory::from_existing(db.as_hashdb_mut(), &mut self.root)?;
-            self.top_cache.commit(&mut *trie)?;
+            self.top_cache.commit(&mut trie)?;
         }
         Ok(self.root)
     }
@@ -636,46 +636,46 @@ impl TopLevelState {
 
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.account_mut(&a, &*trie)
+        self.top_cache.account_mut(&a, &trie)
     }
 
     fn get_regular_account_mut(&self, public: &Public) -> TrieResult<RefMut<RegularAccount>> {
         let regular_account_address = RegularAccountAddress::new(public);
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.regular_account_mut(&regular_account_address, &*trie)
+        self.top_cache.regular_account_mut(&regular_account_address, &trie)
     }
 
     fn get_metadata_mut(&self) -> TrieResult<RefMut<Metadata>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let address = MetadataAddress::new();
-        self.top_cache.metadata_mut(&address, &*trie)
+        self.top_cache.metadata_mut(&address, &trie)
     }
 
     fn get_shard_mut(&self, shard_id: ShardId) -> TrieResult<RefMut<Shard>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let shard_address = ShardAddress::new(shard_id);
-        self.top_cache.shard_mut(&shard_address, &*trie)
+        self.top_cache.shard_mut(&shard_address, &trie)
     }
 
     fn get_text(&self, key: &TxHash) -> TrieResult<Option<Text>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.text(key, &*trie)
+        self.top_cache.text(key, &trie)
     }
 
     fn get_text_mut(&self, key: &TxHash) -> TrieResult<RefMut<Text>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.text_mut(key, &*trie)
+        self.top_cache.text_mut(key, &trie)
     }
 
     fn get_action_data_mut(&self, key: &H256) -> TrieResult<RefMut<ActionData>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
-        self.top_cache.action_data_mut(key, &*trie)
+        self.top_cache.action_data_mut(key, &trie)
     }
 
     pub fn journal_under(&self, batch: &mut DBTransaction, now: u64) -> Result<u32, UtilError> {

--- a/state/src/tests.rs
+++ b/state/src/tests.rs
@@ -17,7 +17,7 @@
 pub mod helpers {
     use std::sync::Arc;
 
-    use cmerkle::TrieFactory;
+    use cmerkle::{TrieFactory, TrieMut};
     use ctypes::{BlockNumber, Tracker};
     use cvm::ChainTimeInfo;
     use hashdb::AsHashDB;

--- a/sync/src/snapshot/snapshot.rs
+++ b/sync/src/snapshot/snapshot.rs
@@ -296,7 +296,7 @@ mod tests {
 
     use ccore::COL_STATE;
 
-    use cmerkle::{Trie, TrieDB, TrieDBMut, TrieMut};
+    use cmerkle::{Trie, TrieFactory, TrieMut};
     use journaldb;
     use journaldb::Algorithm;
     use kvdb_memorydb;
@@ -315,7 +315,7 @@ mod tests {
         let kvdb = Arc::new(kvdb_memorydb::create(1));
         let mut jdb = journaldb::new(kvdb.clone(), Algorithm::Archive, COL_STATE);
         {
-            let _ = TrieDBMut::new(jdb.as_hashdb_mut(), &mut root);
+            let _ = TrieFactory::create(jdb.as_hashdb_mut(), &mut root);
         }
         /* do nothing */
         let result = snapshot.write_snapshot(kvdb.as_ref(), &root);
@@ -341,7 +341,7 @@ mod tests {
             let kvdb = Arc::new(kvdb_memorydb::create(1));
             let mut jdb = journaldb::new(kvdb.clone(), Algorithm::Archive, COL_STATE);
             {
-                let mut t = TrieDBMut::new(jdb.as_hashdb_mut(), &mut root);
+                let mut t = TrieFactory::create(jdb.as_hashdb_mut(), &mut root);
                 let mut inserted_keys = HashSet::new();
                 for &(ref key, ref value) in &x {
                     if !inserted_keys.insert(key) {
@@ -364,8 +364,8 @@ mod tests {
             let kvdb = Arc::new(kvdb_memorydb::create(1));
             snapshot.read_snapshot(kvdb.clone(), &root).unwrap();
 
-            let mut jdb = journaldb::new(kvdb, Algorithm::Archive, COL_STATE);
-            let t = TrieDB::try_new(jdb.as_hashdb_mut(), &root).unwrap();
+            let jdb = journaldb::new(kvdb, Algorithm::Archive, COL_STATE);
+            let t = TrieFactory::readonly(jdb.as_hashdb(), &root).unwrap();
             let mut inserted_keys = HashSet::new();
             for &(ref key, ref value) in &x {
                 if !inserted_keys.insert(key) {

--- a/util/merkle/src/lib.rs
+++ b/util/merkle/src/lib.rs
@@ -39,8 +39,8 @@ pub mod triehash;
 
 pub use crate::node::Node;
 pub use crate::skewed::skewed_merkle_root;
-pub use crate::triedb::TrieDB;
-pub use crate::triedbmut::TrieDBMut;
+use crate::triedb::TrieDB;
+use crate::triedbmut::TrieDBMut;
 
 /// Trie Errors.
 ///
@@ -99,17 +99,17 @@ pub enum TrieFactory {}
 
 impl TrieFactory {
     /// Create new immutable instance of Trie.
-    pub fn readonly<'db>(db: &'db dyn HashDB, root: &'db H256) -> Result<Box<dyn Trie + 'db>> {
-        Ok(Box::new(TrieDB::try_new(db, root)?))
+    pub fn readonly<'db>(db: &'db dyn HashDB, root: &'db H256) -> Result<impl Trie + 'db> {
+        Ok(TrieDB::try_new(db, root)?)
     }
 
     /// Create new mutable instance of Trie.
-    pub fn create<'db>(db: &'db mut dyn HashDB, root: &'db mut H256) -> Box<dyn TrieMut + 'db> {
-        Box::new(TrieDBMut::new(db, root))
+    pub fn create<'db>(db: &'db mut dyn HashDB, root: &'db mut H256) -> impl TrieMut + 'db {
+        TrieDBMut::new(db, root)
     }
 
     /// Create new mutable instance of trie and check for errors.
-    pub fn from_existing<'db>(db: &'db mut dyn HashDB, root: &'db mut H256) -> Result<Box<dyn TrieMut + 'db>> {
-        Ok(Box::new(TrieDBMut::from_existing(db, root)?))
+    pub fn from_existing<'db>(db: &'db mut dyn HashDB, root: &'db mut H256) -> Result<impl TrieMut + 'db> {
+        Ok(TrieDBMut::from_existing(db, root)?)
     }
 }

--- a/util/merkle/src/triedb.rs
+++ b/util/merkle/src/triedb.rs
@@ -40,12 +40,12 @@ use crate::{Trie, TrieError};
 ///
 /// let mut memdb = MemoryDB::new();
 /// let mut root = H256::new();
-/// TrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
-/// let t = TrieDB::try_new(&memdb, &root).unwrap();
+/// TrieFactory::create(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
+/// let t = TrieFactory::readonly(&memdb, &root).unwrap();
 /// assert!(t.contains(b"foo").unwrap());
 /// assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
 /// ```
-pub struct TrieDB<'db> {
+pub(crate) struct TrieDB<'db> {
     db: &'db dyn HashDB,
     root: &'db H256,
 }
@@ -65,11 +65,6 @@ impl<'db> TrieDB<'db> {
                 root,
             })
         }
-    }
-
-    /// Get the backing database.
-    pub fn db(&self) -> &dyn HashDB {
-        self.db
     }
 
     /// Get auxiliary

--- a/util/merkle/src/triedbmut.rs
+++ b/util/merkle/src/triedbmut.rs
@@ -29,7 +29,7 @@ fn empty_children() -> [Option<H256>; 16] {
     [None; 16]
 }
 
-pub struct TrieDBMut<'a> {
+pub(crate) struct TrieDBMut<'a> {
     db: &'a mut dyn HashDB,
     // When Trie is empty, root has None.
     root: &'a mut H256,


### PR DESCRIPTION
This patch makes codechain use Trie and TrieMut which are abstracted
interfaces instead of concrete implementations.