### PR TITLE
Fix a deadlock in miner.rs

### DIFF
--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -114,7 +114,7 @@ struct SealingWork {
 pub struct Miner {
     mem_pool: Arc<RwLock<MemPool>>,
     next_allowed_reseal: Mutex<Instant>,
-    next_mandatory_reseal: RwLock<Instant>,
+    next_mandatory_reseal: NextMandatoryReseal,
     sealing_block_last_request: Mutex<u64>,
     sealing_work: Mutex<SealingWork>,
     params: RwLock<AuthoringParams>,
@@ -127,6 +127,26 @@ pub struct Miner {
     notifiers: RwLock<Vec<Box<dyn NotifyWork>>>,
     malicious_users: RwLock<HashSet<Address>>,
     immune_users: RwLock<HashSet<Address>>,
+}
+
+struct NextMandatoryReseal {
+    instant: RwLock<Instant>,
+}
+
+impl NextMandatoryReseal {
+    pub fn new(instant: Instant) -> Self {
+        Self {
+            instant: RwLock::new(instant),
+        }
+    }
+
+    pub fn get(&self) -> Instant {
+        *self.instant.read()
+    }
+
+    pub fn set(&self, instant: Instant) {
+        *self.instant.write() = instant;
+    }
 }
 
 impl Miner {
@@ -171,7 +191,7 @@ impl Miner {
         Self {
             mem_pool,
             next_allowed_reseal: Mutex::new(Instant::now()),
-            next_mandatory_reseal: RwLock::new(Instant::now() + options.reseal_max_period),
+            next_mandatory_reseal: NextMandatoryReseal::new(Instant::now() + options.reseal_max_period),
             params: RwLock::new(AuthoringParams::default()),
             sealing_block_last_request: Mutex::new(0),
             sealing_work: Mutex::new(SealingWork {
@@ -620,7 +640,7 @@ impl Miner {
         C: BlockChainTrait + ImportBlock, {
         if block.transactions().is_empty()
             && !self.options.force_sealing
-            && Instant::now() <= *self.next_mandatory_reseal.read()
+            && Instant::now() <= self.next_mandatory_reseal.get()
         {
             cdebug!(MINER, "seal_block_internally: no sealing.");
             return false
@@ -637,7 +657,7 @@ impl Miner {
             return false
         }
 
-        *self.next_mandatory_reseal.write() = Instant::now() + self.options.reseal_max_period;
+        self.next_mandatory_reseal.set(Instant::now() + self.options.reseal_max_period);
         let sealed = if self.engine_type().is_seal_first() {
             block.lock().already_sealed()
         } else {

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -30,7 +30,7 @@ use ctypes::{BlockHash, BlockNumber, Header, TxHash};
 use cvm::ChainTimeInfo;
 use kvdb::KeyValueDB;
 use parking_lot::{Mutex, RwLock};
-use primitives::{Bytes, H256};
+use primitives::{Bytes, H256, U256};
 
 use super::mem_pool::{Error as MemPoolError, MemPool};
 use super::mem_pool_types::{AccountDetails, MemPoolInput, TxOrigin, TxTimelock};
@@ -124,9 +124,36 @@ pub struct Miner {
     sealing_enabled: AtomicBool,
 
     accounts: Option<Arc<AccountProvider>>,
-    notifiers: RwLock<Vec<Box<dyn NotifyWork>>>,
+    notifiers: Notifiers,
     malicious_users: RwLock<HashSet<Address>>,
     immune_users: RwLock<HashSet<Address>>,
+}
+
+struct Notifiers {
+    notifiers: RwLock<Vec<Box<dyn NotifyWork>>>,
+}
+
+impl Notifiers {
+    pub fn new(notifiers: Vec<Box<dyn NotifyWork>>) -> Self {
+        Self {
+            notifiers: RwLock::new(notifiers),
+        }
+    }
+
+    pub fn push(&self, notifier: Box<dyn NotifyWork>) {
+        self.notifiers.write().push(notifier);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.notifiers.read().is_empty()
+    }
+
+    pub fn notify(&self, pow_hash: H256, target: U256) {
+        // FIXME: Calling callbacks inside of lock lifetime may cause a deadlock.
+        for notifier in self.notifiers.read().iter() {
+            notifier.notify(pow_hash, target)
+        }
+    }
 }
 
 struct SealingBlockLastRequest {
@@ -201,7 +228,7 @@ impl Params {
 impl Miner {
     /// Push listener that will handle new jobs
     pub fn add_work_listener(&self, notifier: Box<dyn NotifyWork>) {
-        self.notifiers.write().push(notifier);
+        self.notifiers.push(notifier);
     }
 
     pub fn new(
@@ -251,7 +278,7 @@ impl Miner {
             options,
             sealing_enabled: AtomicBool::new(true),
             accounts,
-            notifiers: RwLock::new(notifiers),
+            notifiers: Notifiers::new(notifiers),
             malicious_users: RwLock::new(HashSet::new()),
             immune_users: RwLock::new(HashSet::new()),
         }
@@ -502,7 +529,7 @@ impl Miner {
                 let is_new = original_work_hash.map_or(true, |h| *block.block().header().hash() != h);
                 sealing_work.queue.push(block);
                 // If push notifications are enabled we assume all work items are used.
-                if !self.notifiers.read().is_empty() && is_new {
+                if !self.notifiers.is_empty() && is_new {
                     sealing_work.queue.use_last_ref();
                 }
                 (Some((pow_hash, score, number)), is_new)
@@ -519,9 +546,7 @@ impl Miner {
         if is_new {
             if let Some((pow_hash, score, _number)) = work {
                 let target = self.engine.score_to_target(&score);
-                for notifier in self.notifiers.read().iter() {
-                    notifier.notify(pow_hash, target)
-                }
+                self.notifiers.notify(pow_hash, target);
             }
         }
     }


### PR DESCRIPTION
There is a deadlock between immune_users and mem_pool.

A client worker thread locks immune_users first and mem_pool second in
prepare_block function.

An HTTP thread locks mem_pool first in import_own_transactions function
and locks immune_users in add_transactions_to_pool function.

It seems that this deadlock is added when we add immune_users lock. We
need to review the lock of immune_users.