### PR TITLE
Remove the comment related to an old policy

### DIFF
--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -330,7 +330,6 @@ impl TopLevelState {
         self.inc_seq(&fee_payer)?;
         self.sub_balance(&fee_payer, fee)?;
 
-        // The failed transaction also must pay the fee and increase seq.
         self.create_checkpoint(ACTION_CHECKPOINT);
         let result = self.apply_action(
             &tx.action,


### PR DESCRIPTION
We do not include failed transactions in blocks. Therefore, fee
imposition and sequence increase do not occur for a failed
transaction.