### PR TITLE
Make sync tests not to propagate transactions

### DIFF
--- a/test/src/e2e.long/sync2.test.ts
+++ b/test/src/e2e.long/sync2.test.ts
@@ -25,8 +25,10 @@ describe("sync 2 nodes", function() {
 
     describe("2 nodes", function() {
         beforeEach(async function() {
-            nodeA = new CodeChain();
-            nodeB = new CodeChain();
+            // To generate a block this test sends a tx to a node.
+            // If the tx is propagated before generating a block, tests in this file would fail.
+            nodeA = new CodeChain({ argv: ["--no-tx-relay"] });
+            nodeB = new CodeChain({ argv: ["--no-tx-relay"] });
 
             await Promise.all([nodeA.start(), nodeB.start()]);
         });

--- a/test/src/e2e.long/sync3.test.ts
+++ b/test/src/e2e.long/sync3.test.ts
@@ -28,7 +28,9 @@ describe("sync 3 nodes", function() {
         nodes = [];
         for (let i = 0; i < NUM_NODES; i++) {
             const node = new CodeChain({
-                argv: ["--no-discovery"]
+                // To generate a block this test sends a tx to a node.
+                // If the tx is propagated before generating a block, tests in this file would fail.
+                argv: ["--no-discovery", "--no-tx-relay"]
             });
             nodes.push(node);
         }

--- a/test/src/e2e.long/sync5.test.ts
+++ b/test/src/e2e.long/sync5.test.ts
@@ -27,8 +27,10 @@ describe("sync 5 nodes", function() {
 
         nodes = [];
         for (let i = 0; i < NUM_NODES; i++) {
+            // To generate a block this test sends a tx to a node.
+            // If the tx is propagated before generating a block, tests in this file would fail.
             const node = new CodeChain({
-                argv: ["--no-discovery"]
+                argv: ["--no-discovery", "--no-tx-relay"]
             });
             nodes.push(node);
         }


### PR DESCRIPTION
The current CodeChain master does not fail the tests without this commit. 
However, https://github.com/CodeChain-io/codechain/pull/1979 fails the tests quite often without this PR.

These tests use solo consensus. To generate a block with the solo
consensus, there should be a transaction. These tests send a
transaction to a node to make a block. Then the node propagates the
generated block to other nodes. These tests then check the other nodes
whether the received the block or not.

However, if the transaction is propagated before the block, these
tests fail. If the transaction is propagated, other nodes will
generate their own blocks. Then they will reject the block that the
first node generated.