### PR TITLE
Fetch consistent state in mempool functions

### DIFF
--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -384,6 +384,9 @@ impl AccountData for TestBlockChainClient {
     fn seq(&self, address: &Address, id: BlockId) -> Option<u64> {
         match id {
             BlockId::Latest => Some(self.seqs.read().get(address).cloned().unwrap_or(0)),
+            BlockId::Hash(hash) if hash == *self.last_hash.read() => {
+                Some(self.seqs.read().get(address).cloned().unwrap_or(0))
+            }
             _ => None,
         }
     }
@@ -391,6 +394,9 @@ impl AccountData for TestBlockChainClient {
     fn balance(&self, address: &Address, state: StateOrBlock) -> Option<u64> {
         match state {
             StateOrBlock::Block(BlockId::Latest) | StateOrBlock::State(_) => {
+                Some(self.balances.read().get(address).cloned().unwrap_or(0))
+            }
+            StateOrBlock::Block(BlockId::Hash(hash)) if hash == *self.last_hash.read() => {
                 Some(self.balances.read().get(address).cloned().unwrap_or(0))
             }
             _ => None,

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -197,13 +197,16 @@ pub enum TransactionImportResult {
 #[cfg(all(feature = "nightly", test))]
 mod mem_pool_benches;
 
-fn fetch_account_creator<'c>(client: &'c dyn AccountData) -> impl Fn(&Public) -> AccountDetails + 'c {
+fn fetch_account_creator<'c>(
+    client: &'c dyn AccountData,
+    block_id: BlockId,
+) -> impl Fn(&Public) -> AccountDetails + 'c {
     move |public: &Public| {
         let address = public_to_address(public);
-        let a = client.latest_regular_key_owner(&address).unwrap_or(address);
+        let a = client.regular_key_owner(&address, block_id.into()).unwrap_or(address);
         AccountDetails {
-            seq: client.latest_seq(&a),
-            balance: client.latest_balance(&a),
+            seq: client.seq(&a, block_id).expect("We are querying sequence using trusted block id"),
+            balance: client.balance(&a, block_id.into()).expect("We are querying balance using trusted block id"),
         }
     }
 }


### PR DESCRIPTION
We found that mempool mis-calculates sequence in the TPS test. After
fixing the mempool to read consistent state, mempool calculates
sequence well.

This PR is copied from https://github.com/CodeChain-io/codechain/pull/1976.