### PR TITLE
Ignore yarn & node related files in any paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@
 
 # macOS
 .DS_store
+
+keystore.db
+
+# CodeChain uses node & yarn for tests
+node_modules/
+yarn-error.log
+yarn.lock

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,0 @@
-node_modules/
-yarn-error.log
-keystore.db
-yarn.lock


### PR DESCRIPTION
Since CodeChain uses JavaScript for tests, it ignores node generated
files in the test directory but doesn't have a rule created in other
paths. For this reason, it's easy to include node and yarn generated
files by mistake.
This patch makes git ignore them in any paths.