### PR TITLE
Add an RPC deleteAllPendingTransactions()

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -739,6 +739,10 @@ impl BlockChainClient for Client {
         }
     }
 
+    fn delete_all_pending_transactions(&self) {
+        self.importer.miner.delete_all_pending_transactions();
+    }
+
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
         self.importer.miner.ready_transactions(range)
     }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -221,6 +221,9 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     /// Queue transactions for importing.
     fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: NodeId);
 
+    /// Delete all pending transactions.
+    fn delete_all_pending_transactions(&self);
+
     /// List all transactions that are allowed into the next block.
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -538,6 +538,10 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.import_external_transactions(self, transactions);
     }
 
+    fn delete_all_pending_transactions(&self) {
+        self.miner.delete_all_pending_transactions();
+    }
+
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
         self.miner.ready_transactions(range)
     }

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -379,6 +379,12 @@ impl MemPool {
             .collect()
     }
 
+    /// Clear both current and future.
+    pub fn remove_all(&mut self) {
+        self.current.clear();
+        self.future.clear();
+    }
+
     /// Checks the current seq for all transactions' senders in the pool and removes the old transactions.
     /// Expired transactions are removed by this function only.
     pub fn remove_old<F>(&mut self, fetch_account: &F, current_block_number: PoolingInstant, current_timestamp: u64)

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -374,6 +374,11 @@ impl Miner {
         results
     }
 
+    pub fn delete_all_pending_transactions(&self) {
+        let mut mem_pool = self.mem_pool.write();
+        mem_pool.remove_all();
+    }
+
     fn calculate_timelock<C: BlockChainTrait>(&self, tx: &SignedTransaction, client: &C) -> Result<TxTimelock, Error> {
         let mut max_block = None;
         let mut max_timestamp = None;

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -71,6 +71,11 @@ where
         Ok(self.client.error_hint(&transaction_hash))
     }
 
+    fn delete_all_pending_transactions(&self) -> Result<()> {
+        self.client.delete_all_pending_transactions();
+        Ok(())
+    }
+
     fn get_pending_transactions(
         &self,
         from: Option<u64>,

--- a/rpc/src/v1/traits/mempool.rs
+++ b/rpc/src/v1/traits/mempool.rs
@@ -35,6 +35,10 @@ pub trait Mempool {
     #[rpc(name = "mempool_getErrorHint")]
     fn get_error_hint(&self, transaction_hash: TxHash) -> Result<Option<String>>;
 
+    /// Deletes all pending transactions in the mem pool, including future queue.
+    #[rpc(name = "mempool_deleteAllPendingTransactions")]
+    fn delete_all_pending_transactions(&self) -> Result<()>;
+
     /// Gets transactions in the current mem pool. future_included is set to check whether append future queue or not.
     #[rpc(name = "mempool_getPendingTransactions")]
     fn get_pending_transactions(


### PR DESCRIPTION
This new RPC takes no argument and deletes all pending transactions(both current and future), returning nothing.

Fixes #1482