### PR TITLE
Add "install `cmake` to build CodeChain" in README.md and Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ CodeChain requires Rust version 1.40.0 to build. Using [rustup](https://rustup.r
 - For Linux Systems:
   - Ubuntu
 
-    > `gcc`, `g++` and `make` are required for installing packages.
+    > `cmake`, `gcc`, `g++` and `make` are required for installing packages.
     ```sh
     $ curl https://sh.rustup.rs -sSf | sh
     ```
@@ -86,7 +86,7 @@ CodeChain requires Rust version 1.40.0 to build. Using [rustup](https://rustup.r
 
 - For Mac Systems:
   - MacOS 10.13.2 (17C88) tested
-    > `clang` is required for installing packages.
+    > `cmake` and `clang` are required for installing packages.
 
     ```sh
     $ curl https://sh.rustup.rs -sSf | sh

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
         binutils \
         libssl-dev \
         pkg-config \
-        libudev-dev
+        libudev-dev \
+        cmake
 
 # install rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
To build `parity-snappy-sys`, which is a dependency of CodeChain, we need to install `cmake`.