### PR TITLE
Fetch consistent state in mempool functions

### DIFF
--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -392,6 +392,9 @@ impl AccountData for TestBlockChainClient {
     fn seq(&self, address: &Address, id: BlockId) -> Option<u64> {
         match id {
             BlockId::Latest => Some(self.seqs.read().get(address).cloned().unwrap_or(0)),
+            BlockId::Hash(hash) if hash == *self.last_hash.read() => {
+                Some(self.seqs.read().get(address).cloned().unwrap_or(0))
+            }
             _ => None,
         }
     }
@@ -399,6 +402,9 @@ impl AccountData for TestBlockChainClient {
     fn balance(&self, address: &Address, state: StateOrBlock) -> Option<u64> {
         match state {
             StateOrBlock::Block(BlockId::Latest) | StateOrBlock::State(_) => {
+                Some(self.balances.read().get(address).cloned().unwrap_or(0))
+            }
+            StateOrBlock::Block(BlockId::Hash(hash)) if hash == *self.last_hash.read() => {
                 Some(self.balances.read().get(address).cloned().unwrap_or(0))
             }
             _ => None,


### PR DESCRIPTION
We found that mempool mis-calculates sequence in the TPS test. After fixing the mempool to read consistent state, mempool calculates sequence well.