### PR TITLE
Do not count validators who do not proposed in additional reward calculation

### DIFF
--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -471,6 +471,7 @@ fn give_additional_rewards<F: FnMut(&Address, u64) -> Result<(), Error>>(
 ) -> Result<(), Error> {
     let sorted_validators = work_info
         .into_iter()
+        .filter(|(_, work)| work.proposed > 0)
         .map(|(address, info)| (address, Ratio::new(info.missed, info.proposed)))
         // When one sees the Ratio crate's Order trait implementation, he/she can easily realize that the
         // comparing routine is erroneous. It inversely compares denominators when the numerators are the same.


### PR DESCRIPTION
In the additional reward calculation, we divide a validator's missed precommits by the validator's proposed count. Some validators may not proposed in a term. To avoid "divide by zero" error, ignore the validators who did not proposed any block.

The "divide by zero" error happens after this commit: https://github.com/CodeChain-io/codechain/commit/79322e18609fa566ce52c95976a4d05a687c82ea
The 2.x releases do not have the commit. Only the master branch has the problem.